### PR TITLE
fix: ingress service name not found

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.13
+version: 0.2.14
 appVersion: 0.5.0
 
 keywords:

--- a/charts/rekor/templates/server/service.yaml
+++ b/charts/rekor/templates/server/service.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- if .Values.server.service.labels }}
 {{ toYaml .Values.server.service.labels | indent 4 }}
 {{- end }}
-  name: {{ template "rekor.fullname" . }}
+  name: {{ template "rekor.server.fullname" . }}
 {{ include "rekor.namespace" . | indent 2 }}
 spec:
   ports:


### PR DESCRIPTION
Signed-off-by: hectorj2f <hectorf@vmware.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Ingress service name `scaffold-rekor-server` does not match the service name of the rekor server which was `rekor`. Another option would be to change the helpers.tpl so the service name is `rekor.fullname` instead of `rekor.server.fullname`.

![Screenshot 2022-03-18 at 14 52 55](https://user-images.githubusercontent.com/3602792/159028906-ba0bfb8d-22b7-4872-811f-11fe426d7980.png)


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
