### PR TITLE
fix: webhook-name added multiple double quotes

### DIFF
--- a/charts/cosigned/Chart.yaml
+++ b/charts/cosigned/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: cosigned
-version: 0.1.18
+version: 0.1.19
 appVersion: 1.8.0
 
 maintainers:

--- a/charts/cosigned/templates/policy-webhook/deployment_policy_webhook.yaml
+++ b/charts/cosigned/templates/policy-webhook/deployment_policy_webhook.yaml
@@ -57,8 +57,8 @@ spec:
         imagePullPolicy: "{{ .Values.policywebhook.image.pullPolicy }}"
         args:
         {{- if semverCompare ">= 1.8-0" .Chart.AppVersion }}
-        - --mutating-webhook-name={{ required "A valid policywebhook.webhookNames.defaulting is required" .Values.policywebhook.webhookNames.defaulting }}
-        - --validating-webhook-name={{ required "A valid policywebhook.webhookNames.validating is required" .Values.policywebhook.webhookNames.validating }}
+        - -mutating-webhook-name={{ required "A valid policywebhook.webhookNames.defaulting is required" .Values.policywebhook.webhookNames.defaulting }}
+        - -validating-webhook-name={{ required "A valid policywebhook.webhookNames.validating is required" .Values.policywebhook.webhookNames.validating }}
         {{- end }}
         {{- range $key, $value := .Values.policywebhook.extraArgs }}
         - -{{ $key }}={{ $value }}

--- a/charts/cosigned/templates/webhook/deployment_webhook.yaml
+++ b/charts/cosigned/templates/webhook/deployment_webhook.yaml
@@ -59,7 +59,7 @@ spec:
 {{- end }}
         args:
         {{- if semverCompare ">= 1.8-0" .Chart.AppVersion }}
-        - --webhook-name={{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
+        - -webhook-name={{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
         {{- end }}
         {{- if and .Values.cosign.secretKeyRef }}
         {{- if .Values.cosign.secretKeyRef.name }}

--- a/charts/cosigned/templates/webhook/deployment_webhook.yaml
+++ b/charts/cosigned/templates/webhook/deployment_webhook.yaml
@@ -59,7 +59,7 @@ spec:
 {{- end }}
         args:
         {{- if semverCompare ">= 1.8-0" .Chart.AppVersion }}
-        - --webhook-name={{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName | quote }}
+        - --webhook-name={{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
         {{- end }}
         {{- if and .Values.cosign.secretKeyRef }}
         {{- if .Values.cosign.secretKeyRef.name }}


### PR DESCRIPTION
Signed-off-by: hectorj2f <hectorf@vmware.com>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

 **Description of the change**
 Double quotes were added twice  causing the following error:
 
 `error retrieving webhook: mutatingwebhookconfiguration.admissionregistration.k8s.io \"\\\"cosigned.sigstore.dev\\\"\" not found"`
 
 Fixes: https://github.com/sigstore/helm-charts/issues/165

<!-- Describe the change being requested. -->

 **Existing or Associated Issue(s)**

<!-- List any related issues. -->

 **Additional Information**

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-doc --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
