### PR TITLE
Remove duplicated termination seconds in policy webhook and increase it for the controller

### DIFF
--- a/charts/cosigned/Chart.yaml
+++ b/charts/cosigned/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: cosigned
-version: 0.1.21
+version: 0.1.22
 appVersion: 1.8.0
 
 maintainers:

--- a/charts/cosigned/templates/policy-webhook/deployment_policy_webhook.yaml
+++ b/charts/cosigned/templates/policy-webhook/deployment_policy_webhook.yaml
@@ -37,7 +37,6 @@ spec:
       tolerations:
         {{- toYaml .Values.commonTolerations | nindent 8 }}
       serviceAccountName: {{ template "cosigned.fullname" . }}-policy-webhook
-      terminationGracePeriodSeconds: 10
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:

--- a/charts/cosigned/templates/policy-webhook/deployment_policy_webhook.yaml
+++ b/charts/cosigned/templates/policy-webhook/deployment_policy_webhook.yaml
@@ -47,7 +47,6 @@ spec:
                   control-plane: {{ template "cosigned.fullname" . }}-policy-webhook
               topologyKey: kubernetes.io/hostname
             weight: 100
-      serviceAccountName: {{ template "cosigned.fullname" . }}-policy-webhook
       containers:
       - name: policy-webhook
         # This is the Go import path for the binary that is containerized

--- a/charts/cosigned/templates/webhook/deployment_webhook.yaml
+++ b/charts/cosigned/templates/webhook/deployment_webhook.yaml
@@ -23,7 +23,6 @@ spec:
       tolerations:
         {{- toYaml .Values.commonTolerations | nindent 8 }}
       serviceAccountName: {{ template "cosigned.fullname" . }}-webhook
-      terminationGracePeriodSeconds: 10
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:
@@ -109,6 +108,11 @@ spec:
         {{- toYaml . | nindent 10}}
         {{- end }}
       {{- if .Values.webhook.securityContext.enabled }}
+
+      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
+      # high value that we respect whatever value it has configured for the lame duck grace period.
+      terminationGracePeriodSeconds: 300
+
       securityContext:
         {{- with .Values.webhook.securityContext }}
         {{- toYaml . | nindent 8}}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

 **Description of the change**
1. Removes duplicated `terminationGracePeriodSeconds` field in the policy-webhook deployment
2. Increase `terminationGracePeriodSeconds` to 300s for the policy-controller, [ref](https://github.com/sigstore/cosign/blob/cf80511294b9f8cf3678dfc1e2584e5ee2ef6553/config/webhook.yaml#L98)
3. Removes duplicated `serviceAccountName` field in the policy-webhook deployment 

<!-- Describe the change being requested. -->

 **Existing or Associated Issue(s)**
Fixes #163 

<!-- List any related issues. -->

 **Additional Information**

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-doc --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
