### PR TITLE
Add option to store CT log config in a secret

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.11
+version: 0.2.12
 
 keywords:
   - security

--- a/charts/ctlog/templates/ctlog-deployment.yaml
+++ b/charts/ctlog/templates/ctlog-deployment.yaml
@@ -55,8 +55,16 @@ spec:
               - key: rootca
                 path: roots.pem
         - name: config
+          {{- if .Values.server.config.secret.enabled }}
+          secret:
+            secretName: {{ .Values.server.config.secret.name }}
+            items:
+              - key: config
+                path: ct_server.cfg
+          {{ else }}
           configMap:
             name: {{ template "ctlog.config" . }}
             items:
               - key: config
                 path: ct_server.cfg
+          {{- end }}

--- a/charts/ctlog/values.schema.json
+++ b/charts/ctlog/values.schema.json
@@ -37,6 +37,12 @@
                             "targetPort": 6962
                         }
                     ]
+                },
+                "config": {
+                    "secret": {
+                        "enabled": false,
+                        "name": "ctlog-config"
+                    }
                 }
             },
             "createtree": {

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -3,6 +3,10 @@ namespace:
   name: ctlog-system
 server:
   replicaCount: 1
+  config:
+    secret:
+      enabled: false
+      name: ctlog-config
   image:
     registry: ghcr.io
     repository: sigstore/scaffolding/ct_server


### PR DESCRIPTION
Right now the CT log config has to be stored in a configmap. This PR also adds the option to store it in a Secret, leaving the ConfigMap as the default.

This will make it possible to store the config externally & use something like external-secrets to access the config. The config also stores the password for the ct log private key decryption, so it might make more sense in a Secret.