### PR TITLE
default mysql hostname to localhost when using gcp mysql

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -4,7 +4,7 @@ description: Trillian
 
 type: application
 
-version: 0.1.5
+version: 0.1.6
 
 keywords:
   - security

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -90,7 +90,7 @@ The following table lists the configurable parameters of the trilian chart and t
 | mysql.gcp.cloudsql.version | string | `"1.28.1"` |  |
 | mysql.gcp.enabled | string | `""` |  |
 | mysql.gcp.instance | string | `""` |  |
-| mysql.hostname | string | `""` |  |
+| mysql.hostname | string | `""` | `Will default to localhost if not specified when mysql.gcp.enabled=true` |
 | mysql.image.pullPolicy | string | `"IfNotPresent"` |  |
 | mysql.image.registry | string | `"gcr.io"` |  |
 | mysql.image.repository | string | `"trillian-opensource-ci/db_server"` |  |

--- a/charts/trillian/templates/_helpers.tpl
+++ b/charts/trillian/templates/_helpers.tpl
@@ -27,7 +27,11 @@ If release name contains chart name it will be used as a full name.
 Return the hostname for mysql
 */}}
 {{- define "mysql.hostname" -}}
+{{- if (and (not .Values.mysql.enabled) .Values.mysql.gcp.enabled) -}}
+{{- default "localhost" .Values.mysql.hostname }}
+{{- else -}}
 {{- default (include "trillian.mysql.fullname" .) .Values.mysql.hostname }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -18,7 +18,7 @@ initContainerImage:
 mysql:
   gcp:
     enabled: false
-    instance: ""
+    instance: "projectid:region:instance-name"
     cloudsql:
       registry: gcr.io
       repository: cloudsql-docker/gce-proxy


### PR DESCRIPTION


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

default mysql hostname to localhost when using gcp mysql
Fix bad cloud sql proxy image tag. missing patch .0, for 1.29.0

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
