### PR TITLE
[wip] feat: add cosigned chart

### DIFF
--- a/charts/cosigned/.helmignore
+++ b/charts/cosigned/.helmignore
@@ -1,0 +1,20 @@
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cosigned/Chart.yaml
+++ b/charts/cosigned/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+appVersion: "dev"
+description: The Helm chart for Cosigned
+home: https://github.com/sigstore/cosign
+name: cosigned
+type: application
+version: v0.0.0-dev
+maintainers:
+  - name: dlorenc
+  - name: hectorj2f

--- a/charts/cosigned/README.md
+++ b/charts/cosigned/README.md
@@ -1,0 +1,90 @@
+# Cosigned Admission Webhook
+
+## Requirements
+* kind (or any other Kubernetes cluster).
+* Helm.
+
+## Run `cosigned`
+
+Cosigned requires `cert-manager` to be pre-configured on the running cluster.
+To install `cert-manager` follow the next steps:
+
+```shell
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version v1.5.0 \
+  --set installCRDs=true
+```
+
+Once `cert-manager` is installed in your cluster, you can start configuring `cosigned`.
+
+Generate a keypair to validate the signatures of the deployed Kubernetes resources and their images:
+
+```shell
+cosign generate-key-pair
+```
+
+The previous command generates two key files `cosign.key` and `cosign.pub`. Next, create a secret to validate the signatures:
+
+```shell
+kubectl create secret generic mysecret -n cosigned --from-file=cosign.pub=./cosign.pub
+```
+
+Install `cosigned` using Helm and setting the value of the secret key reference to `k8s://cosigned/mysecret`:
+
+```shell
+helm install cosigned -n cosigned chart/cosigned --replace --set webhook.secretKeyRef.name=k8s://cosigned/mysecret --create-namespace
+```
+
+Validate the `cosigned` functionality by create a `Deployment` with and without signed images:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-unsigned
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-signed
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: hectorj2f/nginx
+        ports:
+        - containerPort: 80
+```
+

--- a/charts/cosigned/templates/_helpers.tpl
+++ b/charts/cosigned/templates/_helpers.tpl
@@ -1,0 +1,106 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cosigned.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cosigned.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cosigned.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cosigned.labels" -}}
+helm.sh/chart: {{ include "cosigned.chart" . }}
+{{ include "cosigned.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cosigned.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cosigned.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cosigned.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cosigned.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Self-signed certificate authority issuer name
+*/}}
+{{- define "cosigned.CAIssuerName" -}}
+{{- if .Values.certificates.ca.issuer.name -}}
+{{ .Values.certificates.ca.issuer.name }}
+{{- else -}}
+{{ template "cosigned.fullname" . }}-ca-issuer
+{{- end -}}
+{{- end -}}
+
+{{/*
+CA Certificate issuer name
+*/}}
+{{- define "cosigned.CAissuerName" -}}
+{{- if .Values.certificates.selfSigned -}}
+{{ template "cosigned.CAIssuerName" . }}
+{{- else -}}
+{{ required "A valid .Values.certificates.ca.issuer.name is required!" .Values.certificates.issuer.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+CA signed certificate issuer name
+*/}}
+{{- define "cosigned.IssuerName" -}}
+{{- if .Values.certificates.issuer.name -}}
+{{ .Values.certificates.issuer.name }}
+{{- else -}}
+{{ template "cosigned.fullname" . }}-issuer
+{{- end -}}
+{{- end -}}
+
+{{/*
+Certificate issuer name
+*/}}
+{{- define "cosigned.issuerName" -}}
+{{- if .Values.certificates.selfSigned -}}
+{{ template "cosigned.IssuerName" . }}
+{{- else -}}
+{{ required "A valid .Values.certificates.issuer.name is required!" .Values.certificates.issuer.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/cosigned/templates/webhook/certificate_webhook.yaml
+++ b/charts/cosigned/templates/webhook/certificate_webhook.yaml
@@ -1,0 +1,29 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "cosigned.fullname" . }}-webhook-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cosigned.labels" . | nindent 4 }}
+    control-plane: {{ template "cosigned.fullname" . }}-webhook
+spec:
+  commonName: {{ template "cosigned.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
+  dnsNames:
+    - {{ template "cosigned.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
+    - {{ template "cosigned.fullname" . }}-webhook.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: {{ .Values.certificates.issuer.kind }}
+    name: {{ template "cosigned.issuerName" . }}
+  secretName: {{ template "cosigned.fullname" . }}-webhook-tls
+---
+{{- if  (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
+{{- if .Values.certificates.selfSigned }}
+apiVersion: cert-manager.io/v1
+kind: {{ .Values.certificates.issuer.kind }}
+metadata:
+  name: {{ template "cosigned.issuerName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+{{- end }}
+{{- end }}

--- a/charts/cosigned/templates/webhook/clusterrole_webhook.yaml
+++ b/charts/cosigned/templates/webhook/clusterrole_webhook.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "cosigned.fullname" . }}-webhook
+  labels:
+    {{- include "cosigned.labels" . | nindent 4 }}
+    control-plane: {{ template "cosigned.fullname" . }}-webhook
+rules:
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources:
+  - events
+  verbs: ["list", "get", "watch", "create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["list", "get", "watch", "create", "update", "delete"]

--- a/charts/cosigned/templates/webhook/clusterrolebindings_webhook.yaml
+++ b/charts/cosigned/templates/webhook/clusterrolebindings_webhook.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "cosigned.fullname" . }}-webhook
+  labels:
+    {{- include "cosigned.labels" . | nindent 4 }}
+    control-plane: {{ template "cosigned.fullname" . }}-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "cosigned.fullname" . }}-webhook
+subjects:
+- kind: ServiceAccount
+  name: {{ template "cosigned.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}

--- a/charts/cosigned/templates/webhook/deployment_webhook.yaml
+++ b/charts/cosigned/templates/webhook/deployment_webhook.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "cosigned.labels" . | nindent 4 }}
+    control-plane: {{ template "cosigned.fullname" . }}-webhook
+  name: {{ template "cosigned.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "cosigned.selectorLabels" . | nindent 6 }}
+      control-plane: {{ template "cosigned.fullname" . }}-webhook
+  template:
+    metadata:
+      labels:
+        {{- include "cosigned.selectorLabels" . | nindent 8 }}
+        control-plane: {{ template "cosigned.fullname" . }}-webhook
+    spec:
+      nodeSelector:
+        {{- toYaml .Values.commonNodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.commonTolerations | nindent 8 }}
+      serviceAccountName: {{ template "cosigned.fullname" . }}-webhook
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: webhook
+        image: "{{ .Values.webhook.image.repository }}:{{ .Values.webhook.image.tag | default $.Chart.AppVersion }}"
+        imagePullPolicy: "{{ .Values.webhook.image.pullPolicy }}"
+{{- if .Values.webhook.env }}
+        env:
+{{- range $key, $value := .Values.webhook.env }}
+        - name: "{{ $key }}"
+          value: "{{ $value }}"
+{{- end }}
+{{- end }}
+        args:
+        - --tls-cert-dir=/certs/
+        - --secret-key-ref={{ .Values.webhook.secretKeyRef.name }}
+        {{- range $key, $value := .Values.webhook.extraArgs }}
+        - --{{ $key }}={{ $value }}
+        {{- end }}
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          {{ with .Values.webhook.resources }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        volumeMounts:
+        - mountPath: /certs
+          name: cert
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            port: 8443
+            scheme: HTTPS
+            path: /healthz
+        readinessProbe:
+          httpGet:
+            port: 8443
+            scheme: HTTPS
+            path: /readyz
+      securityContext:
+        {{ with .Values.webhook.securityContext }}
+        {{- toYaml . | nindent 8}}
+        {{- end }}
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ template "cosigned.fullname" . }}-webhook-tls

--- a/charts/cosigned/templates/webhook/sa_webhook.yaml
+++ b/charts/cosigned/templates/webhook/sa_webhook.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "cosigned.labels" . | nindent 4 }}
+    control-plane: {{ template "cosigned.fullname" . }}-webhook
+  name: {{ template "cosigned.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}

--- a/charts/cosigned/templates/webhook/service_webhook.yaml
+++ b/charts/cosigned/templates/webhook/service_webhook.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    {{- if .Values.webhook.service.annotations }}
+    {{ toYaml .Values.webhook.service.annotations | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "cosigned.labels" . | nindent 4 }}
+    control-plane: {{ template "cosigned.fullname" . }}-webhook
+  name: {{ template "cosigned.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: {{.Values.webhook.service.type}}
+  ports:
+  - name: https
+    port: {{ .Values.webhook.service.port }}
+    protocol: TCP
+    targetPort: https
+    {{- if and .Values.webhook.service.nodePort (eq "NodePort" .Values.webhook.service.type) }}
+    nodePort: {{ .Values.webhook.service.nodePort }}
+    {{- end }}
+  selector:
+    {{- include "cosigned.selectorLabels" . | nindent 4 }}
+    control-plane: {{ template "cosigned.fullname" . }}-webhook

--- a/charts/cosigned/templates/webhook/webhook_validating.yaml
+++ b/charts/cosigned/templates/webhook/webhook_validating.yaml
@@ -1,0 +1,52 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "cosigned.fullname" . }}-webhook-tls
+  name: {{ template "cosigned.fullname" . }}-validating
+  labels:
+    {{- include "cosigned.labels" . | nindent 4 }}
+    control-plane: {{ template "cosigned.fullname" . }}-webhook
+webhooks:
+  - clientConfig:
+      service:
+        name: {{ template "cosigned.fullname" . }}-webhook
+        namespace: {{ .Release.Namespace }}
+        path: /validations
+    failurePolicy: Ignore
+    #namespaceSelector:
+    #  matchLabels:
+    #    cosigned: "true"
+    name: webhook.cosigned.sigstore.dev
+    rules:
+      - apiGroups:
+        - ""
+        apiVersions:
+        - v1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - pods
+      - apiGroups:
+        - "apps"
+        apiVersions:
+        - v1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - daemonset
+        - statefulset
+        - replicaset
+        - deployments     
+      - apiGroups:
+        - "batch"
+        apiVersions:
+        - v1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - jobs
+    sideEffects: None

--- a/charts/cosigned/values.yaml
+++ b/charts/cosigned/values.yaml
@@ -1,0 +1,48 @@
+# Cosigned requires the installation of cert-manager
+certificates:
+  selfSigned: true
+  ca:
+    issuer:
+      name:
+      kind: Issuer
+  issuer:
+    name:
+    kind: Issuer
+
+## common node selector for all the pods
+commonNodeSelector: {}
+#  key1: value1
+#  key2: value2
+
+## common tolerations for all the pods
+commonTolerations: []
+# - key: "key"
+#   operator: "Equal"
+#   value: "value"
+#   effect: "NoSchedule"
+
+webhook:
+  secretKeyRef:
+    name: 
+  image:
+    repository: gcr.io/projectsigstore/cosigned
+    tag: 
+    pullPolicy: IfNotPresent
+  env: {}
+  extraArgs: {}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  securityContext:
+    runAsUser: 65532
+  service:
+    annotations: {}
+    type: ClusterIP
+    port: 443
+    # For nodeport, specify the following:
+    #   type: NodePort
+    #   nodePort: <port-number>


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hectorf@vmware.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

This PR adds the helm chart for the installation of a sigstore admission controller for cosign. We are still figuring it out other details such as the image name and the release process under `sigstore/cosign` repo.

It is related to https://github.com/sigstore/cosign/issues/550. 