### PR TITLE
bump fulcio for ctlog 0.2.24

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -4,7 +4,7 @@ description: Fulcio
 
 type: application
 
-version: 0.4.4
+version: 0.4.5
 appVersion: 0.5.0
 
 keywords:
@@ -18,7 +18,7 @@ maintainers:
 
 dependencies:
   - name: ctlog
-    version: 0.2.23
+    version: 0.2.24
     repository: https://sigstore.github.io/helm-charts
     condition: ctlog.enabled
 


### PR DESCRIPTION
 **Description of the change**

bump fulcio for ctlog 0.2.24

 **Existing or Associated Issue(s)**

Depends on #210 

 **Additional Information**

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [ ] JSON Schema generated
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
