### PR TITLE
move default into template helper to allow overwrite.

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -4,7 +4,7 @@ description: Fulcio
 
 type: application
 
-version: 0.2.7
+version: 0.2.8
 
 keywords:
   - security

--- a/charts/fulcio/templates/_helpers.tpl
+++ b/charts/fulcio/templates/_helpers.tpl
@@ -188,3 +188,28 @@ service:
     number: {{ $servicePort | int }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the contents for fulcio config.
+*/}}
+{{- define "fulcio.configmap.contents" -}}
+{{- if .Values.config.contents -}}
+{{- toPrettyJson .Values.config.contents }}
+{{- else -}}
+{
+  "OIDCIssuers": {
+    "https://kubernetes.default.svc": {
+      "IssuerURL": "https://kubernetes.default.svc",
+      "ClientID": "sigstore",
+      "Type": "kubernetes"
+    }
+  },
+  "MetaIssuers": {
+    "https://kubernetes.*.svc": {
+      "ClientID": "sigstore",
+      "Type": "kubernetes"
+    }
+  }
+}
+{{- end -}}
+{{- end -}}

--- a/charts/fulcio/templates/fulcio-configmap.yaml
+++ b/charts/fulcio/templates/fulcio-configmap.yaml
@@ -7,4 +7,4 @@ metadata:
     {{- include "fulcio.labels" . | nindent 4 }}
 data:
   config.json: |-
-{{ .Values.config.contents | toPrettyJson | indent 4 }}
+{{ include "fulcio.configmap.contents" . | indent 4 }}

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -2,21 +2,7 @@ namespace:
   create: false
   name: fulcio-system
 config:
-  contents: {
-    "OIDCIssuers": {
-      "https://kubernetes.default.svc": {
-        "IssuerURL": "https://kubernetes.default.svc",
-        "ClientID": "sigstore",
-        "Type": "kubernetes"
-      }
-    },
-    "MetaIssuers": {
-      "https://kubernetes.*.svc": {
-        "ClientID": "sigstore",
-        "Type": "kubernetes"
-      }
-    }
-  }
+  contents: {}
 server:
   replicaCount: 1
   name: server


### PR DESCRIPTION


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Due to the nature of helm handling of maps, it is not possible to
overwrite keys in the base value.yaml of the chart. Keys from value.yaml
included with the chart will always be present.

If it was the main chart, it would be possible to null existing keys,
but due to https://github.com/helm/helm/issues/9136, it does not work
with sub-charts at the moment.

So to allow downstream users to overwrite the config contents, the
default is now set in the template helper, when an empty object is
specified.

@nsmith5 what do you think about this solution? 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes https://github.com/sigstore/helm-charts/issues/109

this addresses the issue https://github.com/sigstore/helm-charts/issues/109 without changing config.content to string type.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
