### PR TITLE
bump scaffold for ctlog 0.2.24

### DIFF
--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.3.4
+version: 0.3.5
 
 keywords:
   - security
@@ -17,7 +17,7 @@ maintainers:
 
 dependencies:
   - name: fulcio
-    version: 0.4.4
+    version: 0.4.5
     repository: https://sigstore.github.io/helm-charts
     condition: fulcio.enabled
   - name: rekor
@@ -29,7 +29,7 @@ dependencies:
     repository: https://sigstore.github.io/helm-charts
     condition: trillian.enabled
   - name: ctlog
-    version: 0.2.23
+    version: 0.2.24
     repository: https://sigstore.github.io/helm-charts
     condition: ctlog.enabled
 


### PR DESCRIPTION
bump scaffold for ctlog 0.2.24

 **Description of the change**

bump scaffold for ctlog 0.2.24

 **Existing or Associated Issue(s)**

#211 #210 

 **Additional Information**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [ ] JSON Schema generated
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
