### PR TITLE
Allow customizing securityContext, resources, etc. for Fulcio

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -4,7 +4,7 @@ description: Fulcio
 
 type: application
 
-version: 0.2.2
+version: 0.2.3
 
 keywords:
   - security

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -69,8 +69,13 @@ The following table lists the configurable parameters of the Fulcio chart and th
 | server.image.version | string | `"sha256:66870bd6b111f3c5478703a8fb31c062003f0127b2c2c5e49ccd82abc4ec7841"` |  |
 | server.ingress.annotations | object | `{}` |  |
 | server.ingress.enabled | bool | `true` |  |
-| server.ingress.path | string | `"/"` |  |
-| server.ingress.tls | object | `{}` |  |
+| server.ingress.hosts | array | [] |  |
+| server.ingress.hosts.host | string |  |  |
+| server.ingress.hosts.path | string | `"/"` |  |
+| server.ingress.hosts.service_name | string |  |  |
+| server.ingress.tls | array | `[]` |  |
+| server.ingress.tls.hosts | array | `[]` |  |
+| server.ingress.tls.secretName | string | `` |  |
 | server.replicaCount | int | `1` |  |
 | server.service.ports[0].name | string | `"80-tcp"` |  |
 | server.service.ports[0].port | int | `80` |  |

--- a/charts/fulcio/ci/ci-values.yaml
+++ b/charts/fulcio/ci/ci-values.yaml
@@ -1,4 +1,5 @@
 ---
 server:
   ingress:
-    hostname: fulcio.localhost
+    hosts:
+      - host: fulcio.localhost

--- a/charts/fulcio/templates/createcerts-job.yaml
+++ b/charts/fulcio/templates/createcerts-job.yaml
@@ -22,4 +22,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+    {{- if .Values.createcerts.securityContext }}
+      securityContext:
+{{ toYaml .Values.createcerts.securityContext | indent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/fulcio/templates/fulcio-configmap.yaml
+++ b/charts/fulcio/templates/fulcio-configmap.yaml
@@ -7,4 +7,4 @@ metadata:
     {{- include "fulcio.labels" . | nindent 4 }}
 data:
   config.json: |-
-{{ .Values.config.contents | toJson | indent 4 }}
+{{ .Values.config.contents | toPrettyJson | indent 4 }}

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -12,6 +12,10 @@ spec:
       {{- include "fulcio.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+    {{- if .Values.server.podAnnotations }}
+      annotations:
+        {{- toYaml .Values.server.podAnnotations | nindent 8 }}
+    {{- end }}
       labels:
         {{- include "fulcio.selectorLabels" . | nindent 8 }}
     spec:
@@ -23,7 +27,7 @@ spec:
           image: "{{ template "fulcio.image" .Values.server.image }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           ports:
-            - containerPort: {{ .Values.server.args.port}}
+{{- include "fulcio.containerPorts" .Values.server.service.ports | indent 12 }}
           args:
             - "serve"
             - "--port={{ .Values.server.args.port}}"
@@ -64,6 +68,14 @@ spec:
               mountPath: "/var/run/fulcio-secrets"
               readOnly: true
            {{- end }}
+    {{- if .Values.server.resources }}
+          resources:
+{{ toYaml .Values.server.resources | indent 12 }}
+    {{- end }}
+    {{- if .Values.server.securityContext }}
+      securityContext:
+{{ toYaml .Values.server.securityContext | indent 8 }}
+    {{- end }}
       volumes:
         - name: fulcio-config
           configMap:

--- a/charts/fulcio/templates/fulcio-ingress.yaml
+++ b/charts/fulcio/templates/fulcio-ingress.yaml
@@ -10,18 +10,24 @@ metadata:
 {{ toYaml .Values.server.ingress.annotations | indent 4 }}
 spec:
   rules:
-    - host: {{ required "An Ingress hostname is required" .Values.server.ingress.hostname }}
+    {{- range .Values.server.ingress.hosts }}
+    - host: {{ required "An Ingress hostname is required" .host | quote }}
       http:
         paths:
-          - path: {{ .Values.server.ingress.path }}
-            {{- if eq "true" (include "ingress.supportsPathType" .) }}
-            pathType: {{ default "Prefix" .Values.server.ingress.pathType }}
+          - path: {{ .path }}
+            {{- if eq "true" (include "ingress.supportsPathType" $) }}
+            pathType: {{ default "Prefix" .pathType }}
             {{- end }}
-            backend: {{- include "fulcio.server.ingress.backend" .  | nindent 14 }}
+            backend: {{- include "fulcio.server.ingress.backend" (list $ .) | nindent 14 }}
+    {{- end }}
 {{- if .Values.server.ingress.tls }}
   tls:
+    {{- range .Values.server.ingress.tls }}
     - hosts:
-        - {{  .Values.server.ingress.hostname | quote }}
-      secretName: {{ .Values.server.ingress.tls.secretName }}
+      {{- range .hosts }}
+      - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
 {{- end -}}
 {{- end }}

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -64,8 +64,13 @@
                 "ingress": {
                     "enabled": true,
                     "annotations": {},
-                    "path": "/",
-                    "tls": {}
+                    "hosts": [
+                      {
+                        "host": "fulcio.localhost",
+                        "path": "/"
+                      }
+                    ],
+                    "tls": []
                 }
             },
             "createcerts": {
@@ -370,8 +375,13 @@
                     "ingress": {
                         "enabled": true,
                         "annotations": {},
-                        "path": "/",
-                        "tls": {}
+                        "hosts": [
+                          {
+                            "host": "fulcio.localhost",
+                            "path": "/"
+                          }
+                        ],
+                        "tls": []
                     }
                 }
             ],
@@ -455,6 +465,16 @@
                         }
                     },
                     "additionalProperties": true
+                },
+                "name": {
+                    "$id": "#/properties/server/properties/name",
+                    "type": "string",
+                    "title": "The name schema",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": "",
+                    "examples": [
+                        "server"
+                    ]
                 },
                 "args": {
                     "$id": "#/properties/server/properties/args",
@@ -713,8 +733,12 @@
                         {
                             "enabled": true,
                             "annotations": {},
-                            "path": "/",
-                            "tls": {}
+                            "hosts": [
+                              {
+                                "host": "fulcio.localhost"
+                              }
+                            ],
+                            "tls": []
                         }
                     ],
                     "required": [],
@@ -741,25 +765,68 @@
                             "required": [],
                             "additionalProperties": true
                         },
-                        "path": {
-                            "$id": "#/properties/server/properties/ingress/properties/path",
-                            "type": "string",
-                            "title": "The path schema",
+                        "hosts": {
+                            "$id": "#/properties/server/properties/ingress/properties/hosts",
+                            "type": "array",
+                            "title": "Hostname for ingress.",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "/"
-                            ]
+                            "properties": {
+                              "host": {
+                                  "$id": "#/properties/server/properties/ingress/properties/hosts/properties/host",
+                                  "type": "string",
+                                  "title": "The host rule",
+                                  "description": "An explanation about the purpose of this instance.",
+                                  "examples": [
+                                      ""
+                                  ]
+                              },
+                              "path": {
+                                  "$id": "#/properties/server/properties/ingress/properties/hosts/properties/path",
+                                  "type": "string",
+                                  "title": "The host path",
+                                  "description": "An explanation about the purpose of this instance.",
+                                  "default": "",
+                                  "examples": [
+                                      "/"
+                                  ]
+                              },
+                              "service_name": {
+                                  "$id": "#/properties/server/properties/ingress/properties/hosts/properties/service_name",
+                                  "type": "string",
+                                  "title": "The backend service name",
+                                  "description": "An explanation about the purpose of this instance.",
+                                  "default": "",
+                                  "examples": [
+                                      ""
+                                  ]
+                              }
+
+                            },
+                            "default": [],
+                            "examples": [],
+                            "required": [],
+                            "additionalProperties": true
                         },
                         "tls": {
                             "$id": "#/properties/server/properties/ingress/properties/tls",
-                            "type": "object",
+                            "type": "array",
                             "title": "The tls schema",
                             "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {}
-                            ],
+                            "properties": {
+                              "hosts": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "description": "Hosts are a list of hosts included in the TLS certificate."
+                              },
+                              "secretName": {
+                                "type": "string",
+                                "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing."
+                              }
+                            },
+                            "default": [],
+                            "examples": [],
                             "required": [],
                             "additionalProperties": true
                         }

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -19,6 +19,7 @@ config:
   }
 server:
   replicaCount: 1
+  name: server
   svcPort: 80
   image:
     registry: gcr.io
@@ -41,15 +42,20 @@ server:
   service:
     type: ClusterIP
     ports:
-      - name: 80-tcp
+      - name: 5555-tcp
         port: 80
         protocol: TCP
         targetPort: 5555
+      - name: 2112-tcp
+        port: 2112
+        protocol: TCP
+        targetPort: 2112
   ingress:
     enabled: true
     annotations: {}
-    path: /
-    tls: {}
+    hosts:
+      - path: /
+    tls: []
 createcerts:
   enabled: true
   replicaCount: 1

--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.19
+version: 0.2.20
 appVersion: 0.5.0
 
 keywords:

--- a/charts/rekor/templates/_helpers.tpl
+++ b/charts/rekor/templates/_helpers.tpl
@@ -341,7 +341,7 @@ Return the appropriate apiVersion for ingress.
 Print "true" if the API pathType field is supported
 */}}
 {{- define "ingress.supportsPathType" -}}
-{{- if (semverCompare "<1.18-0" $.Capabilities.KubeVersion.Version) -}}
+{{- if (semverCompare "<1.18-0" .Capabilities.KubeVersion.Version) -}}
 {{- print "false" -}}
 {{- else -}}
 {{- print "true" -}}

--- a/charts/rekor/templates/server/ingress.yaml
+++ b/charts/rekor/templates/server/ingress.yaml
@@ -20,7 +20,7 @@ spec:
             {{- end }}
             backend: {{- include "rekor.server.ingress.backend" $  | nindent 14 }}
     {{- end }}
-{{- if .Values.server.ingress.tlsEnabled }}
+{{- if .Values.server.ingress.tls }}
   tls:
     {{- range .Values.server.ingress.tls }}
     - hosts:

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -94,8 +94,7 @@
                       }
                     ],
                     "annotations": {},
-                    "tls": [],
-                    "tlsEnabled": false
+                    "tls": []
                 },
                 "service": {
                     "type": "ClusterIP",
@@ -879,8 +878,7 @@
                             "path": "/"
                           }
                         ],
-                        "tls": [],
-                        "tlsEnabled": false
+                        "tls": []
                     },
                     "service": {
                         "type": "ClusterIP",
@@ -1100,8 +1098,7 @@
                                 "path": "/"
                               }
                             ],
-                            "tls": [],
-                            "tlsEnabled": false
+                            "tls": []
                         }
                     ],
                     "required": [],
@@ -1181,14 +1178,6 @@
                             "examples": [],
                             "required": [],
                             "additionalProperties": true
-                        },
-                        "tlsEnabled": {
-                            "$id": "#/properties/server/properties/ingress/properties/tlsEnabled",
-                            "type": "boolean",
-                            "title": "Whether to have TLS.",
-                            "description": "Whether to have TLS clause.",
-                            "default": false,
-                            "examples": [ true ]
                         }
                     },
                     "additionalProperties": true

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -69,11 +69,9 @@ server:
   ingress:
     enabled: true
     hosts:
-      - host: rekor.localhost
-        path: /
+      - path: /
     annotations: {}
     tls: []
-    tlsEnabled: false
   service:
     type: ClusterIP
     ports:


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

    - allow specifying multiple container ports
    - allow specifying multiple hosts/tls for ingress
    - allow specifying ingress backend service name
    - allow specifying deployment name
    - allow specifying securityContext for create*jobs and deployment
    - allow specifying resources for deployment
    - allow specifying annotations for pods, for prometheus scrapping
    - change json config to use toPrettyJson for readability

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
