### PR TITLE
bump rekor helm chart for 0.6.0

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,8 +4,8 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.25
-appVersion: 0.5.0
+version: 0.2.26
+appVersion: 0.6.0
 
 keywords:
   - security
@@ -19,7 +19,7 @@ maintainers:
 
 dependencies:
   - name: trillian
-    version: 0.1.3
+    version: 0.1.6
     repository: https://sigstore.github.io/helm-charts
     condition: trillian.enabled
 
@@ -27,10 +27,10 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: createtree
-      image: ghcr.io/sigstore/scaffolding/createtree@sha256:de57091f8b846ad7935b1c70af0a45e55af7fed50508bec30a51f41509ae75f1
+      image: ghcr.io/sigstore/scaffolding/createtree@sha256:f20a73f4c581c0b13daf9ede832b5b6b838acfeb04fe5f2690722c2146d9d8d7
     - name: curlimages/curl
-      image: docker.io/curlimages/curl@sha256:faaba66e89c87fd3fb51336857142ee6ce78fa8d8f023a5713d2bf4957f1aca8
+      image: docker.io/curlimages/curl@sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498
     - name: rekor-server
-      image: gcr.io/projectsigstore/rekor-server@sha256:516651575db19412c94d4260349a84a9c30b37b5d2635232fba669262c5cbfa6
+      image: gcr.io/projectsigstore/rekor-server@sha256:f0e178b838bd2da4dae5b56fc8d6d084ac90dbda8e72a91a64b3c956c4620a7c
     - name: redis
-      image: docker.io/redis@sha256:306e7a9e4f3970c79b42481002cde2332de69c4e3b86c419fd965365f0f4f189
+      image: docker.io/redis@sha256:6c42cce2871e8dc5fb3e843ed5c4e7939d312faf5e53ff0ff4ca955a7e0b2b39

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -7,8 +7,8 @@ initContainerImage:
   curl:
     registry: docker.io
     repository: curlimages/curl
-    # -- 7.81.0
-    version: sha256:faaba66e89c87fd3fb51336857142ee6ce78fa8d8f023a5713d2bf4957f1aca8
+    # -- 7.82.0
+    version: "sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498"
     imagePullPolicy: IfNotPresent
 
 redis:
@@ -26,8 +26,8 @@ redis:
     registry: docker.io
     repository: redis
     pullPolicy: IfNotPresent
-    # -- 5.0.10
-    version: "sha256:0a0d563fd6fe5361316dd53f7f0a244656675054302567230e85eb114f683db4"
+    # -- 6.2.6-alpine3.15
+    version: "sha256:6c42cce2871e8dc5fb3e843ed5c4e7939d312faf5e53ff0ff4ca955a7e0b2b39"
   resources: {}
   readinessProbe:
     initialDelaySeconds: 5
@@ -62,8 +62,8 @@ server:
     registry: gcr.io
     repository: projectsigstore/rekor-server
     pullPolicy: IfNotPresent
-    # -- v0.5.0
-    version: "sha256:516651575db19412c94d4260349a84a9c30b37b5d2635232fba669262c5cbfa6"
+    # -- v0.6.0
+    version: "sha256:f0e178b838bd2da4dae5b56fc8d6d084ac90dbda8e72a91a64b3c956c4620a7c"
   logging:
     production: false
   ingress:
@@ -138,8 +138,8 @@ createtree:
     registry: ghcr.io
     repository: sigstore/scaffolding/createtree
     pullPolicy: IfNotPresent
-    # v0.2.1
-    version: "sha256:6bef73fa9c9d1f2b00c5c2c8c2d7e0b43b651686b686d3c66235e78f426c0aa5"
+    # v0.2.6
+    version: "sha256:f20a73f4c581c0b13daf9ede832b5b6b838acfeb04fe5f2690722c2146d9d8d7"
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
bump createtree to 0.2.6, from 0.2.1
bump redis to 6.2.6-alpine3.15, from 5.0.10
bump curl to 7.82.0, from 7.81.0

Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
