### PR TITLE
feat: support secret key ref

### DIFF
--- a/charts/cosigned/Chart.yaml
+++ b/charts/cosigned/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: cosigned
-version: v0.1.0
+version: v0.1.1
 appVersion: v1.3.0
 
 maintainers:

--- a/charts/cosigned/README.md
+++ b/charts/cosigned/README.md
@@ -18,9 +18,7 @@ The previous command generates two key files `cosign.key` and `cosign.pub`. Next
 kubectl create namespace cosign-system
 
 kubectl create secret generic mysecret -n \
-cosign-system --from-file=cosign.pub=./cosign.pub \
---from-file=cosign.key=./cosign.key \
---from-literal=cosign.password=$COSIGN_PASSWORD
+cosign-system --from-file=cosign.pub=./cosign.pub
 ```
 
 Install `cosigned` using Helm and setting the value of the secret key reference to `mysecret` that you created above:
@@ -30,7 +28,7 @@ helm repo add sigstore https://sigstore.github.io/helm-charts
 
 helm repo update
 
-helm install cosigned -n cosign-system sigstore/cosigned --devel --set webhook.secretKeyRef.name=mysecret
+helm install cosigned -n cosign-system sigstore/cosigned --devel --set cosign.secretKeyRef.name=mysecret
 ```
 
 ### Enabling Admission control

--- a/charts/cosigned/templates/webhook/cosign_secret.yaml
+++ b/charts/cosigned/templates/webhook/cosign_secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cosign.cosignPub }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  cosign.key: {{ .Values.cosign.cosignKey}}
-  cosign.password: {{ .Values.cosign.cosignPassword}}
+  cosign.key: {{ default "" .Values.cosign.cosignKey}}
+  cosign.password: {{ default "" .Values.cosign.cosignPassword}}
   cosign.pub: {{ .Values.cosign.cosignPub}}
+{{- end -}}

--- a/charts/cosigned/templates/webhook/deployment_webhook.yaml
+++ b/charts/cosigned/templates/webhook/deployment_webhook.yaml
@@ -48,7 +48,13 @@ spec:
 {{- end }}
 {{- end }}
         args:
+        {{- if and .Values.cosign.secretKeyRef }}
+        {{- if .Values.cosign.secretKeyRef.name }}
+        - -secret-name="{{ .Values.cosign.secretKeyRef.name }}"
+        {{- end }}
+        {{- else }}
         - -secret-name={{ template "cosigned.fullname" . }}-cosign-key
+        {{- end }}
         {{- range $key, $value := .Values.webhook.extraArgs }}
         - -{{ $key }}={{ $value }}
         {{- end }}

--- a/charts/cosigned/values.yaml
+++ b/charts/cosigned/values.yaml
@@ -6,7 +6,6 @@ cosign:
   cosignPub:
   cosignPassword:
 
-
 webhook:
   name: webhook
   image:

--- a/charts/cosigned/values.yaml
+++ b/charts/cosigned/values.yaml
@@ -1,8 +1,11 @@
 cosign:
+  secretKeyRef:
+    name:
   # add the values in base64 encoded
   cosignKey:
   cosignPub:
   cosignPassword:
+
 
 webhook:
   name: webhook


### PR DESCRIPTION
Signed-off-by: hectorj2f <hectorf@vmware.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Support using a specific secret from the cluster as the cosign secret. 
Fixes the documentation to only store the public key instead of the private and cosign password.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes https://github.com/sigstore/helm-charts/issues/29

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Add support to specific an existing secret key for cosign validations.
```
