### PR TITLE
remove the v to make it semver compatible for OCI

### DIFF
--- a/charts/cosigned/Chart.yaml
+++ b/charts/cosigned/Chart.yaml
@@ -8,8 +8,8 @@ sources:
 type: application
 
 name: cosigned
-version: v0.1.9
-appVersion: v1.4.1
+version: 0.1.10
+appVersion: 1.4.1
 
 maintainers:
   - name: dlorenc


### PR DESCRIPTION
#### Summary
- remove the v to make it semver compatible for OCI

#### Ticket Link
Fixes https://github.com/sigstore/helm-charts/issues/54

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
remove the v to make it semver compatible for OCI
```
