### PR TITLE
Specify metrics port for ctlog

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.4
+version: 0.2.5
 
 keywords:
   - security

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -53,6 +53,9 @@ The following table lists the configurable parameters of the ctlog chart and the
 | server.image.registry | string | `"ghcr.io"` |  |
 | server.image.repository | string | `"sigstore/scaffolding/ct_server"` |  |
 | server.image.version | string | `"sha256:f828f66c731ba104fdb7133c4a65653156c8e8394a47915813a7e90ed954b4a1"` |  |
+| server.podAnnotations | string | `{}` |  |
+| server.portHTTP | integer | `6962` |  |
+| server.portHTTPMetrics | integer | `6963` |  |
 | server.replicaCount | int | `1` |  |
 | server.resources | object | `{}` |  |
 | server.securityContext | object | `{}` |  |

--- a/charts/ctlog/templates/_helpers.tpl
+++ b/charts/ctlog/templates/_helpers.tpl
@@ -106,7 +106,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Server Arguments
 */}}
 {{- define "ctlog.server.args" -}}
-- "--http_endpoint=0.0.0.0:6962"
+- {{ printf "--http_endpoint=0.0.0.0:%d" (.Values.server.portHTTP | int) | quote }}
+- {{ printf "--metrics_endpoint=0.0.0.0:%d" (.Values.server.portHTTPMetrics | int) | quote }}
 - "--log_config=/ctfe-config/ct_server.cfg"
 - "--alsologtostderr"
 {{- if .Values.server.extraArgs -}}
@@ -177,3 +178,13 @@ Create the name of the secret
 {{- define "ctlog.secret" -}}
 {{ printf "%s-secret" (include "ctlog.fullname" .) }}
 {{- end }}
+
+{{/*
+Create Container Ports based on Service Ports
+*/}}
+{{- define "ctlog.containerPorts" -}}
+{{- range . }}
+- containerPort: {{ (ternary .port .targetPort (empty .targetPort)) | int }}
+  protocol: {{ default "TCP" .protocol }}
+{{- end -}}
+{{- end -}}

--- a/charts/ctlog/templates/ctlog-deployment.yaml
+++ b/charts/ctlog/templates/ctlog-deployment.yaml
@@ -30,7 +30,7 @@ spec:
               mountPath: "/ctfe-config"
               readOnly: true
           ports:
-            - containerPort: 6962
+{{- include "ctlog.containerPorts" .Values.server.service.ports | indent 12 }}
     {{- if .Values.server.resources }}
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}

--- a/charts/ctlog/values.schema.json
+++ b/charts/ctlog/values.schema.json
@@ -19,6 +19,8 @@
                     "pullPolicy": "IfNotPresent",
                     "version": "sha256:f828f66c731ba104fdb7133c4a65653156c8e8394a47915813a7e90ed954b4a1"
                 },
+                "portHTTP": 6962,
+                "portHTTPMetrics": 6963,
                 "serviceAccount": {
                     "create": true,
                     "name": "",
@@ -134,6 +136,8 @@
                         "pullPolicy": "IfNotPresent",
                         "version": "sha256:f828f66c731ba104fdb7133c4a65653156c8e8394a47915813a7e90ed954b4a1"
                     },
+                    "portHTTP": 6962,
+                    "portHTTPMetrics": 6963,
                     "serviceAccount": {
                         "create": true,
                         "name": "",
@@ -223,6 +227,24 @@
                         }
                     },
                     "additionalProperties": true
+                },
+                "portHTTP": {
+                    "$id": "#/properties/server/properties/portHTTP",
+                    "type": "integer",
+                    "title": "The HTTP port schema",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": {},
+                    "examples": [],
+                    "required": []
+                },
+                "portHTTP": {
+                    "$id": "#/properties/server/properties/portHTTPMetrics",
+                    "type": "integer",
+                    "title": "The HTTP metrics port schema",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": {},
+                    "examples": [],
+                    "required": []
                 },
                 "serviceAccount": {
                     "$id": "#/properties/server/properties/serviceAccount",

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -14,14 +14,22 @@ server:
     name: ""
     annotations: {}
     mountToken: false
+  portHTTP: 6962
+  portHTTPMetrics: 6963
   service:
     type: ClusterIP
     ports:
-      - name: 80-tcp
+      - name: 6962-tcp
         port: 80
         protocol: TCP
         targetPort: 6962
+      - name: 6963-tcp
+        port: 6963
+        protocol: TCP
+        targetPort: 6963
   extraArgs: []
+  securityContext:
+    runAsNonRoot: true
 createtree:
   enabled: true
   name: createtree
@@ -36,6 +44,8 @@ createtree:
     name: ""
     annotations: {}
     mountToken: true
+  securityContext:
+    runAsNonRoot: true
 createctconfig:
   enabled: true
   replicaCount: 1
@@ -51,6 +61,8 @@ createctconfig:
     name: ""
     annotations: {}
     mountToken: true
+  securityContext:
+    runAsNonRoot: true
 trillian:
   namespace: trillian-system
   logServer:


### PR DESCRIPTION


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Specify metrics port for ctlog
Allow specifying pod annotations.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
