### PR TITLE
allow specifying existing treeID and private key password.

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.19
+version: 0.2.20
 appVersion: 0.3.0
 
 keywords:

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -31,6 +31,7 @@ The following table lists the configurable parameters of the ctlog chart and the
 | createctconfig.image.version | string | `"sha256:7412243415a984b697a630b2f0b322a519285abc5c458053790e4e5f9a4156b2"` |  |
 | createctconfig.logPrefix | string | `"sigstorescaffolding"` |  |
 | createctconfig.name | string | `"createctconfig"` |  |
+| createctconfig.privateKeyPasswordSecretName | string | `nil` |  |
 | createctconfig.replicaCount | int | `1` |  |
 | createctconfig.securityContext.runAsNonRoot | bool | `true` |  |
 | createctconfig.securityContext.runAsUser | int | `65533` |  |
@@ -53,8 +54,10 @@ The following table lists the configurable parameters of the ctlog chart and the
 | forceNamespace | string | `""` |  |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"ctlog-system"` |  |
+| server.config.key | string | `"treeID"` |  |
 | server.config.secret.enabled | bool | `false` |  |
 | server.config.secret.name | string | `"ctlog-config"` |  |
+| server.config.treeID | string | `""` |  |
 | server.extraArgs | list | `[]` |  |
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"ghcr.io"` |  |

--- a/charts/ctlog/templates/createctconfig-job.yaml
+++ b/charts/ctlog/templates/createctconfig-job.yaml
@@ -22,6 +22,9 @@ spec:
             "--secret={{ template "ctlog.secret" . }}",
             "--fulcio-url={{ .Values.createctconfig.fulcioURL }}",
             "--trillian-server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace }}:{{ .Values.trillian.logServer.portRPC}}",
+          {{- if .Values.createctconfig.privateKeyPasswordSecretName }}
+            "--key-password=$(PRIVATE_KEY_PASSWORD)",
+          {{- end }}
             "--log-prefix={{ .Values.createctconfig.logPrefix }}"
           ]
           env:
@@ -29,6 +32,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if .Values.createctconfig.privateKeyPasswordSecretName }}
+            - name: PRIVATE_KEY_PASSWORD
+              valueFrom:
+                secretKeyRef
+                  name: {{ .Values.createctconfig.privateKeyPasswordSecretName  }}
+                  key: password
+          {{- end }}
     {{- if .Values.createctconfig.securityContext }}
       securityContext:
 {{ toYaml .Values.createctconfig.securityContext | indent 8 }}

--- a/charts/ctlog/templates/ctlog-configmap.yaml
+++ b/charts/ctlog/templates/ctlog-configmap.yaml
@@ -11,3 +11,6 @@ data:
     # Just a placeholder so that reapplying this won't overwrite treeID
     # if it already exists. This caused grief, do not remove.
     ###################################################################
+  {{- if .Values.server.config.treeID }}
+  {{ .Values.server.config.key }}: "{{ .Values.server.config.treeID }}"
+  {{- end }}

--- a/charts/ctlog/values.schema.json
+++ b/charts/ctlog/values.schema.json
@@ -75,7 +75,8 @@
                     "default": {},
                     "title": "The config Schema",
                     "required": [
-                        "secret"
+                        "secret",
+                        "key"
                     ],
                     "properties": {
                         "secret": {
@@ -108,13 +109,31 @@
                                 "enabled": false,
                                 "name": "ctlog-config"
                             }]
+                        },
+                        "key": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The key Schema",
+                            "examples": [
+                                "treeID"
+                            ]
+                        },
+                        "treeID": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The treeID Schema",
+                            "examples": [
+                                ""
+                            ]
                         }
                     },
                     "examples": [{
                         "secret": {
                             "enabled": false,
                             "name": "ctlog-config"
-                        }
+                        },
+                        "key": "treeID",
+                        "treeID": ""
                     }]
                 },
                 "image": {
@@ -518,7 +537,9 @@
                     "secret": {
                         "enabled": false,
                         "name": "ctlog-config"
-                    }
+                    },
+                    "key": "treeID",
+                    "treeID": ""
                 },
                 "image": {
                     "registry": "ghcr.io",
@@ -868,6 +889,14 @@
                         "sigstorescaffolding"
                     ]
                 },
+                "privateKeyPasswordSecretName": {
+                    "type": "null",
+                    "default": null,
+                    "title": "The privateKeyPasswordSecretName Schema",
+                    "examples": [
+                        null
+                    ]
+                },
                 "serviceAccount": {
                     "type": "object",
                     "default": {},
@@ -964,6 +993,7 @@
                 },
                 "fulcioURL": "http://fulcio-server.fulcio-system.svc",
                 "logPrefix": "sigstorescaffolding",
+                "privateKeyPasswordSecretName": null,
                 "serviceAccount": {
                     "create": true,
                     "name": "",
@@ -1053,7 +1083,9 @@
                 "secret": {
                     "enabled": false,
                     "name": "ctlog-config"
-                }
+                },
+                "key": "treeID",
+                "treeID": ""
             },
             "image": {
                 "registry": "ghcr.io",
@@ -1137,6 +1169,7 @@
             },
             "fulcioURL": "http://fulcio-server.fulcio-system.svc",
             "logPrefix": "sigstorescaffolding",
+            "privateKeyPasswordSecretName": null,
             "serviceAccount": {
                 "create": true,
                 "name": "",

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -7,6 +7,8 @@ server:
     secret:
       enabled: false
       name: ctlog-config
+    key: treeID
+    treeID: ""
   image:
     registry: ghcr.io
     repository: sigstore/scaffolding/ct_server
@@ -76,6 +78,7 @@ createctconfig:
     version: "sha256:2795b42d3b42cdb9eaf3825e0bca742963208a51e30d5a7173f8a68ac6d47732"
   fulcioURL: "http://fulcio-server.fulcio-system.svc"
   logPrefix: sigstorescaffolding
+  privateKeyPasswordSecretName:
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

 **Description of the change**

<!-- Describe the change being requested. -->

treeID is handled the same way as rekor.
https://github.com/sigstore/helm-charts/blob/main/charts/rekor/templates/server/configmap.yaml#L14

Private key password is to set the key-password flag to the
createctconfig job.
https://github.com/sigstore/scaffolding/blob/main/cmd/ctlog/createctconfig/main.go#L60

Signed-off-by: Kenny Leung <kleung@chainguard.dev>

 **Existing or Associated Issue(s)**

<!-- List any related issues. -->

 **Additional Information**

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
