### PR TITLE
feat: add ArtifactHub Verified Publisher

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,9 @@
+# Artifact Hub repository metadata file
+repositoryID: <artifacthub-id>
+owners:
+  - name: cpanato
+    email: ctadeu@gmail.com
+  - name: sabre1041
+    email: andy.block@gmail.com
+  - name: hectorj2f
+    email: hectorj@gmail.com


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

#### Summary

Hi @cpanato, @hectorj2f   and @sabre1041,

I would just need the id from the ArtifactHub Control panel to add to the `artifacthub-repo.yml` file. Its not a secret, so you could comment it into the PR or contact me in private. Or merge and added on your own. :)

See https://artifacthub.io/docs/topics/repositories/#verified-publisher for details. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #20 

