### PR TITLE
Add default securityContext.runAsUser value for ctlog and fulcio

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.12
+version: 0.2.13
 
 keywords:
   - security

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -44,6 +44,7 @@ server:
   extraArgs: []
   securityContext:
     runAsNonRoot: true
+    runAsUser: 65533
 createtree:
   enabled: true
   name: createtree
@@ -60,6 +61,7 @@ createtree:
     mountToken: true
   securityContext:
     runAsNonRoot: true
+    runAsUser: 65533
 createctconfig:
   enabled: true
   replicaCount: 1
@@ -78,6 +80,7 @@ createctconfig:
     mountToken: true
   securityContext:
     runAsNonRoot: true
+    runAsUser: 65533
 trillian:
   namespace: trillian-system
   logServer:

--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -4,7 +4,7 @@ description: Fulcio
 
 type: application
 
-version: 0.3.0
+version: 0.3.1
 
 keywords:
   - security

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -65,6 +65,7 @@ server:
             - fulcio.localhost
   securityContext:
     runAsNonRoot: true
+    runAsUser: 65533
 createcerts:
   enabled: true
   replicaCount: 1
@@ -82,6 +83,7 @@ createcerts:
     mountToken: true
   securityContext:
     runAsNonRoot: true
+    runAsUser: 65533
 # Configure ctlog dependency
 ctlog:
   enabled: true


### PR DESCRIPTION
Signed-off-by: Shuanglei Tao <tsl0922@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Add default securityContext.runAsUser value for ctlog and fulcio

This makes the chart's default `values.yaml` runnable.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Add default securityContext.runAsUser value for ctlog and fulcio
```
