### PR TITLE
Management of mysql secret

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Rekor is an API based server for validation and a transparency log 
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 
 appVersion: 0.3.0
 

--- a/charts/rekor/templates/_helpers.tpl
+++ b/charts/rekor/templates/_helpers.tpl
@@ -461,3 +461,20 @@ Return the location for file based Attestation storage.
 {{- define "rekor.server.fileAttestationStorage.path" -}}
 {{- print (substr 7 -1 .Values.server.attestation_storage.bucket) -}}
 {{- end -}}
+
+{{/*
+Return a random Secret value or the value of an exising Secret key value
+*/}}
+{{- define "rekor.randomSecret" -}}
+{{- $randomSecret := (randAlpha 10) }}
+{{- $secret := (lookup "v1" "Secret" .context.Release.Namespace .secretName) }}
+{{- if $secret }}
+{{- if hasKey $secret.data .key }}
+{{- print (index $secret.data .key) | b64dec }}
+{{- else }}
+{{- print $randomSecret }}
+{{- end }}
+{{- else }}
+{{- print $randomSecret }}
+{{- end }}
+{{- end -}}

--- a/charts/rekor/templates/mysql/secret.yaml
+++ b/charts/rekor/templates/mysql/secret.yaml
@@ -17,14 +17,14 @@ type: Opaque
 data:
   {{- if .Values.mysql.enabled -}}
   {{- if not (empty .Values.mysql.auth.rootPassword) }}
-  mysql-root-password: {{ .Values.auth.rootPassword | b64enc | quote }}
+  mysql-root-password: {{ .Values.mysql.auth.rootPassword | b64enc | quote }}
   {{- else }}
-  mysql-root-password: {{ randAlphaNum 10 | b64enc | quote }}
+  mysql-root-password: {{ (include "rekor.randomSecret" (dict "secretName" (include "rekor.mysql.fullname" .) "key" "mysql-root-password" "context" $)) | b64enc | quote }}
   {{- end }}
   {{- end }}
   {{- if not (empty .Values.mysql.auth.password) }}
   mysql-password: {{ .Values.mysql.auth.password | b64enc | quote }}
   {{- else }}
-  mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
+  mysql-password: {{ (include "rekor.randomSecret" (dict "secretName" (include "rekor.mysql.fullname" .) "key" "mysql-password" "context" $)) | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Several corrections to how mysql secret is managed

* Fix incorrect reference to `mysql.auth.rootPassword`
* Reuse existing secret content upon upgrade