### PR TITLE
Update rekor chart to v0.6

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,8 +4,8 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.25
-appVersion: 0.5.0
+version: 0.2.26
+appVersion: 0.6.0
 
 keywords:
   - security
@@ -19,7 +19,7 @@ maintainers:
 
 dependencies:
   - name: trillian
-    version: 0.1.3
+    version: 0.1.6
     repository: https://sigstore.github.io/helm-charts
     condition: trillian.enabled
 
@@ -27,10 +27,10 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: createtree
-      image: ghcr.io/sigstore/scaffolding/createtree@sha256:de57091f8b846ad7935b1c70af0a45e55af7fed50508bec30a51f41509ae75f1
+      image: ghcr.io/sigstore/scaffolding/createtree@sha256:f20a73f4c581c0b13daf9ede832b5b6b838acfeb04fe5f2690722c2146d9d8d7
     - name: curlimages/curl
-      image: docker.io/curlimages/curl@sha256:faaba66e89c87fd3fb51336857142ee6ce78fa8d8f023a5713d2bf4957f1aca8
+      image: docker.io/curlimages/curl@sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498
     - name: rekor-server
-      image: gcr.io/projectsigstore/rekor-server@sha256:516651575db19412c94d4260349a84a9c30b37b5d2635232fba669262c5cbfa6
+      image: gcr.io/projectsigstore/rekor-server@sha256:f0e178b838bd2da4dae5b56fc8d6d084ac90dbda8e72a91a64b3c956c4620a7c
     - name: redis
-      image: docker.io/redis@sha256:306e7a9e4f3970c79b42481002cde2332de69c4e3b86c419fd965365f0f4f189
+      image: docker.io/redis@sha256:6c42cce2871e8dc5fb3e843ed5c4e7939d312faf5e53ff0ff4ca955a7e0b2b39

--- a/charts/rekor/templates/_helpers.tpl
+++ b/charts/rekor/templates/_helpers.tpl
@@ -302,6 +302,7 @@ Server Arguments
 - "serve"
 - {{ printf "--trillian_log_server.address=%s.%s" .Values.trillian.logServer.name .Values.trillian.forceNamespace | quote }}
 - {{ printf "--trillian_log_server.port=%d" (.Values.trillian.logServer.portRPC | int) | quote }}
+- {{ printf "--trillian_log_server.sharding_config=%s/%s" .Values.server.sharding.mountPath .Values.server.sharding.filename | quote }}
 - {{ printf "--redis_server.address=%s" (include "redis.hostname" .) | quote }}
 - {{ printf "--redis_server.port=%d" (.Values.redis.port | int) | quote }}
 - "--rekor_server.address=0.0.0.0"
@@ -409,4 +410,11 @@ Create the name of the config
 */}}
 {{- define "rekor.config" -}}
 {{ printf "%s-config" (include "rekor.fullname" .) }}
+{{- end }}
+
+{{/*
+Create the name of the sharding config
+*/}}
+{{- define "rekor.sharding-config" -}}
+{{ printf "%s-sharding-config" (include "rekor.fullname" .) }}
 {{- end }}

--- a/charts/rekor/templates/server/configmap-sharding.yaml
+++ b/charts/rekor/templates/server/configmap-sharding.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "rekor.sharding-config" . }}
+{{ include "rekor.namespace" . | indent 2 }}
+  labels:
+    {{- include "rekor.server.labels" . | nindent 4 }}
+data:
+  {{ .Values.server.sharding.filename }}: |
+    {{ .Values.server.sharding.contents }}

--- a/charts/rekor/templates/server/deployment.yaml
+++ b/charts/rekor/templates/server/deployment.yaml
@@ -64,6 +64,8 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: {{ template "rekor.server.fileAttestationStorage.path" . }}
+            - name: {{ template "rekor.sharding-config" . }}
+              mountPath: {{ .Values.server.sharding.mountPath }}
 {{- end -}}
 {{- if .Values.server.livenessProbe }}
           livenessProbe:
@@ -101,6 +103,9 @@ spec:
     {{- end }}
 {{- if eq "true" (include "rekor.server.fileAttestationStorage" .) }}
       volumes:
+        - name: {{ template "rekor.sharding-config" . }}
+          configMap:
+            name: {{ template "rekor.sharding-config" . }}
   {{- if not .Values.server.attestation_storage.persistence.enabled }}
         - name: storage
           emptyDir: {}

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -7,8 +7,8 @@ initContainerImage:
   curl:
     registry: docker.io
     repository: curlimages/curl
-    # -- 7.81.0
-    version: sha256:faaba66e89c87fd3fb51336857142ee6ce78fa8d8f023a5713d2bf4957f1aca8
+    # -- 7.82.0
+    version: "sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498"
     imagePullPolicy: IfNotPresent
 
 redis:
@@ -26,8 +26,8 @@ redis:
     registry: docker.io
     repository: redis
     pullPolicy: IfNotPresent
-    # -- 5.0.10
-    version: "sha256:0a0d563fd6fe5361316dd53f7f0a244656675054302567230e85eb114f683db4"
+    # -- 6.2.6-alpine3.15
+    version: "sha256:6c42cce2871e8dc5fb3e843ed5c4e7939d312faf5e53ff0ff4ca955a7e0b2b39"
   resources: {}
   readinessProbe:
     initialDelaySeconds: 5
@@ -62,8 +62,8 @@ server:
     registry: gcr.io
     repository: projectsigstore/rekor-server
     pullPolicy: IfNotPresent
-    # -- v0.5.0
-    version: "sha256:516651575db19412c94d4260349a84a9c30b37b5d2635232fba669262c5cbfa6"
+    # -- v0.6.0
+    version: "sha256:f0e178b838bd2da4dae5b56fc8d6d084ac90dbda8e72a91a64b3c956c4620a7c"
   logging:
     production: false
   ingress:
@@ -93,6 +93,10 @@ server:
     httpGet:
       port: 3000
       path: /ping
+  sharding:
+    mountPath: /sharding
+    filename: sharding-config.yaml
+    contents: ""
   livenessProbe:
     initialDelaySeconds: 30
     periodSeconds: 10
@@ -138,8 +142,8 @@ createtree:
     registry: ghcr.io
     repository: sigstore/scaffolding/createtree
     pullPolicy: IfNotPresent
-    # v0.2.1
-    version: "sha256:6bef73fa9c9d1f2b00c5c2c8c2d7e0b43b651686b686d3c66235e78f426c0aa5"
+    # v0.2.6
+    version: "sha256:f20a73f4c581c0b13daf9ede832b5b6b838acfeb04fe5f2690722c2146d9d8d7"
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

Adds the sharding configmap as a helm template, which is a required configmap for rekor >= v0.6


```release-note
Update rekor chart to v0.6
```
