### PR TITLE
Feat/cosigned/add support for webhook name flag

### DIFF
--- a/charts/cosigned/Chart.yaml
+++ b/charts/cosigned/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: cosigned
-version: 0.1.15
+version: 0.1.16
 appVersion: 1.7.2
 
 maintainers:

--- a/charts/cosigned/README.md
+++ b/charts/cosigned/README.md
@@ -15,7 +15,7 @@ The following table lists the configurable parameters of the cosigned chart and 
 | commonTolerations | list | `[]` |  |
 | cosign.cosignPub | string | `""` |  |
 | cosign.secretKeyRef.name | string | `""` |  |
-| cosign.webhookName | string | `""` |  |
+| cosign.webhookName | string | `"cosigned.sigstore.dev"` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | webhook.env | object | `{}` |  |
 | webhook.extraArgs | object | `{}` |  |

--- a/charts/cosigned/README.md
+++ b/charts/cosigned/README.md
@@ -15,6 +15,7 @@ The following table lists the configurable parameters of the cosigned chart and 
 | commonTolerations | list | `[]` |  |
 | cosign.cosignPub | string | `""` |  |
 | cosign.secretKeyRef.name | string | `""` |  |
+| cosign.webhookName | string | `""` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | webhook.env | object | `{}` |  |
 | webhook.extraArgs | object | `{}` |  |

--- a/charts/cosigned/templates/_helpers.tpl
+++ b/charts/cosigned/templates/_helpers.tpl
@@ -117,17 +117,6 @@ Create the image path for the passed in image field
 {{- end -}}
 
 {{/*
-Cosigned webhook name
-*/}}
-{{- define "cosigned.webhookName" -}}
-{{- if .Values.cosign.webhookName -}}
-{{- .Values.cosign.webhookName -}}
-{{- else -}}
-cosigned.sigstore.dev
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create the image path for the passed in policy-webhook image field
 */}}
 {{- define "policywebhook.image" -}}

--- a/charts/cosigned/templates/_helpers.tpl
+++ b/charts/cosigned/templates/_helpers.tpl
@@ -117,6 +117,17 @@ Create the image path for the passed in image field
 {{- end -}}
 
 {{/*
+Cosigned webhook name
+*/}}
+{{- define "cosigned.webhookName" -}}
+{{- if .Values.cosign.webhookName -}}
+{{- .Values.cosign.webhookName -}}
+{{- else -}}
+cosigned.sigstore.dev
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the image path for the passed in policy-webhook image field
 */}}
 {{- define "policywebhook.image" -}}

--- a/charts/cosigned/templates/policy-webhook/clusterrole_policy_webhook.yaml
+++ b/charts/cosigned/templates/policy-webhook/clusterrole_policy_webhook.yaml
@@ -32,7 +32,10 @@ rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
     verbs: ["get", "update"]
-    resourceNames: [ {{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName | quote }}, "validating.clusterimagepolicy.sigstore.dev", "defaulting.clusterimagepolicy.sigstore.dev"]
+    resourceNames:
+    - {{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName | quote }}
+    - {{ required "A valid policywebhook.webhookNames.defaulting is required" .Values.policywebhook.webhookNames.defaulting | quote }}
+    - {{ required "A valid policywebhook.webhookNames.validating is required" .Values.policywebhook.webhookNames.validating | quote }}
 
   - apiGroups: [""]
     resources: ["namespaces"]

--- a/charts/cosigned/templates/policy-webhook/clusterrole_policy_webhook.yaml
+++ b/charts/cosigned/templates/policy-webhook/clusterrole_policy_webhook.yaml
@@ -32,7 +32,7 @@ rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
     verbs: ["get", "update"]
-    resourceNames: ["cosigned.sigstore.dev","validating.clusterimagepolicy.sigstore.dev", "defaulting.clusterimagepolicy.sigstore.dev"]
+    resourceNames: [ {{ include "cosigned.webhookName" . | quote }}, "validating.clusterimagepolicy.sigstore.dev", "defaulting.clusterimagepolicy.sigstore.dev"]
 
   - apiGroups: [""]
     resources: ["namespaces"]

--- a/charts/cosigned/templates/policy-webhook/clusterrole_policy_webhook.yaml
+++ b/charts/cosigned/templates/policy-webhook/clusterrole_policy_webhook.yaml
@@ -32,7 +32,7 @@ rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
     verbs: ["get", "update"]
-    resourceNames: [ {{ include "cosigned.webhookName" . | quote }}, "validating.clusterimagepolicy.sigstore.dev", "defaulting.clusterimagepolicy.sigstore.dev"]
+    resourceNames: [ {{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName | quote }}, "validating.clusterimagepolicy.sigstore.dev", "defaulting.clusterimagepolicy.sigstore.dev"]
 
   - apiGroups: [""]
     resources: ["namespaces"]

--- a/charts/cosigned/templates/policy-webhook/deployment_policy_webhook.yaml
+++ b/charts/cosigned/templates/policy-webhook/deployment_policy_webhook.yaml
@@ -25,12 +25,12 @@ spec:
   selector:
     matchLabels:
       {{- include "cosigned.selectorLabels" . | nindent 6 }}
-      control-plane: {{ template "cosigned.fullname" . }}-policy-webhook      
+      control-plane: {{ template "cosigned.fullname" . }}-policy-webhook
   template:
     metadata:
       labels:
         {{- include "cosigned.selectorLabels" . | nindent 8 }}
-        control-plane: {{ template "cosigned.fullname" . }}-policy-webhook        
+        control-plane: {{ template "cosigned.fullname" . }}-policy-webhook
     spec:
       nodeSelector:
         {{- toYaml .Values.commonNodeSelector | nindent 8 }}
@@ -56,6 +56,10 @@ spec:
         image: "{{ template "cosigned.image" .Values.policywebhook.image }}"
         imagePullPolicy: "{{ .Values.policywebhook.image.pullPolicy }}"
         args:
+        {{- if semverCompare ">= 1.8-0" .Chart.AppVersion }}
+        - --mutating-webhook-name={{ required "A valid policywebhook.webhookNames.defaulting is required" .Values.policywebhook.webhookNames.defaulting }}
+        - --validating-webhook-name={{ required "A valid policywebhook.webhookNames.validating is required" .Values.policywebhook.webhookNames.validating }}
+        {{- end }}
         {{- range $key, $value := .Values.policywebhook.extraArgs }}
         - -{{ $key }}={{ $value }}
         {{- end }}
@@ -69,7 +73,7 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
 {{- end }}
-{{- end }}        
+{{- end }}
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:
@@ -88,7 +92,7 @@ spec:
           protocol: TCP
         - containerPort: 9090
           name: metrics
-          protocol: TCP          
+          protocol: TCP
         securityContext:
           {{- with .Values.webhook.podSecurityContext }}
           {{- toYaml . | nindent 10}}
@@ -112,7 +116,7 @@ spec:
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.
       terminationGracePeriodSeconds: 300
-      
+
       {{- if .Values.policywebhook.securityContext.enabled }}
       securityContext:
         {{- with .Values.policywebhook.securityContext }}

--- a/charts/cosigned/templates/policy-webhook/policy_webhook_configurations.yaml
+++ b/charts/cosigned/templates/policy-webhook/policy_webhook_configurations.yaml
@@ -16,7 +16,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: defaulting.clusterimagepolicy.sigstore.dev
+  name: {{ required "A valid policywebhook.webhookNames.defaulting is required" .Values.policywebhook.webhookNames.defaulting }}
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -26,13 +26,13 @@ webhooks:
         namespace: {{ .Release.Namespace }}
     failurePolicy: Fail
     matchPolicy: Equivalent
-    name: defaulting.clusterimagepolicy.sigstore.dev
+    name: {{ required "A valid policywebhook.webhookNames.defaulting is required" .Values.policywebhook.webhookNames.defaulting }}
     sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating.clusterimagepolicy.sigstore.dev
+  name: {{ required "A valid policywebhook.webhookNames.validating is required" .Values.policywebhook.webhookNames.validating }}
 webhooks:
   - admissionReviewVersions:
       - v1
@@ -42,5 +42,5 @@ webhooks:
         namespace: {{ .Release.Namespace }}
     failurePolicy: Fail
     matchPolicy: Equivalent
-    name: validating.clusterimagepolicy.sigstore.dev
+    name: {{ required "A valid policywebhook.webhookNames.defaulting is required" .Values.policywebhook.webhookNames.defaulting }}
     sideEffects: None

--- a/charts/cosigned/templates/webhook/clusterrole_webhook.yaml
+++ b/charts/cosigned/templates/webhook/clusterrole_webhook.yaml
@@ -17,7 +17,7 @@ rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
     verbs: ["get", "update"]
-    resourceNames: ["cosigned.sigstore.dev"]
+    resourceNames: [{{ include "cosigned.webhookName" . | quote }}]
 
   - apiGroups: [""]
     resources: ["namespaces"]

--- a/charts/cosigned/templates/webhook/clusterrole_webhook.yaml
+++ b/charts/cosigned/templates/webhook/clusterrole_webhook.yaml
@@ -17,7 +17,7 @@ rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
     verbs: ["get", "update"]
-    resourceNames: [{{ include "cosigned.webhookName" . | quote }}]
+    resourceNames: [{{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName | quote }}]
 
   - apiGroups: [""]
     resources: ["namespaces"]

--- a/charts/cosigned/templates/webhook/deployment_webhook.yaml
+++ b/charts/cosigned/templates/webhook/deployment_webhook.yaml
@@ -55,6 +55,9 @@ spec:
         {{- else }}
         - -secret-name={{ template "cosigned.fullname" . }}-cosign-key
         {{- end }}
+        {{- if .Values.cosign.webhookName }}
+        - --webhook-name={{ include "cosigned.webhookName" . | quote }}
+        {{- end }}
         {{- range $key, $value := .Values.webhook.extraArgs }}
         - -{{ $key }}={{ $value }}
         {{- end }}

--- a/charts/cosigned/templates/webhook/deployment_webhook.yaml
+++ b/charts/cosigned/templates/webhook/deployment_webhook.yaml
@@ -48,15 +48,13 @@ spec:
 {{- end }}
 {{- end }}
         args:
+        - --webhook-name={{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName | quote }}
         {{- if and .Values.cosign.secretKeyRef }}
         {{- if .Values.cosign.secretKeyRef.name }}
         - -secret-name={{ .Values.cosign.secretKeyRef.name }}
         {{- end }}
         {{- else }}
         - -secret-name={{ template "cosigned.fullname" . }}-cosign-key
-        {{- end }}
-        {{- if .Values.cosign.webhookName }}
-        - --webhook-name={{ include "cosigned.webhookName" . | quote }}
         {{- end }}
         {{- range $key, $value := .Values.webhook.extraArgs }}
         - -{{ $key }}={{ $value }}

--- a/charts/cosigned/templates/webhook/deployment_webhook.yaml
+++ b/charts/cosigned/templates/webhook/deployment_webhook.yaml
@@ -48,7 +48,9 @@ spec:
 {{- end }}
 {{- end }}
         args:
+        {{- if semverCompare ">= 1.8-0" .Chart.AppVersion }}
         - --webhook-name={{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName | quote }}
+        {{- end }}
         {{- if and .Values.cosign.secretKeyRef }}
         {{- if .Values.cosign.secretKeyRef.name }}
         - -secret-name={{ .Values.cosign.secretKeyRef.name }}

--- a/charts/cosigned/templates/webhook/webhook_mutating.yaml
+++ b/charts/cosigned/templates/webhook/webhook_mutating.yaml
@@ -1,9 +1,9 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: cosigned.sigstore.dev
+  name: {{ include "cosigned.webhookName" . }}
 webhooks:
-- name: cosigned.sigstore.dev
+- name: {{ include "cosigned.webhookName" . }}
   namespaceSelector:
     # The webhook should only apply to things that opt-in
     matchExpressions:

--- a/charts/cosigned/templates/webhook/webhook_mutating.yaml
+++ b/charts/cosigned/templates/webhook/webhook_mutating.yaml
@@ -1,9 +1,9 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: {{ include "cosigned.webhookName" . }}
+  name: {{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
 webhooks:
-- name: {{ include "cosigned.webhookName" . }}
+- name: {{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
   namespaceSelector:
     # The webhook should only apply to things that opt-in
     matchExpressions:

--- a/charts/cosigned/templates/webhook/webhook_validating.yaml
+++ b/charts/cosigned/templates/webhook/webhook_validating.yaml
@@ -1,9 +1,9 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: {{ include "cosigned.webhookName" . }}
+  name: {{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
 webhooks:
-- name: {{ include "cosigned.webhookName" . }}
+- name: {{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
   namespaceSelector:
     # The webhook should only apply to things that opt-in
     matchExpressions:

--- a/charts/cosigned/templates/webhook/webhook_validating.yaml
+++ b/charts/cosigned/templates/webhook/webhook_validating.yaml
@@ -1,9 +1,9 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: cosigned.sigstore.dev
+  name: {{ include "cosigned.webhookName" . }}
 webhooks:
-- name: cosigned.sigstore.dev
+- name: {{ include "cosigned.webhookName" . }}
   namespaceSelector:
     # The webhook should only apply to things that opt-in
     matchExpressions:

--- a/charts/cosigned/values.schema.json
+++ b/charts/cosigned/values.schema.json
@@ -13,7 +13,8 @@
                 "cosignPub": "",
                 "secretKeyRef": {
                     "name": ""
-                }
+                },
+                "webhookName": ""
             },
             "policywebhook": {
                 "env": {},
@@ -149,7 +150,8 @@
                     "cosignPub": "",
                     "secretKeyRef": {
                         "name": ""
-                    }
+                    },
+                    "webhookName": ""
                 }
             ],
             "required": [
@@ -194,6 +196,16 @@
                         }
                     },
                     "additionalProperties": true
+                },
+                "webhookName": {
+                    "$id": "#/properties/cosign/properties/webhookName",
+                    "type": "string",
+                    "title": "The webhookName schema",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": "",
+                    "examples": [
+                        ""
+                    ]
                 }
             },
             "additionalProperties": true

--- a/charts/cosigned/values.schema.json
+++ b/charts/cosigned/values.schema.json
@@ -14,7 +14,7 @@
                 "secretKeyRef": {
                     "name": ""
                 },
-                "webhookName": ""
+                "webhookName": "cosigned.sigstore.dev"
             },
             "policywebhook": {
                 "env": {},
@@ -151,12 +151,13 @@
                     "secretKeyRef": {
                         "name": ""
                     },
-                    "webhookName": ""
+                    "webhookName": "cosigned.sigstore.dev"
                 }
             ],
             "required": [
                 "cosignPub",
-                "secretKeyRef"
+                "secretKeyRef",
+                "webhookName"
             ],
             "properties": {
                 "cosignPub": {
@@ -204,7 +205,7 @@
                     "description": "An explanation about the purpose of this instance.",
                     "default": "",
                     "examples": [
-                        ""
+                        "cosigned.sigstore.dev"
                     ]
                 }
             },

--- a/charts/cosigned/values.schema.json
+++ b/charts/cosigned/values.schema.json
@@ -55,6 +55,10 @@
                 },
                 "serviceAccount": {
                     "annotations": {}
+                },
+                "webhookNames": {
+                    "defaulting": "defaulting.clusterimagepolicy.sigstore.dev",
+                    "validating": "validating.clusterimagepolicy.sigstore.dev"
                 }
             },
             "serviceMonitor": {
@@ -257,6 +261,10 @@
                     },
                     "serviceAccount": {
                         "annotations": {}
+                    },
+                    "webhookNames": {
+                        "defaulting": "defaulting.clusterimagepolicy.sigstore.dev",
+                        "validating": "validating.clusterimagepolicy.sigstore.dev"
                     }
                 }
             ],
@@ -268,7 +276,8 @@
                 "resources",
                 "securityContext",
                 "service",
-                "serviceAccount"
+                "serviceAccount",
+                "webhookNames"
             ],
             "properties": {
                 "env": {
@@ -679,6 +688,46 @@
                             ],
                             "required": [],
                             "additionalProperties": true
+                        }
+                    },
+                    "additionalProperties": true
+                },
+                "webhookNames": {
+                    "$id": "#/properties/policywebhook/properties/webhookNames",
+                    "type": "object",
+                    "title": "The webhookNames schema",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": {},
+                    "examples": [
+                        {
+                            "defaulting": "defaulting.clusterimagepolicy.sigstore.dev",
+                            "validating": "validating.clusterimagepolicy.sigstore.dev"
+                        }
+                    ],
+                    "required": [
+                        "defaulting",
+                        "validating"
+                    ],
+                    "properties": {
+                        "defaulting": {
+                            "$id": "#/properties/policywebhook/properties/webhookNames/properties/defaulting",
+                            "type": "string",
+                            "title": "The defaulting schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                "defaulting.clusterimagepolicy.sigstore.dev"
+                            ]
+                        },
+                        "validating": {
+                            "$id": "#/properties/policywebhook/properties/webhookNames/properties/validating",
+                            "type": "string",
+                            "title": "The validating schema",
+                            "description": "An explanation about the purpose of this instance.",
+                            "default": "",
+                            "examples": [
+                                "validating.clusterimagepolicy.sigstore.dev"
+                            ]
                         }
                     },
                     "additionalProperties": true

--- a/charts/cosigned/values.yaml
+++ b/charts/cosigned/values.yaml
@@ -3,7 +3,7 @@ cosign:
     name: ""
   # add the values in base64 encoded
   cosignPub: ""
-  webhookName: ""
+  webhookName: "cosigned.sigstore.dev"
 
 policywebhook:
   image:

--- a/charts/cosigned/values.yaml
+++ b/charts/cosigned/values.yaml
@@ -3,6 +3,7 @@ cosign:
     name: ""
   # add the values in base64 encoded
   cosignPub: ""
+  webhookName: ""
 
 policywebhook:
   image:

--- a/charts/cosigned/values.yaml
+++ b/charts/cosigned/values.yaml
@@ -35,6 +35,9 @@ policywebhook:
     annotations: {}
     type: ClusterIP
     port: 443
+  webhookNames:
+    defaulting: "defaulting.clusterimagepolicy.sigstore.dev"
+    validating: "validating.clusterimagepolicy.sigstore.dev"
 
 webhook:
   name: webhook


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
With https://github.com/sigstore/cosign/pull/1726, cosigned will support new flag `--webhook-name` that controls the name of the mutating and validating webhook configurations. With this PR, this flag is also configurable via the chart. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
The cosigned flag `--webhook-name` can be now set via `.Values.cosign.webhookName` field, which is required with default value `cosigned.sigstore.dev`.
```

/cc @hectorj2f