### PR TITLE
Make resources and securityContext configurable for ctlog helm chart

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.2
+version: 0.2.3
 
 keywords:
   - security

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -29,6 +29,7 @@ The following table lists the configurable parameters of the ctlog chart and the
 | createctconfig.image.version | string | `"sha256:a1a886e10c49a0d6f705e99fd879853c074fb537ec7411ab9f3eb61e0eebfc5e"` |  |
 | createctconfig.name | string | `"createctconfig"` |  |
 | createctconfig.replicaCount | int | `1` |  |
+| createctconfig.securityContext | object | `{}` |  |
 | createctconfig.serviceAccount.annotations | object | `{}` |  |
 | createctconfig.serviceAccount.create | bool | `true` |  |
 | createctconfig.serviceAccount.mountToken | bool | `true` |  |
@@ -39,6 +40,7 @@ The following table lists the configurable parameters of the ctlog chart and the
 | createtree.image.repository | string | `"sigstore/scaffolding/createtree"` |  |
 | createtree.image.version | string | `"sha256:de57091f8b846ad7935b1c70af0a45e55af7fed50508bec30a51f41509ae75f1"` |  |
 | createtree.name | string | `"createtree"` |  |
+| createtree.securityContext | object | `{}` |  |
 | createtree.serviceAccount.annotations | object | `{}` |  |
 | createtree.serviceAccount.create | bool | `true` |  |
 | createtree.serviceAccount.mountToken | bool | `true` |  |
@@ -46,11 +48,14 @@ The following table lists the configurable parameters of the ctlog chart and the
 | forceNamespace | string | `""` |  |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"ctlog-system"` |  |
+| server.extraArgs | object | `{}` |  |
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"ghcr.io"` |  |
 | server.image.repository | string | `"sigstore/scaffolding/ct_server"` |  |
 | server.image.version | string | `"sha256:f828f66c731ba104fdb7133c4a65653156c8e8394a47915813a7e90ed954b4a1"` |  |
 | server.replicaCount | int | `1` |  |
+| server.resources | object | `{}` |  |
+| server.securityContext | object | `{}` |  |
 | server.service.ports[0].name | string | `"80-tcp"` |  |
 | server.service.ports[0].port | int | `80` |  |
 | server.service.ports[0].protocol | string | `"TCP"` |  |

--- a/charts/ctlog/templates/_helpers.tpl
+++ b/charts/ctlog/templates/_helpers.tpl
@@ -103,6 +103,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Server Arguments
+*/}}
+{{- define "ctlog.server.args" -}}
+- "--http_endpoint=0.0.0.0:6962"
+- "--log_config=/ctfe-config/ct_server.cfg"
+- "--alsologtostderr"
+{{- if .Values.server.extraArgs -}}
+{{- range $key, $value := .Values.server.extraArgs }}
+{{- if $value }}
+- {{ printf "%v=%v" $key $value | quote }}
+{{- else }}
+- {{ printf $key | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "ctlog.serviceAccountName" -}}

--- a/charts/ctlog/templates/createctconfig-job.yaml
+++ b/charts/ctlog/templates/createctconfig-job.yaml
@@ -15,9 +15,18 @@ spec:
         - name: {{ template "ctlog.createctconfig.fullname" . }}
           image: "{{ template "ctlog.image" .Values.createctconfig.image }}"
           imagePullPolicy: "{{ .Values.createctconfig.image.pullPolicy }}"
-          args: ["--namespace=$(NAMESPACE)", "--configmap={{ template "ctlog.config" . }}", "--secret={{ template "ctlog.secret" . }}","--trillian-server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace }}:{{ .Values.trillian.logServer.portRPC}}"]
+          args: [
+            "--namespace=$(NAMESPACE)",
+            "--configmap={{ template "ctlog.config" . }}",
+            "--secret={{ template "ctlog.secret" . }}",
+            "--trillian-server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace }}:{{ .Values.trillian.logServer.portRPC}}"
+          ]
           env:
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+    {{- if .Values.createctconfig.securityContext }}
+      securityContext:
+{{ toYaml .Values.createctconfig.securityContext | indent 8 }}
+    {{- end }}

--- a/charts/ctlog/templates/createtree-job.yaml
+++ b/charts/ctlog/templates/createtree-job.yaml
@@ -20,4 +20,13 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          args: ["--namespace=$(NAMESPACE)", "--configmap={{ template "ctlog.config" . }}", "--display_name={{ template "ctlog.createtree.fullname" . }}","--admin_server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace }}:{{ .Values.trillian.logServer.portRPC}}"]
+          args: [
+            "--namespace=$(NAMESPACE)",
+            "--configmap={{ template "ctlog.config" . }}",
+            "--display_name={{ template "ctlog.createtree.fullname" . }}",
+            "--admin_server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace }}:{{ .Values.trillian.logServer.portRPC}}"
+          ]
+    {{- if .Values.createtree.securityContext }}
+      securityContext:
+{{ toYaml .Values.createtree.securityContext | indent 8 }}
+    {{- end }}

--- a/charts/ctlog/templates/ctlog-deployment.yaml
+++ b/charts/ctlog/templates/ctlog-deployment.yaml
@@ -20,7 +20,8 @@ spec:
         - name: {{ template "ctlog.fullname" . }}
           image: "{{ template "ctlog.image" .Values.server.image }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
-          args: ["--http_endpoint=0.0.0.0:6962", "--log_config=/ctfe-config/ct_server.cfg", "--alsologtostderr"]
+          args:
+{{  include "ctlog.server.args" . | indent 12 }}
           volumeMounts:
             - name: keys
               mountPath: "/ctfe-keys"
@@ -30,6 +31,14 @@ spec:
               readOnly: true
           ports:
             - containerPort: 6962
+    {{- if .Values.server.resources }}
+          resources:
+{{ toYaml .Values.server.resources | indent 12 }}
+    {{- end }}
+    {{- if .Values.server.securityContext }}
+      securityContext:
+{{ toYaml .Values.server.securityContext | indent 8 }}
+    {{- end }}
       volumes:
         - name: keys
           secret:

--- a/charts/ctlog/values.schema.json
+++ b/charts/ctlog/values.schema.json
@@ -283,6 +283,7 @@
                             ]
                         }
                     },
+                    "extraArgs": [],
                     "additionalProperties": true
                 },
                 "service": {

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -21,6 +21,7 @@ server:
         port: 80
         protocol: TCP
         targetPort: 6962
+  extraArgs: []
 createtree:
   enabled: true
   name: createtree


### PR DESCRIPTION

Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Allow securityContext to be configurable.
Allow resources to be set on ctlog server
Allow specifying extraArgs for ctlog server
Split args on to multiple lines to make it more readable.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
