### PR TITLE
Remove initContainer when mysql disabled

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -4,7 +4,7 @@ description: Trillian
 
 type: application
 
-version: 0.1.3
+version: 0.1.4
 
 keywords:
   - security

--- a/charts/trillian/templates/trillian-log-server/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-server/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         {{- end}}
     spec:
       serviceAccountName: {{ template "trillian.serviceAccountName.logServer" . }}
+{{- if .Values.mysql.enabled }}
       initContainers:
         - name: "wait-for-trillian-db"
           image: "{{ template "trillian.image" .Values.initContainerImage.netcat }}"
@@ -43,6 +44,7 @@ spec:
       {{- if .Values.logServer.extraInitContainers }}
 {{ toYaml .Values.logServer.extraInitContainers | indent 8 }}
       {{- end }}
+{{- end }}
 {{- if .Values.logServer.priorityClassName }}
       priorityClassName: "{{ .Values.logServer.priorityClassName }}"
 {{- end }}

--- a/charts/trillian/templates/trillian-log-signer/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-signer/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         {{- end}}
     spec:
       serviceAccountName: {{ template "trillian.serviceAccountName.logSigner" . }}
+{{- if .Values.mysql.enabled }}
       initContainers:
         - name: "wait-for-trillian-db"
           image: "{{ template "trillian.image" .Values.initContainerImage.netcat }}"
@@ -43,6 +44,7 @@ spec:
       {{- if .Values.logSigner.extraInitContainers }}
 {{ toYaml .Values.logSigner.extraInitContainers | indent 8 }}
       {{- end }}
+{{- end }}
 {{- if .Values.logSigner.priorityClassName }}
       priorityClassName: "{{ .Values.logSigner.priorityClassName }}"
 {{- end }}


### PR DESCRIPTION


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Dont add initContainer to wait for MySQL when mysql.enabled != true.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
