### PR TITLE
rekor: wait for services to start to avoid crashloop

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -30,3 +30,5 @@ annotations:
       image: gcr.io/trillian-opensource-ci/db_server@sha256:e21b597eedb84063c7d958b6548e62ff1531a2ce7c024f366ccb4fb43163218c
     - name: redis
       image: docker.io/redis@sha256:0a0d563fd6fe5361316dd53f7f0a244656675054302567230e85eb114f683db4
+    - name: appropriate/curl
+      image: docker.io/appropriate/curl@sha256:c8bf5bbec6397465a247c2bb3e589bb77e4f62ff88a027175ecb2d9e4f12c9d7

--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.3
+version: 0.2.4
 appVersion: 0.3.0
 
 keywords:

--- a/charts/rekor/templates/_helpers.tpl
+++ b/charts/rekor/templates/_helpers.tpl
@@ -350,8 +350,8 @@ Log Server Arguments
 {{- define "rekor.trillianLogServer.args" -}}
 - '--storage_system=mysql'
 - '--mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOSTNAME):$(MYSQL_PORT))/$(MYSQL_DATABASE)'
-- '--rpc_endpoint=0.0.0.0:8091'
-- '--http_endpoint=0.0.0.0:8090'
+- {{ printf "--rpc_endpoint=0.0.0.0:%d" (.Values.trillianLogServer.portRPC | int) | quote }}
+- {{ printf "--http_endpoint=0.0.0.0:%d" (.Values.trillianLogServer.portHTTP | int) | quote }}
 - '--alsologtostderr'
 {{- if .Values.trillianLogServer.extraArgs -}}
 {{ toYaml .Values.trillianLogServer.extraArgs }}
@@ -364,8 +364,8 @@ Log Signer Arguments
 {{- define "rekor.trillianLogSigner.args" -}}
 - '--storage_system=mysql'
 - '--mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOSTNAME):$(MYSQL_PORT))/$(MYSQL_DATABASE)'
-- '--rpc_endpoint=0.0.0.0:8091'
-- '--http_endpoint=0.0.0.0:8090'
+- {{ printf "--rpc_endpoint=0.0.0.0:%d" (.Values.trillianLogSigner.portRPC | int) | quote }}
+- {{ printf "--http_endpoint=0.0.0.0:%d" (.Values.trillianLogSigner.portHTTP | int) | quote }}
 - '--force_master'
 - '--alsologtostderr'
 {{- if .Values.trillianLogSigner.extraArgs -}}
@@ -380,7 +380,7 @@ Server Arguments
 {{- define "rekor.server.args" -}}
 - "serve"
 - {{ printf "--trillian_log_server.address=%s" (include "rekor.trillianLogServer.fullname" .) | quote }}
-- {{ printf "--trillian_log_server.port=%d" (.Values.trillianLogServer.port | int) | quote }}
+- {{ printf "--trillian_log_server.port=%d" (.Values.trillianLogServer.portRPC | int) | quote }}
 - {{ printf "--redis_server.address=%s" (include "redis.hostname" .) | quote }}
 - {{ printf "--redis_server.port=%d" (.Values.redis.port | int) | quote }}
 - "--rekor_server.address=0.0.0.0"

--- a/charts/rekor/templates/server/deployment.yaml
+++ b/charts/rekor/templates/server/deployment.yaml
@@ -35,8 +35,12 @@ spec:
         {{- end}}
     spec:
       serviceAccountName: {{ template "rekor.serviceAccountName.server" . }}
-      {{- if .Values.server.extraInitContainers }}
       initContainers:
+        - name: "wait-for-trillian-log-server"
+          image: "{{ template "rekor.image" .Values.initContainerImage }}"
+          imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
+          command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-trillian-log-server:8090; do echo waiting for {{ .Release.Name }}-trillian-log-server; sleep 5; done;"]
+      {{- if .Values.server.extraInitContainers }}
 {{ toYaml .Values.server.extraInitContainers | indent 8 }}
       {{- end }}
 {{- if .Values.server.priorityClassName }}

--- a/charts/rekor/templates/server/deployment.yaml
+++ b/charts/rekor/templates/server/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: "wait-for-trillian-log-server"
           image: "{{ template "rekor.image" .Values.initContainerImage }}"
           imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
-          command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-trillian-log-server:8090; do echo waiting for {{ .Release.Name }}-trillian-log-server; sleep 5; done;"]
+          command: ["sh", "-c", "until curl --max-time 10 http://{{ template "rekor.trillianLogServer.fullname" . }}:{{ .Values.trillianLogServer.portHTTP}}; do echo waiting for {{ template "rekor.trillianLogServer.fullname" . }}; sleep 5; done;"]
       {{- if .Values.server.extraInitContainers }}
 {{ toYaml .Values.server.extraInitContainers | indent 8 }}
       {{- end }}

--- a/charts/rekor/templates/trillian-log-server/deployment.yaml
+++ b/charts/rekor/templates/trillian-log-server/deployment.yaml
@@ -35,8 +35,12 @@ spec:
         {{- end}}
     spec:
       serviceAccountName: {{ template "rekor.serviceAccountName.trillianLogServer" . }}
-      {{- if .Values.trillianLogServer.extraInitContainers }}
       initContainers:
+        - name: "wait-for-trillian-db"
+          image: "{{ template "rekor.image" .Values.initContainerImage }}"
+          imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
+          command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
+      {{- if .Values.trillianLogServer.extraInitContainers }}
 {{ toYaml .Values.trillianLogServer.extraInitContainers | indent 8 }}
       {{- end }}
 {{- if .Values.trillianLogServer.priorityClassName }}

--- a/charts/rekor/templates/trillian-log-server/deployment.yaml
+++ b/charts/rekor/templates/trillian-log-server/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: "wait-for-trillian-db"
           image: "{{ template "rekor.image" .Values.initContainerImage }}"
           imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
-          command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
+          command: ["sh", "-c", "until curl --max-time 10 http://{{ template "mysql.hostname" . }}:{{ .Values.mysql.port }}; do echo waiting for {{ template "mysql.hostname" . }}; sleep 5; done;"]
       {{- if .Values.trillianLogServer.extraInitContainers }}
 {{ toYaml .Values.trillianLogServer.extraInitContainers | indent 8 }}
       {{- end }}

--- a/charts/rekor/templates/trillian-log-signer/deployment.yaml
+++ b/charts/rekor/templates/trillian-log-signer/deployment.yaml
@@ -35,8 +35,12 @@ spec:
         {{- end}}
     spec:
       serviceAccountName: {{ template "rekor.serviceAccountName.trillianLogSigner" . }}
-      {{- if .Values.trillianLogSigner.extraInitContainers }}
       initContainers:
+        - name: "wait-for-trillian-db"
+          image: "{{ template "rekor.image" .Values.initContainerImage }}"
+          imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
+          command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
+      {{- if .Values.trillianLogSigner.extraInitContainers }}
 {{ toYaml .Values.trillianLogSigner.extraInitContainers | indent 8 }}
       {{- end }}
 {{- if .Values.trillianLogSigner.priorityClassName }}

--- a/charts/rekor/templates/trillian-log-signer/deployment.yaml
+++ b/charts/rekor/templates/trillian-log-signer/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: "wait-for-trillian-db"
           image: "{{ template "rekor.image" .Values.initContainerImage }}"
           imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
-          command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
+          command: ["sh", "-c", "until curl --max-time 10 http://{{ template "mysql.hostname" . }}:{{ .Values.mysql.port }}; do echo waiting for {{ template "mysql.hostname" . }}; sleep 5; done;"]
       {{- if .Values.trillianLogSigner.extraInitContainers }}
 {{ toYaml .Values.trillianLogSigner.extraInitContainers | indent 8 }}
       {{- end }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -234,7 +234,8 @@
                 "enabled": true,
                 "replicaCount": 1,
                 "name": "trillian-log-server",
-                "port": 8091,
+                "portRPC": 8091,
+                "portHTTP": 8090,
                 "image": {
                     "registry": "gcr.io",
                     "repository": "trillian-opensource-ci/log_server",
@@ -272,6 +273,8 @@
                 "enabled": true,
                 "replicaCount": 1,
                 "name": "trillian-log-signer",
+                "portRPC": 8091,
+                "portHTTP": 8090,
                 "image": {
                     "registry": "gcr.io",
                     "repository": "trillian-opensource-ci/log_signer",
@@ -282,8 +285,8 @@
                     "type": "ClusterIP",
                     "ports": [
                         {
-                            "name": "8092-tcp",
-                            "port": 8092,
+                            "name": "8091-tcp",
+                            "port": 8091,
                             "protocol": "TCP",
                             "targetPort": 8091
                         }
@@ -2854,7 +2857,8 @@
                     "enabled": true,
                     "replicaCount": 1,
                     "name": "trillian-log-server",
-                    "port": 8091,
+                    "portRPC": 8091,
+                    "portHTTP": 8090,
                     "image": {
                         "registry": "gcr.io",
                         "repository": "trillian-opensource-ci/log_server",
@@ -2893,7 +2897,8 @@
                 "enabled",
                 "replicaCount",
                 "name",
-                "port",
+                "portRPC",
+                "portHTTP",
                 "image",
                 "service",
                 "livenessProbe",
@@ -2932,14 +2937,24 @@
                         "trillian-log-server"
                     ]
                 },
-                "port": {
-                    "$id": "#/properties/trillianLogServer/properties/port",
+                "portRPC": {
+                    "$id": "#/properties/trillianLogServer/properties/portRPC",
                     "type": "integer",
                     "title": "The port schema",
                     "description": "An explanation about the purpose of this instance.",
                     "default": 0,
                     "examples": [
                         8091
+                    ]
+                },
+                "portHTTP": {
+                    "$id": "#/properties/trillianLogServer/properties/portHTTP",
+                    "type": "integer",
+                    "title": "The port schema",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": 0,
+                    "examples": [
+                        8090
                     ]
                 },
                 "image": {
@@ -3259,6 +3274,8 @@
                     "enabled": true,
                     "replicaCount": 1,
                     "name": "trillian-log-signer",
+                    "portRPC": 8091,
+                    "portHTTP": 8090,
                     "image": {
                         "registry": "gcr.io",
                         "repository": "trillian-opensource-ci/log_signer",
@@ -3269,8 +3286,8 @@
                         "type": "ClusterIP",
                         "ports": [
                             {
-                                "name": "8092-tcp",
-                                "port": 8092,
+                                "name": "8091-tcp",
+                                "port": 8091,
                                 "protocol": "TCP",
                                 "targetPort": 8091
                             }
@@ -3291,6 +3308,8 @@
                 "enabled",
                 "replicaCount",
                 "name",
+                "portRPC",
+                "portHTTP",
                 "image",
                 "service",
                 "livenessProbe",
@@ -3327,6 +3346,26 @@
                     "default": "",
                     "examples": [
                         "trillian-log-signer"
+                    ]
+                },
+                "portRPC": {
+                    "$id": "#/properties/trillianLogSigner/properties/portRPC",
+                    "type": "integer",
+                    "title": "The port schema",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": 0,
+                    "examples": [
+                        8091
+                    ]
+                },
+                "portHTTP": {
+                    "$id": "#/properties/trillianLogSigner/properties/portHTTP",
+                    "type": "integer",
+                    "title": "The port schema",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": 0,
+                    "examples": [
+                        8090
                     ]
                 },
                 "image": {

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -1,5 +1,12 @@
 imagePullSecrets:
 
+initContainerImage:
+  registry: docker.io
+  repository: appropriate/curl
+  # latest from 2021-10-28
+  version: sha256:c8bf5bbec6397465a247c2bb3e589bb77e4f62ff88a027175ecb2d9e4f12c9d7
+  imagePullPolicy: IfNotPresent
+
 redis:
   enabled: true
   replicaCount: 1

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -187,7 +187,8 @@ trillianLogServer:
   enabled: true
   replicaCount: 1
   name: trillian-log-server
-  port: 8091
+  portRPC: 8091
+  portHTTP: 8090
   image:
     registry: gcr.io
     repository: trillian-opensource-ci/log_server
@@ -217,6 +218,8 @@ trillianLogSigner:
   enabled: true
   replicaCount: 1
   name: trillian-log-signer
+  portRPC: 8091
+  portHTTP: 8090
   image:
     registry: gcr.io
     repository: trillian-opensource-ci/log_signer
@@ -226,8 +229,8 @@ trillianLogSigner:
   service:
     type: ClusterIP
     ports:
-      - name: 8092-tcp
-        port: 8092
+      - name: 8091-tcp
+        port: 8091
         protocol: TCP
         targetPort: 8091
   livenessProbe: {}


### PR DESCRIPTION
#### Summary
when installing the rekor chart notice some pods are in crashloop

```
$ k get po
NAME                                         READY   STATUS             RESTARTS   AGE
rekor-mysql-756d7b8b4f-gcn82                 1/1     Running            0          2m11s
rekor-redis-6d5c5c99d8-5t8bn                 1/1     Running            0          2m11s
rekor-server-579c97969-zmffm                 0/1     CrashLoopBackOff   4          2m11s
rekor-trillian-log-server-7b659656bb-9pnp9   0/1     CrashLoopBackOff   4          2m11s
rekor-trillian-log-signer-c8ccc8cfc-8hsrk    0/1     CrashLoopBackOff   3          2m11s
```

this is because `trillian` needs the mysql be up and running to run and `rekor-server` needs `trillian` 
adding some init containers to perform the check before trying to start the services

after the change

```
$ k get po
NAME                                         READY   STATUS     RESTARTS   AGE
rekor-mysql-756d7b8b4f-885f2                 0/1     Running    0          16s
rekor-redis-6d5c5c99d8-9gx6n                 1/1     Running    0          16s
rekor-server-6bc774f9c6-d5mhd                0/1     Init:0/1   0          16s
rekor-trillian-log-server-59b5f5d7b-g52zx    0/1     Init:0/1   0          16s
rekor-trillian-log-signer-579cf4cc9f-v7hdx   0/1     Init:0/1   0          16s


$ k get po
NAME                                         READY   STATUS            RESTARTS   AGE
rekor-mysql-756d7b8b4f-885f2                 1/1     Running           0          56s
rekor-redis-6d5c5c99d8-9gx6n                 1/1     Running           0          56s
rekor-server-6bc774f9c6-d5mhd                0/1     Init:0/1          0          56s
rekor-trillian-log-server-59b5f5d7b-g52zx    0/1     PodInitializing   0          56s
rekor-trillian-log-signer-579cf4cc9f-v7hdx   0/1     PodInitializing   0          56s


$ k get po
NAME                                         READY   STATUS    RESTARTS   AGE
rekor-mysql-756d7b8b4f-885f2                 1/1     Running   0          68s
rekor-redis-6d5c5c99d8-9gx6n                 1/1     Running   0          68s
rekor-server-6bc774f9c6-d5mhd                0/1     Running   0          68s
rekor-trillian-log-server-59b5f5d7b-g52zx    1/1     Running   0          68s
rekor-trillian-log-signer-579cf4cc9f-v7hdx   1/1     Running   0          68s


$ k get po
NAME                                         READY   STATUS    RESTARTS   AGE
rekor-mysql-756d7b8b4f-885f2                 1/1     Running   0          83s
rekor-redis-6d5c5c99d8-9gx6n                 1/1     Running   0          83s
rekor-server-6bc774f9c6-d5mhd                1/1     Running   0          83s
rekor-trillian-log-server-59b5f5d7b-g52zx    1/1     Running   0          83s
rekor-trillian-log-signer-579cf4cc9f-v7hdx   1/1     Running   0          83s
```


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note

```release-note
rekor: wait for services to start to avoid crashloop
```
