### PR TITLE
Dont create sa for createcert if no job for Fulcio

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -4,7 +4,7 @@ description: Fulcio
 
 type: application
 
-version: 0.2.5
+version: 0.2.6
 
 keywords:
   - security

--- a/charts/fulcio/templates/createcerts-serviceacount.yaml
+++ b/charts/fulcio/templates/createcerts-serviceacount.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.server.args.certificateAuthority "fileca" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,3 +8,4 @@ metadata:
     {{- include "fulcio.labels" . | nindent 4 }}
   annotations:
 {{ toYaml .Values.createcerts.serviceAccount.annotations | indent 4 }}
+{{- end }}

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -56,6 +56,8 @@ server:
     hosts:
       - path: /
     tls: []
+  securityContext:
+    runAsNonRoot: true
 createcerts:
   enabled: true
   replicaCount: 1
@@ -71,6 +73,8 @@ createcerts:
     name: ""
     annotations: {}
     mountToken: true
+  securityContext:
+    runAsNonRoot: true
 # Configure ctlog dependency
 ctlog:
   enabled: true


### PR DESCRIPTION


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Add same condition for service account for as the job.
That is, guard if fileca for createcert for serviceaccount.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
