### PR TITLE
cosigned: add policy fields to the CRD

### DIFF
--- a/charts/cosigned/Chart.yaml
+++ b/charts/cosigned/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: cosigned
-version: 0.1.19
+version: 0.1.20
 appVersion: 1.8.0
 
 maintainers:

--- a/charts/cosigned/templates/crds/clusterimagepolicy.yaml
+++ b/charts/cosigned/templates/crds/clusterimagepolicy.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -45,6 +44,36 @@ spec:
                   items:
                     type: object
                     properties:
+                      attestations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              description: Name of the attestation. These can then be referenced at the CIP level policy.
+                              type: string
+                            policy:
+                              type: object
+                              properties:
+                                configMapRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      description: Name is unique within a namespace to reference a configmap resource.
+                                      type: string
+                                    namespace:
+                                      description: Namespace defines the space within which the configmap name must be unique.
+                                      type: string
+                                data:
+                                  type: string
+                                type:
+                                  description: Which kind of policy this is, currently only rego or cue are supported. Furthermore, only cue is tested :)
+                                  type: string
+                                url:
+                                  type: string
+                            predicateType:
+                              description: Which predicate type to verify. Matches cosign verify-attestation options.
+                              type: string
                       ctlog:
                         type: object
                         properties:
@@ -100,6 +129,9 @@ spec:
                                   type: string
                           url:
                             type: string
+                      name:
+                        description: Name is the name for this authority. Used by the CIP Policy validator to be able to reference matching signature or attestation verifications. If not specified, the name will be authority-<index in array>
+                        type: string
                       source:
                         type: array
                         items:
@@ -107,6 +139,15 @@ spec:
                           properties:
                             oci:
                               type: string
+                            signaturePullSecrets:
+                              description: SignaturePullSecrets is an optional list of references to secrets in the same namespace as the deploying resource for pulling any of the signatures used by this Source.
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
                 images:
                   type: array
                   items:
@@ -115,4 +156,24 @@ spec:
                       glob:
                         type: string
                       regex:
-                        type: string
+                        type: string  
+                policy:
+                  description: Policy is an optional policy that can be applied against all the successfully validated Authorities. If no authorities pass, this does not even get evaluated, as the Policy is considered failed.
+                  type: object
+                  properties:
+                    configMapRef:
+                      type: object
+                      properties:
+                        name:
+                          description: Name is unique within a namespace to reference a configmap resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the space within which the configmap name must be unique.
+                          type: string
+                    data:
+                      type: string
+                    type:
+                      description: Which kind of policy this is, currently only rego or cue are supported. Furthermore, only cue is tested :)
+                      type: string
+                    url:
+                      type: string


### PR DESCRIPTION
Signed-off-by: hectorj2f <hectorf@vmware.com>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

 **Description of the change**

<!-- Describe the change being requested. -->

Add the new policy attestations fields to the CRD.

Fixes https://github.com/sigstore/helm-charts/issues/168

 **Existing or Associated Issue(s)**

<!-- List any related issues. -->

 **Additional Information**

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-doc --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
