### PR TITLE
set job permissions to push data to GitHub release and packages 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # pin@v1.1
         with:
-          version: v3.7.1
+          version: v3.8.1
 
       - name: Install sigstore Helm plugin
         run: |


### PR DESCRIPTION
#### Summary
- add dependabot
- update helm to v3.8.1
- set job permissions to push data to GitHub release and packages (related to https://github.com/sigstore/helm-charts/runs/5360536935?check_suite_focus=true)
 
#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
