### PR TITLE
rekor: refactor service wait init containers

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.5
+version: 0.2.6
 appVersion: 0.3.0
 
 keywords:
@@ -30,5 +30,7 @@ annotations:
       image: gcr.io/trillian-opensource-ci/db_server@sha256:e21b597eedb84063c7d958b6548e62ff1531a2ce7c024f366ccb4fb43163218c
     - name: redis
       image: docker.io/redis@sha256:0a0d563fd6fe5361316dd53f7f0a244656675054302567230e85eb114f683db4
-    - name: appropriate/curl
-      image: docker.io/appropriate/curl@sha256:c8bf5bbec6397465a247c2bb3e589bb77e4f62ff88a027175ecb2d9e4f12c9d7
+    - name: curlimages/curl
+      image: docker.io/curlimages/curl@sha256:1a2209a10a11295c3ab6952d1278a9ea2ce0d20e33fdeaeb24d7a4586767c825
+    - name: toolbelt/netcat
+      image: docker.io/toolbelt/netcat@sha256:a88ddd1f371229e7ea40a200a02145ddd48af602a028e0657e0ba6a18c58dbaf

--- a/charts/rekor/templates/server/deployment.yaml
+++ b/charts/rekor/templates/server/deployment.yaml
@@ -37,8 +37,8 @@ spec:
       serviceAccountName: {{ template "rekor.serviceAccountName.server" . }}
       initContainers:
         - name: "wait-for-trillian-log-server"
-          image: "{{ template "rekor.image" .Values.initContainerImage }}"
-          imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
+          image: "{{ template "rekor.image" .Values.initContainerImage.curl }}"
+          imagePullPolicy: {{ .Values.initContainerImage.curl.imagePullPolicy }}
           command: ["sh", "-c", "until curl --max-time 10 http://{{ template "rekor.trillianLogServer.fullname" . }}:{{ .Values.trillianLogServer.portHTTP}}; do echo waiting for {{ template "rekor.trillianLogServer.fullname" . }}; sleep 5; done;"]
       {{- if .Values.server.extraInitContainers }}
 {{ toYaml .Values.server.extraInitContainers | indent 8 }}

--- a/charts/rekor/templates/trillian-log-server/deployment.yaml
+++ b/charts/rekor/templates/trillian-log-server/deployment.yaml
@@ -37,9 +37,9 @@ spec:
       serviceAccountName: {{ template "rekor.serviceAccountName.trillianLogServer" . }}
       initContainers:
         - name: "wait-for-trillian-db"
-          image: "{{ template "rekor.image" .Values.initContainerImage }}"
-          imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
-          command: ["sh", "-c", "until curl --max-time 10 http://{{ template "mysql.hostname" . }}:{{ .Values.mysql.port }}; do echo waiting for {{ template "mysql.hostname" . }}; sleep 5; done;"]
+          image: "{{ template "rekor.image" .Values.initContainerImage.netcat }}"
+          imagePullPolicy: {{ .Values.initContainerImage.netcat.imagePullPolicy }}
+          command: ["sh", "-c", "until nc -z -w 10 {{ template "mysql.hostname" . }} {{ .Values.mysql.port }}; do echo waiting for {{ template "mysql.hostname" . }}; sleep 5; done;"]
       {{- if .Values.trillianLogServer.extraInitContainers }}
 {{ toYaml .Values.trillianLogServer.extraInitContainers | indent 8 }}
       {{- end }}

--- a/charts/rekor/templates/trillian-log-signer/deployment.yaml
+++ b/charts/rekor/templates/trillian-log-signer/deployment.yaml
@@ -37,9 +37,9 @@ spec:
       serviceAccountName: {{ template "rekor.serviceAccountName.trillianLogSigner" . }}
       initContainers:
         - name: "wait-for-trillian-db"
-          image: "{{ template "rekor.image" .Values.initContainerImage }}"
-          imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
-          command: ["sh", "-c", "until curl --max-time 10 http://{{ template "mysql.hostname" . }}:{{ .Values.mysql.port }}; do echo waiting for {{ template "mysql.hostname" . }}; sleep 5; done;"]
+          image: "{{ template "rekor.image" .Values.initContainerImage.netcat }}"
+          imagePullPolicy: {{ .Values.initContainerImage.netcat.imagePullPolicy }}
+          command: ["sh", "-c", "until nc -z -w 10 {{ template "mysql.hostname" . }} {{ .Values.mysql.port }}; do echo waiting for {{ template "mysql.hostname" . }}; sleep 5; done;"]
       {{- if .Values.trillianLogSigner.extraInitContainers }}
 {{ toYaml .Values.trillianLogSigner.extraInitContainers | indent 8 }}
       {{- end }}

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -1,11 +1,18 @@
 imagePullSecrets:
 
 initContainerImage:
-  registry: docker.io
-  repository: appropriate/curl
-  # latest from 2021-10-28
-  version: sha256:c8bf5bbec6397465a247c2bb3e589bb77e4f62ff88a027175ecb2d9e4f12c9d7
-  imagePullPolicy: IfNotPresent
+  curl:
+    registry: docker.io
+    repository: curlimages/curl
+    # 7.79.1
+    version: sha256:1a2209a10a11295c3ab6952d1278a9ea2ce0d20e33fdeaeb24d7a4586767c825
+    imagePullPolicy: IfNotPresent
+  netcat:
+    registry: docker.io
+    repository: toolbelt/netcat
+    # 2021-10-23
+    version: sha256:a88ddd1f371229e7ea40a200a02145ddd48af602a028e0657e0ba6a18c58dbaf
+    imagePullPolicy: IfNotPresent
 
 redis:
   enabled: true


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
The goal of this change is to upgrade curl to the current stable release. However, since the current stable release of curl behaves differently with respect to non-HTTP servers, a different solution was necessary for determining availability of the database (MySQL and MariaDB do not use HTTP).

This resulted in three changes:

1. Change the curl image to docker.io/curlimages/curl:7.79.1
2. Modify the test for database server availability to use netcat instead of curl
3. Refactor the initContainerImage section of the values.yaml to support multiple init containers

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
rekor: refactored service wait init containers which includes a change to the structure of the initContainerImage section of values.yaml
```
