### PR TITLE
Add option to specify tree ID in rekor configmap

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.2.28
+version: 0.2.29
 appVersion: 0.6.0
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -91,6 +91,7 @@ The following table lists the configurable parameters of the Rekor chart and the
 | server.attestation_storage.persistence.storageClass | string | `nil` |  |
 | server.attestation_storage.persistence.subPath | string | `""` |  |
 | server.config.key | string | `"treeID"` |  |
+| server.config.treeID | string | `""` |  |
 | server.deploymentAnnotations."prometheus.io/path" | string | `"/metrics"` |  |
 | server.deploymentAnnotations."prometheus.io/port" | string | `"2112"` |  |
 | server.deploymentAnnotations."prometheus.io/scrape" | string | `"true"` |  |

--- a/charts/rekor/templates/server/configmap.yaml
+++ b/charts/rekor/templates/server/configmap.yaml
@@ -11,3 +11,6 @@ data:
     # Just a placeholder so that reapplying this won't overwrite treeID
     # if it already exists. This caused grief, do not remove.
     ###################################################################
+  {{ if .Values.server.config.treeID }}
+  {{ .Values.server.config.key }}: "{{ .Values.server.config.treeID }}"
+  {{ end }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -137,7 +137,8 @@
                     }
                 },
                 "config": {
-                    "key": "treeID"
+                    "key": "treeID",
+                    "treeID": ""
                 },
                 "retrieve_api": {
                     "enabled": true

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -111,6 +111,7 @@ server:
     runAsUser: 65533
   config:
     key: treeID
+    treeID: ""
   retrieve_api:
     enabled: true
   attestation_storage:


### PR DESCRIPTION
This is helpful for client who aren't using the `createtree` job and have a specific tree ID they want to use at install time.

Tested locally & this seems to work as expected.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

