### PR TITLE
Support for signed released

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,28 @@ jobs:
         with:
           version: v3.7.1
 
+      - name: Install sigstore Helm plugin
+        run: |
+          helm plugin install https://github.com/sigstore/helm-sigstore
+      - name: Install GPG Keys
+        run: |
+          cat <(echo -e "${{ secrets.GPG_PRIVATE_KEY }}") | gpg --import --batch
+          gpg --export > /home/runner/.gnupg/pubring.gpg
+          gpg --export-secret-keys > /home/runner/.gnupg/secring.gpg
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@c25b74a986eb925b398320414b576227f375f946 # pin@v1.2.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SIGN: "true"
+          CR_KEY: "${{ secrets.GPG_KEY_NAME }}"
+          CR_KEYRING: "/home/runner/.gnupg/secring.gpg"
+
+      - name: Upload Helm Charts to Rekor
+        run: |
+          for chart in `find .cr-release-packages -name '*.tgz' -print`; do
+            helm sigstore upload --keyring=/home/runner/.gnupg/secring.gpg ${chart}
+          done
 
       - name: Login to GitHub Container Registry
         run: |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ Install one of the available charts:
 $ helm upgrade -i oci://ghcr.io/sigstore/helm-charts/<chart_name> --version=<version>
 ```
 
+## Provenance
+
+Charts are signed using the [provenance methods provided by the Helm project](https://helm.sh/docs/topics/provenance/) as well as uploaded to the [Rekor transparency server](https://github.com/sigstore/rekor) using the [Helm sigtore plugin](https://github.com/sigstore/helm-sigstore).
+
+Verification of the signed charts can be accomplished by importing the GPG Public Key that was used to sign the associated chart.
+
+```shell
+cat security/pubkey.gpg | gpg --import --batch
+```
+
+Once the public key has been imported, charts can be verified using the `helm verify` and/or `helm sigstore verify` commands.
+
+NOTE: The public key that was used to sign a particular chart may not be identical to the public key on the `main` branch. Each chart release has an associated git tag. The public key that was used to sign the particular chart will be included in this tag.
+
 ## Charts
 
 * [rekor](charts/rekor)

--- a/charts/cosigned/Chart.yaml
+++ b/charts/cosigned/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: cosigned
-version: v0.1.8
+version: v0.1.9
 appVersion: v1.4.1
 
 maintainers:

--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.7
+version: 0.2.9
 appVersion: 0.3.0
 
 keywords:


### PR DESCRIPTION
Support for signing Helm releases and publishing to Rekor

Requires `GPG_PRIVATE_KEY` and `GPG_KEY_NAME` to be set as Secrets

CC: @SantiagoTorres @dlorenc We should also have some information about how to retrieve the public key and steps that can be used to validate the packages.