### PR TITLE
allow specifying annotations on service account

### DIFF
--- a/charts/cosigned/Chart.yaml
+++ b/charts/cosigned/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: cosigned
-version: v0.1.9
+version: v0.1.10
 appVersion: v1.4.1
 
 maintainers:

--- a/charts/cosigned/Chart.yaml
+++ b/charts/cosigned/Chart.yaml
@@ -8,8 +8,8 @@ sources:
 type: application
 
 name: cosigned
-version: v0.1.11
-appVersion: v1.4.1
+version: 0.1.11
+appVersion: 1.4.1
 
 maintainers:
   - name: dlorenc

--- a/charts/cosigned/templates/webhook/sa_webhook.yaml
+++ b/charts/cosigned/templates/webhook/sa_webhook.yaml
@@ -6,3 +6,7 @@ metadata:
     control-plane: {{ template "cosigned.fullname" . }}-webhook
   name: {{ template "cosigned.fullname" . }}-webhook
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/cosigned/templates/webhook/sa_webhook.yaml
+++ b/charts/cosigned/templates/webhook/sa_webhook.yaml
@@ -6,7 +6,7 @@ metadata:
     control-plane: {{ template "cosigned.fullname" . }}-webhook
   name: {{ template "cosigned.fullname" . }}-webhook
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.webhook.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/cosigned/values.yaml
+++ b/charts/cosigned/values.yaml
@@ -30,6 +30,8 @@ webhook:
     capabilities:
       drop:
       - all
+  serviceAccount:
+    annotations: {}
   service:
     annotations: {}
     type: ClusterIP


### PR DESCRIPTION
#### Summary
This allows specifying annotations on the service account in the cosigned helm chart. This is needed to use workload identity with GKE.

#### Release Note
```release-note
Added `.Values.webhook.serviceAccount.annotations` to allow specifying service account annotations
```
