### PR TITLE
Allow specifying multiple hosts for service TLS

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.17
+version: 0.2.18
 appVersion: 0.5.0
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -101,8 +101,12 @@ The following table lists the configurable parameters of the Rekor chart and the
 | server.image.version | string | `"sha256:516651575db19412c94d4260349a84a9c30b37b5d2635232fba669262c5cbfa6"` | v0.5.0 |
 | server.ingress.annotations | object | `{}` |  |
 | server.ingress.enabled | bool | `true` |  |
-| server.ingress.path | string | `"/"` |  |
-| server.ingress.tls | object | `{}` |  |
+| server.ingress.hosts | array | [] |  |
+| server.ingress.hosts.host | string |  |  |
+| server.ingress.hosts.path | string | `"/"` |  |
+| server.ingress.tls | array | `[]` |  |
+| server.ingress.tls.hosts | array | `[]` |  |
+| server.ingress.tls.secretName | string | `` |  |
 | server.livenessProbe.failureThreshold | int | `3` |  |
 | server.livenessProbe.httpGet.path | string | `"/ping"` |  |
 | server.livenessProbe.httpGet.port | int | `3000` |  |

--- a/charts/rekor/ci/ci-values.yaml
+++ b/charts/rekor/ci/ci-values.yaml
@@ -1,4 +1,6 @@
 ---
 server:
   ingress:
-    hostname: rekor.localhost
+    hosts:
+      - host: rekor.localhost
+        path: /

--- a/charts/rekor/templates/_helpers.tpl
+++ b/charts/rekor/templates/_helpers.tpl
@@ -341,7 +341,7 @@ Return the appropriate apiVersion for ingress.
 Print "true" if the API pathType field is supported
 */}}
 {{- define "ingress.supportsPathType" -}}
-{{- if (semverCompare "<1.18-0" .Capabilities.KubeVersion.Version) -}}
+{{- if (semverCompare "<1.18-0" $.Capabilities.KubeVersion.Version) -}}
 {{- print "false" -}}
 {{- else -}}
 {{- print "true" -}}

--- a/charts/rekor/templates/server/ingress.yaml
+++ b/charts/rekor/templates/server/ingress.yaml
@@ -10,18 +10,24 @@ metadata:
 {{ toYaml .Values.server.ingress.annotations | indent 4 }}
 spec:
   rules:
-    - host: {{ required "An Ingress hostname is required" .Values.server.ingress.hostname }}
+    {{- range .Values.server.ingress.hosts }}
+    - host: {{ required "An Ingress hostname is required" .host | quote }}
       http:
         paths:
-          - path: {{ .Values.server.ingress.path }}
-            {{- if eq "true" (include "ingress.supportsPathType" .) }}
-            pathType: {{ default "Prefix" .Values.server.ingress.pathType }}
+          - path: {{ .path }}
+            {{- if eq "true" (include "ingress.supportsPathType" $) }}
+            pathType: {{ default "Prefix" .pathType }}
             {{- end }}
-            backend: {{- include "rekor.server.ingress.backend" .  | nindent 14 }}
-{{- if .Values.server.ingress.tls }}
+            backend: {{- include "rekor.server.ingress.backend" $  | nindent 14 }}
+    {{- end }}
+{{- if .Values.server.ingress.tlsEnabled }}
   tls:
+    {{- range .Values.server.ingress.tls }}
     - hosts:
-        - {{  .Values.server.ingress.hostname | quote }}
-      secretName: {{ .Values.server.ingress.tls.secretName }}
+      {{- range .hosts }}
+      - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
 {{- end -}}
 {{- end }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -87,9 +87,15 @@
                 },
                 "ingress": {
                     "enabled": true,
+                    "hosts": [
+                      {
+                        "host": "rekor.localhost",
+                        "path": "/"
+                      }
+                    ],
                     "annotations": {},
-                    "path": "/",
-                    "tls": {}
+                    "tls": [],
+                    "tlsEnabled": false
                 },
                 "service": {
                     "type": "ClusterIP",
@@ -867,8 +873,14 @@
                     "ingress": {
                         "enabled": true,
                         "annotations": {},
-                        "path": "/",
-                        "tls": {}
+                        "hosts": [
+                          {
+                            "host": "rekor.localhost",
+                            "path": "/"
+                          }
+                        ],
+                        "tls": [],
+                        "tlsEnabled": false
                     },
                     "service": {
                         "type": "ClusterIP",
@@ -1082,8 +1094,14 @@
                         {
                             "enabled": true,
                             "annotations": {},
-                            "path": "/",
-                            "tls": {}
+                            "hosts": [
+                              {
+                                "host": "rekor.localhost",
+                                "path": "/"
+                              }
+                            ],
+                            "tls": [],
+                            "tlsEnabled": false
                         }
                     ],
                     "required": [],
@@ -1098,6 +1116,37 @@
                                 true
                             ]
                         },
+                        "hosts": {
+                            "$id": "#/properties/server/properties/ingress/properties/annotations",
+                            "type": "array",
+                            "title": "Hostname for ingress.",
+                            "description": "An explanation about the purpose of this instance.",
+                            "properties": {
+                              "host": {
+                                  "$id": "#/properties/server/properties/ingress/properties/hosts/properties/host",
+                                  "type": "string",
+                                  "title": "The host rule",
+                                  "description": "An explanation about the purpose of this instance.",
+                                  "examples": [
+                                      "/"
+                                  ]
+                              },
+                              "path": {
+                                  "$id": "#/properties/server/properties/ingress/properties/hosts/properties/path",
+                                  "type": "string",
+                                  "title": "The host path",
+                                  "description": "An explanation about the purpose of this instance.",
+                                  "default": "",
+                                  "examples": [
+                                      "/"
+                                  ]
+                              }
+                            },
+                            "default": [],
+                            "examples": [],
+                            "required": [],
+                            "additionalProperties": true
+                        },
                         "annotations": {
                             "$id": "#/properties/server/properties/ingress/properties/annotations",
                             "type": "object",
@@ -1110,27 +1159,36 @@
                             "required": [],
                             "additionalProperties": true
                         },
-                        "path": {
-                            "$id": "#/properties/server/properties/ingress/properties/path",
-                            "type": "string",
-                            "title": "The path schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "/"
-                            ]
-                        },
                         "tls": {
                             "$id": "#/properties/server/properties/ingress/properties/tls",
-                            "type": "object",
+                            "type": "array",
                             "title": "The tls schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {}
-                            ],
+                            "properties": {
+                              "hosts": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "description": "Hosts are a list of hosts included in the TLS certificate."
+                              },
+                              "secretName": {
+                                "type": "string",
+                                "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing."
+                              }
+                            },
+                            "default": [],
+                            "examples": [],
                             "required": [],
                             "additionalProperties": true
+                        },
+                        "tlsEnabled": {
+                            "$id": "#/properties/server/properties/ingress/properties/tlsEnabled",
+                            "type": "boolean",
+                            "title": "Whether to have TLS.",
+                            "description": "Whether to have TLS clause.",
+                            "default": false,
+                            "examples": [ true ]
                         }
                     },
                     "additionalProperties": true

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -68,9 +68,12 @@ server:
     production: false
   ingress:
     enabled: true
+    hosts:
+      - host: rekor.localhost
+        path: /
     annotations: {}
-    path: /
-    tls: {}
+    tls: []
+    tlsEnabled: false
   service:
     type: ClusterIP
     ports:


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

    Add separate property tlsEnabled to control population of tls fields.
    Change existing tls type from object to array to mirror k8s ingress
    schema. allowing multiple tls/hosts to be specified.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
