### PR TITLE
Fix bug where configmap volume not mounted for rekor.

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.26
+version: 0.2.27
 appVersion: 0.6.0
 
 keywords:

--- a/charts/rekor/templates/server/deployment.yaml
+++ b/charts/rekor/templates/server/deployment.yaml
@@ -101,11 +101,11 @@ spec:
       affinity:
 {{ toYaml .Values.server.affinity | indent 8 }}
     {{- end }}
-{{- if eq "true" (include "rekor.server.fileAttestationStorage" .) }}
       volumes:
         - name: {{ template "rekor.sharding-config" . }}
           configMap:
             name: {{ template "rekor.sharding-config" . }}
+{{- if eq "true" (include "rekor.server.fileAttestationStorage" .) }}
   {{- if not .Values.server.attestation_storage.persistence.enabled }}
         - name: storage
           emptyDir: {}


### PR DESCRIPTION
The addition of the sharding configmap was under the file attestation
check, and would be excluded when local file attestation is disabled.

The fix move the inclusion of the sharding configmap to outside the file
attestation check.

Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
