### PR TITLE
Move prometheus annotations from deployment to pod for Rekor.

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.18
+version: 0.2.19
 appVersion: 0.5.0
 
 keywords:

--- a/charts/rekor/templates/server/deployment.yaml
+++ b/charts/rekor/templates/server/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
 {{- if .Values.server.deploymentAnnotations }}
   annotations:
-    {{ toYaml .Values.server.deploymentAnnotations | nindent 4 }}
+    {{- toYaml .Values.server.deploymentAnnotations | nindent 4 }}
 {{- end }}
   labels:
     {{- include "rekor.server.labels" . | nindent 4 }}
@@ -26,7 +26,7 @@ spec:
     metadata:
     {{- if .Values.server.podAnnotations }}
       annotations:
-        {{ toYaml .Values.server.podAnnotations | nindent 8 }}
+        {{- toYaml .Values.server.podAnnotations | nindent 8 }}
     {{- end }}
       labels:
         {{- include "rekor.server.labels" . | nindent 8 }}

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -120,7 +120,7 @@ server:
       existingClaim: ""
       accessModes:
         - ReadWriteOnce
-  deploymentAnnotations:
+  podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/path: /metrics
     prometheus.io/port: "2112"


### PR DESCRIPTION
Prometheus scrap annotations should be on the pod and not the
deployment.

Also clean up some of the extra blank lines.

Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
