### PR TITLE
rekor: Set storageClass types to string in schema

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.4
+version: 0.2.5
 appVersion: 0.3.0
 
 keywords:

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -1700,7 +1700,10 @@
                         },
                         "storageClass": {
                             "$id": "#/properties/mysql/properties/persistence/properties/storageClass",
-                            "type": "null",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
                             "title": "The storageClass schema",
                             "description": "An explanation about the purpose of this instance.",
                             "default": null,
@@ -2630,7 +2633,10 @@
                                 },
                                 "storageClass": {
                                     "$id": "#/properties/server/properties/attestation_storage/properties/persistence/properties/storageClass",
-                                    "type": "null",
+                                    "type":  [
+                                        "string",
+                                        "null"
+                                    ],
                                     "title": "The storageClass schema",
                                     "description": "An explanation about the purpose of this instance.",
                                     "default": null,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This change allows the user to specify non-null values for storageClass for both MySQL and Rekor. Without this change, a schema validation error is thrown when any non-null value is supplied for either of these storageClass variables.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #31

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fixed validation of non-default (non-null) storageClass values for the Rekor chart
```
