### PR TITLE
fix ctlog private key type, null->string

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.21
+version: 0.2.22
 appVersion: 0.3.0
 
 keywords:

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -31,7 +31,7 @@ The following table lists the configurable parameters of the ctlog chart and the
 | createctconfig.image.version | string | `"sha256:7412243415a984b697a630b2f0b322a519285abc5c458053790e4e5f9a4156b2"` |  |
 | createctconfig.logPrefix | string | `"sigstorescaffolding"` |  |
 | createctconfig.name | string | `"createctconfig"` |  |
-| createctconfig.privateKeyPasswordSecretName | string | `nil` |  |
+| createctconfig.privateKeyPasswordSecretName | string | `""` |  |
 | createctconfig.replicaCount | int | `1` |  |
 | createctconfig.securityContext.runAsNonRoot | bool | `true` |  |
 | createctconfig.securityContext.runAsUser | int | `65533` |  |

--- a/charts/ctlog/values.schema.json
+++ b/charts/ctlog/values.schema.json
@@ -76,7 +76,8 @@
                     "title": "The config Schema",
                     "required": [
                         "secret",
-                        "key"
+                        "key",
+                        "treeID"
                     ],
                     "properties": {
                         "secret": {
@@ -786,6 +787,7 @@
                 "image",
                 "fulcioURL",
                 "logPrefix",
+                "privateKeyPasswordSecretName",
                 "serviceAccount",
                 "securityContext"
             ],
@@ -890,11 +892,11 @@
                     ]
                 },
                 "privateKeyPasswordSecretName": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The privateKeyPasswordSecretName Schema",
                     "examples": [
-                        null
+                        ""
                     ]
                 },
                 "serviceAccount": {
@@ -993,7 +995,7 @@
                 },
                 "fulcioURL": "http://fulcio-server.fulcio-system.svc",
                 "logPrefix": "sigstorescaffolding",
-                "privateKeyPasswordSecretName": null,
+                "privateKeyPasswordSecretName": "",
                 "serviceAccount": {
                     "create": true,
                     "name": "",
@@ -1169,7 +1171,7 @@
             },
             "fulcioURL": "http://fulcio-server.fulcio-system.svc",
             "logPrefix": "sigstorescaffolding",
-            "privateKeyPasswordSecretName": null,
+            "privateKeyPasswordSecretName": "",
             "serviceAccount": {
                 "create": true,
                 "name": "",

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -78,7 +78,7 @@ createctconfig:
     version: "sha256:2795b42d3b42cdb9eaf3825e0bca742963208a51e30d5a7173f8a68ac6d47732"
   fulcioURL: "http://fulcio-server.fulcio-system.svc"
   logPrefix: sigstorescaffolding
-  privateKeyPasswordSecretName:
+  privateKeyPasswordSecretName: ""
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

 **Description of the change**

<!-- Describe the change being requested. -->

 **Existing or Associated Issue(s)**

<!-- List any related issues. -->

 **Additional Information**

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
