### PR TITLE
bump ctlog to generate a new release

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.3
+version: 0.2.4
 
 keywords:
   - security


### PR DESCRIPTION
#### Summary
for some reason, the release for ctlog 0.2.3 is missing in the index.yaml but the release exists in Github

bumping the version to get a release out 


