### PR TITLE
chore: add replica field to be configurable

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.1.26
+version: 0.1.27
 appVersion: 1.9.0
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -21,6 +21,7 @@ The following table lists the configurable parameters of the policy-controller c
 | policywebhook.image.pullPolicy | string | `"IfNotPresent"` |  |
 | policywebhook.image.repository | string | `"gcr.io/projectsigstore/policy-webhook"` |  |
 | policywebhook.image.version | string | `"sha256:5ddc8c4c7f609a6a8396f469fde685e8774f7ee3aa4ef56f18adcb90b546a48c"` |  |
+| policywebhook.replicaCount | int | `1` |  |
 | policywebhook.podSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | policywebhook.podSecurityContext.capabilities.drop[0] | string | `"all"` |  |
 | policywebhook.podSecurityContext.enabled | bool | `true` |  |
@@ -41,6 +42,7 @@ The following table lists the configurable parameters of the policy-controller c
 | serviceMonitor.enabled | bool | `false` |  |
 | webhook.env | object | `{}` |  |
 | webhook.extraArgs | object | `{}` |  |
+| webhook.replicaCount | int | `1` |  |
 | webhook.image.pullPolicy | string | `"IfNotPresent"` |  |
 | webhook.image.repository | string | `"gcr.io/projectsigstore/policy-controller"` |  |
 | webhook.image.version | string | `"sha256:18c7db5051c0d5ac147b1785567ef647f23f7949ae5858776561cfc9cd8cc4b2"` |  |

--- a/charts/policy-controller/templates/policy-webhook/clusterrole_policy_webhook.yaml
+++ b/charts/policy-controller/templates/policy-webhook/clusterrole_policy_webhook.yaml
@@ -74,4 +74,4 @@ rules:
 
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update"]

--- a/charts/policy-controller/templates/policy-webhook/deployment_policy_webhook.yaml
+++ b/charts/policy-controller/templates/policy-webhook/deployment_policy_webhook.yaml
@@ -22,6 +22,7 @@ metadata:
     {{- include "policy-controller.labels" . | nindent 4 }}
     control-plane: {{ template "policy-controller.fullname" . }}-policy-webhook
 spec:
+  replicas: {{ .Values.policywebhook.replicaCount }}
   selector:
     matchLabels:
       {{- include "policy-controller.selectorLabels" . | nindent 6 }}

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "policy-controller.fullname" . }}-webhook
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.webhook.replicaCount }}
   selector:
     matchLabels:
       {{- include "policy-controller.selectorLabels" . | nindent 6 }}

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -1,1281 +1,285 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "http://example.com/example.json",
+    "$schema": "http://json-schema.org/schema#",
     "type": "object",
-    "title": "The root schema",
-    "description": "The root schema comprises the entire JSON document.",
-    "default": {},
-    "examples": [
-        {
-            "commonNodeSelector": {},
-            "commonTolerations": [],
-            "cosign": {
-                "cosignPub": "",
-                "secretKeyRef": {
-                    "name": ""
-                },
-                "webhookName": "policy.sigstore.dev"
-            },
-            "policywebhook": {
-                "env": {},
-                "extraArgs": {},
-                "image": {
-                    "pullPolicy": "IfNotPresent",
-                    "repository": "gcr.io/projectsigstore/policy-webhook",
-                    "version": "sha256:59fd679d6629fbfa99b4413771dca16cb7891b0a91dd386dc46ea9fac46bcfbc"
-                },
-                "podSecurityContext": {
-                    "enabled": true,
-                    "allowPrivilegeEscalation": false,
-                    "capabilities": {
-                        "drop": [
-                            "all"
-                        ]
-                    },
-                    "readOnlyRootFilesystem": true,
-                    "runAsNonRoot": true
-                },
-                "resources": {
-                    "limits": {
-                        "cpu": "100m",
-                        "memory": "256Mi"
-                    },
-                    "requests": {
-                        "cpu": "100m",
-                        "memory": "128Mi"
-                    }
-                },
-                "securityContext": {
-                    "enabled": false,
-                    "runAsUser": 65532
-                },
-                "service": {
-                    "annotations": {},
-                    "port": 443,
-                    "type": "ClusterIP"
-                },
-                "serviceAccount": {
-                    "annotations": {}
-                },
-                "webhookNames": {
-                    "defaulting": "defaulting.clusterimagepolicy.sigstore.dev",
-                    "validating": "validating.clusterimagepolicy.sigstore.dev"
-                }
-            },
-            "serviceMonitor": {
-                "enabled": false
-            },
-            "webhook": {
-                "env": {},
-                "extraArgs": {},
-                "image": {
-                    "pullPolicy": "IfNotPresent",
-                    "repository": "gcr.io/projectsigstore/policy-controller",
-                    "version": "sha256:766698b7c472ee4c37133a92203def72c90c3c49e2b334130e6e3a100254911e"
-                },
-                "name": "webhook",
-                "podSecurityContext": {
-                    "enabled": true,
-                    "allowPrivilegeEscalation": false,
-                    "capabilities": {
-                        "drop": [
-                            "all"
-                        ]
-                    },
-                    "readOnlyRootFilesystem": true,
-                    "runAsUser": 1000
-                },
-                "resources": {
-                    "limits": {
-                        "cpu": "100m",
-                        "memory": "256Mi"
-                    },
-                    "requests": {
-                        "cpu": "100m",
-                        "memory": "128Mi"
-                    }
-                },
-                "securityContext": {
-                    "enabled": false,
-                    "runAsUser": 65532
-                },
-                "service": {
-                    "annotations": {},
-                    "port": 443,
-                    "type": "ClusterIP"
-                },
-                "serviceAccount": {
-                    "annotations": {}
-                }
-            }
-        }
-    ],
-    "required": [
-        "commonNodeSelector",
-        "commonTolerations",
-        "cosign",
-        "policywebhook",
-        "serviceMonitor",
-        "webhook"
-    ],
     "properties": {
         "commonNodeSelector": {
-            "$id": "#/properties/commonNodeSelector",
-            "type": "object",
-            "title": "The commonNodeSelector schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": {},
-            "examples": [
-                {}
-            ],
-            "required": [],
-            "additionalProperties": true
+            "type": "object"
         },
         "commonTolerations": {
-            "$id": "#/properties/commonTolerations",
-            "type": "array",
-            "title": "The commonTolerations schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": [],
-            "examples": [
-                []
-            ],
-            "additionalItems": true,
-            "items": {
-                "$id": "#/properties/commonTolerations/items"
-            }
+            "type": "array"
         },
         "cosign": {
-            "$id": "#/properties/cosign",
             "type": "object",
-            "title": "The cosign schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": {},
-            "examples": [
-                {
-                    "cosignPub": "",
-                    "secretKeyRef": {
-                        "name": ""
-                    },
-                    "webhookName": "policy.sigstore.dev"
-                }
-            ],
-            "required": [
-                "cosignPub",
-                "secretKeyRef",
-                "webhookName"
-            ],
             "properties": {
                 "cosignPub": {
-                    "$id": "#/properties/cosign/properties/cosignPub",
-                    "type": "string",
-                    "title": "The cosignPub schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": "",
-                    "examples": [
-                        ""
-                    ]
+                    "type": "string"
                 },
                 "secretKeyRef": {
-                    "$id": "#/properties/cosign/properties/secretKeyRef",
                     "type": "object",
-                    "title": "The secretKeyRef schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "name": ""
-                        }
-                    ],
-                    "required": [
-                        "name"
-                    ],
                     "properties": {
                         "name": {
-                            "$id": "#/properties/cosign/properties/secretKeyRef/properties/name",
-                            "type": "string",
-                            "title": "The name schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                ""
-                            ]
+                            "type": "string"
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "webhookName": {
-                    "$id": "#/properties/cosign/properties/webhookName",
-                    "type": "string",
-                    "title": "The webhookName schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": "",
-                    "examples": [
-                        "policy.sigstore.dev"
-                    ]
+                    "type": "string"
                 }
-            },
-            "additionalProperties": true
+            }
         },
         "policywebhook": {
-            "$id": "#/properties/policywebhook",
             "type": "object",
-            "title": "The policywebhook schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": {},
-            "examples": [
-                {
-                    "env": {},
-                    "extraArgs": {},
-                    "image": {
-                        "pullPolicy": "IfNotPresent",
-                        "repository": "gcr.io/projectsigstore/policy-webhook",
-                        "version": "sha256:59fd679d6629fbfa99b4413771dca16cb7891b0a91dd386dc46ea9fac46bcfbc"
-                    },
-                    "podSecurityContext": {
-                        "enabled": true,
-                        "allowPrivilegeEscalation": false,
-                        "capabilities": {
-                            "drop": [
-                                "all"
-                            ]
-                        },
-                        "readOnlyRootFilesystem": true,
-                        "runAsNonRoot": true
-                    },
-                    "resources": {
-                        "limits": {
-                            "cpu": "100m",
-                            "memory": "256Mi"
-                        },
-                        "requests": {
-                            "cpu": "100m",
-                            "memory": "128Mi"
-                        }
-                    },
-                    "securityContext": {
-                        "enabled": false,
-                        "runAsUser": 65532
-                    },
-                    "service": {
-                        "annotations": {},
-                        "port": 443,
-                        "type": "ClusterIP"
-                    },
-                    "serviceAccount": {
-                        "annotations": {}
-                    },
-                    "webhookNames": {
-                        "defaulting": "defaulting.clusterimagepolicy.sigstore.dev",
-                        "validating": "validating.clusterimagepolicy.sigstore.dev"
-                    }
-                }
-            ],
-            "required": [
-                "env",
-                "extraArgs",
-                "image",
-                "podSecurityContext",
-                "resources",
-                "securityContext",
-                "service",
-                "serviceAccount",
-                "webhookNames"
-            ],
             "properties": {
                 "env": {
-                    "$id": "#/properties/policywebhook/properties/env",
-                    "type": "object",
-                    "title": "The env schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {}
-                    ],
-                    "required": [],
-                    "additionalProperties": true
+                    "type": "object"
                 },
                 "extraArgs": {
-                    "$id": "#/properties/policywebhook/properties/extraArgs",
-                    "type": "object",
-                    "title": "The extraArgs schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {}
-                    ],
-                    "required": [],
-                    "additionalProperties": true
+                    "type": "object"
                 },
                 "image": {
-                    "$id": "#/properties/policywebhook/properties/image",
                     "type": "object",
-                    "title": "The image schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "pullPolicy": "IfNotPresent",
-                            "repository": "gcr.io/projectsigstore/policy-webhook",
-                            "version": "sha256:59fd679d6629fbfa99b4413771dca16cb7891b0a91dd386dc46ea9fac46bcfbc"
-                        }
-                    ],
-                    "required": [
-                        "pullPolicy",
-                        "repository",
-                        "version"
-                    ],
                     "properties": {
                         "pullPolicy": {
-                            "$id": "#/properties/policywebhook/properties/image/properties/pullPolicy",
-                            "type": "string",
-                            "title": "The pullPolicy schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "IfNotPresent"
-                            ]
+                            "type": "string"
                         },
                         "repository": {
-                            "$id": "#/properties/policywebhook/properties/image/properties/repository",
-                            "type": "string",
-                            "title": "The repository schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "gcr.io/projectsigstore/policy-webhook"
-                            ]
+                            "type": "string"
                         },
                         "version": {
-                            "$id": "#/properties/policywebhook/properties/image/properties/version",
-                            "type": "string",
-                            "title": "The version schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "sha256:59fd679d6629fbfa99b4413771dca16cb7891b0a91dd386dc46ea9fac46bcfbc"
-                            ]
+                            "type": "string"
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "podSecurityContext": {
-                    "$id": "#/properties/policywebhook/properties/podSecurityContext",
                     "type": "object",
-                    "title": "The podSecurityContext schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "enabled": true,
-                            "allowPrivilegeEscalation": false,
-                            "capabilities": {
-                                "drop": [
-                                    "all"
-                                ]
-                            },
-                            "readOnlyRootFilesystem": true,
-                            "runAsNonRoot": true
-                        }
-                    ],
-                    "required": [
-                        "allowPrivilegeEscalation",
-                        "capabilities",
-                        "readOnlyRootFilesystem",
-                        "runAsNonRoot"
-                    ],
                     "properties": {
-                        "enabled": {
-                            "$id": "#/properties/policywebhook/properties/podSecurityContext/properties/enabled",
-                            "type": "boolean",
-                            "title": "The enabled schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": true,
-                            "examples": [
-                                true
-                            ]
-                        },
                         "allowPrivilegeEscalation": {
-                            "$id": "#/properties/policywebhook/properties/podSecurityContext/properties/allowPrivilegeEscalation",
-                            "type": "boolean",
-                            "title": "The allowPrivilegeEscalation schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": false,
-                            "examples": [
-                                false
-                            ]
+                            "type": "boolean"
                         },
                         "capabilities": {
-                            "$id": "#/properties/policywebhook/properties/podSecurityContext/properties/capabilities",
                             "type": "object",
-                            "title": "The capabilities schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {
-                                    "drop": [
-                                        "all"
-                                    ]
-                                }
-                            ],
-                            "required": [
-                                "drop"
-                            ],
                             "properties": {
                                 "drop": {
-                                    "$id": "#/properties/policywebhook/properties/podSecurityContext/properties/capabilities/properties/drop",
                                     "type": "array",
-                                    "title": "The drop schema",
-                                    "description": "An explanation about the purpose of this instance.",
-                                    "default": [],
-                                    "examples": [
-                                        [
-                                            "all"
-                                        ]
-                                    ],
-                                    "additionalItems": true,
                                     "items": {
-                                        "$id": "#/properties/policywebhook/properties/podSecurityContext/properties/capabilities/properties/drop/items",
-                                        "anyOf": [
-                                            {
-                                                "$id": "#/properties/policywebhook/properties/podSecurityContext/properties/capabilities/properties/drop/items/anyOf/0",
-                                                "type": "string",
-                                                "title": "The first anyOf schema",
-                                                "description": "An explanation about the purpose of this instance.",
-                                                "default": "",
-                                                "examples": [
-                                                    "all"
-                                                ]
-                                            }
-                                        ]
+                                        "type": "string"
                                     }
                                 }
-                            },
-                            "additionalProperties": true
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "readOnlyRootFilesystem": {
-                            "$id": "#/properties/policywebhook/properties/podSecurityContext/properties/readOnlyRootFilesystem",
-                            "type": "boolean",
-                            "title": "The readOnlyRootFilesystem schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "type": "boolean"
                         },
                         "runAsNonRoot": {
-                            "$id": "#/properties/policywebhook/properties/podSecurityContext/properties/runAsNonRoot",
-                            "type": "boolean",
-                            "title": "The runAsNonRoot schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "type": "boolean"
                         }
-                    },
-                    "additionalProperties": true
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
                 },
                 "resources": {
-                    "$id": "#/properties/policywebhook/properties/resources",
                     "type": "object",
-                    "title": "The resources schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "limits": {
-                                "cpu": "100m",
-                                "memory": "256Mi"
-                            },
-                            "requests": {
-                                "cpu": "100m",
-                                "memory": "128Mi"
-                            }
-                        }
-                    ],
-                    "required": [
-                        "limits",
-                        "requests"
-                    ],
                     "properties": {
                         "limits": {
-                            "$id": "#/properties/policywebhook/properties/resources/properties/limits",
                             "type": "object",
-                            "title": "The limits schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {
-                                    "cpu": "100m",
-                                    "memory": "256Mi"
-                                }
-                            ],
-                            "required": [
-                                "cpu",
-                                "memory"
-                            ],
                             "properties": {
                                 "cpu": {
-                                    "$id": "#/properties/policywebhook/properties/resources/properties/limits/properties/cpu",
-                                    "type": "string",
-                                    "title": "The cpu schema",
-                                    "description": "An explanation about the purpose of this instance.",
-                                    "default": "",
-                                    "examples": [
-                                        "100m"
-                                    ]
+                                    "type": "string"
                                 },
                                 "memory": {
-                                    "$id": "#/properties/policywebhook/properties/resources/properties/limits/properties/memory",
-                                    "type": "string",
-                                    "title": "The memory schema",
-                                    "description": "An explanation about the purpose of this instance.",
-                                    "default": "",
-                                    "examples": [
-                                        "256Mi"
-                                    ]
+                                    "type": "string"
                                 }
-                            },
-                            "additionalProperties": true
+                            }
                         },
                         "requests": {
-                            "$id": "#/properties/policywebhook/properties/resources/properties/requests",
                             "type": "object",
-                            "title": "The requests schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {
-                                    "cpu": "100m",
-                                    "memory": "128Mi"
-                                }
-                            ],
-                            "required": [
-                                "cpu",
-                                "memory"
-                            ],
                             "properties": {
                                 "cpu": {
-                                    "$id": "#/properties/policywebhook/properties/resources/properties/requests/properties/cpu",
-                                    "type": "string",
-                                    "title": "The cpu schema",
-                                    "description": "An explanation about the purpose of this instance.",
-                                    "default": "",
-                                    "examples": [
-                                        "100m"
-                                    ]
+                                    "type": "string"
                                 },
                                 "memory": {
-                                    "$id": "#/properties/policywebhook/properties/resources/properties/requests/properties/memory",
-                                    "type": "string",
-                                    "title": "The memory schema",
-                                    "description": "An explanation about the purpose of this instance.",
-                                    "default": "",
-                                    "examples": [
-                                        "128Mi"
-                                    ]
+                                    "type": "string"
                                 }
-                            },
-                            "additionalProperties": true
+                            }
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "securityContext": {
-                    "$id": "#/properties/policywebhook/properties/securityContext",
                     "type": "object",
-                    "title": "The securityContext schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "enabled": false,
-                            "runAsUser": 65532
-                        }
-                    ],
-                    "required": [
-                        "enabled",
-                        "runAsUser"
-                    ],
                     "properties": {
                         "enabled": {
-                            "$id": "#/properties/policywebhook/properties/securityContext/properties/enabled",
-                            "type": "boolean",
-                            "title": "The enabled schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": false,
-                            "examples": [
-                                false
-                            ]
+                            "type": "boolean"
                         },
                         "runAsUser": {
-                            "$id": "#/properties/policywebhook/properties/securityContext/properties/runAsUser",
-                            "type": "integer",
-                            "title": "The runAsUser schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": 0,
-                            "examples": [
-                                65532
-                            ]
+                            "type": "integer"
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "service": {
-                    "$id": "#/properties/policywebhook/properties/service",
                     "type": "object",
-                    "title": "The service schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "annotations": {},
-                            "port": 443,
-                            "type": "ClusterIP"
-                        }
-                    ],
-                    "required": [
-                        "annotations",
-                        "port",
-                        "type"
-                    ],
                     "properties": {
                         "annotations": {
-                            "$id": "#/properties/policywebhook/properties/service/properties/annotations",
-                            "type": "object",
-                            "title": "The annotations schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {}
-                            ],
-                            "required": [],
-                            "additionalProperties": true
+                            "type": "object"
                         },
                         "port": {
-                            "$id": "#/properties/policywebhook/properties/service/properties/port",
-                            "type": "integer",
-                            "title": "The port schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": 0,
-                            "examples": [
-                                443
-                            ]
+                            "type": "integer"
                         },
                         "type": {
-                            "$id": "#/properties/policywebhook/properties/service/properties/type",
-                            "type": "string",
-                            "title": "The type schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "ClusterIP"
-                            ]
+                            "type": "string"
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "serviceAccount": {
-                    "$id": "#/properties/policywebhook/properties/serviceAccount",
                     "type": "object",
-                    "title": "The serviceAccount schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "annotations": {}
-                        }
-                    ],
-                    "required": [
-                        "annotations"
-                    ],
                     "properties": {
                         "annotations": {
-                            "$id": "#/properties/policywebhook/properties/serviceAccount/properties/annotations",
-                            "type": "object",
-                            "title": "The annotations schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {}
-                            ],
-                            "required": [],
-                            "additionalProperties": true
+                            "type": "object"
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "webhookNames": {
-                    "$id": "#/properties/policywebhook/properties/webhookNames",
                     "type": "object",
-                    "title": "The webhookNames schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "defaulting": "defaulting.clusterimagepolicy.sigstore.dev",
-                            "validating": "validating.clusterimagepolicy.sigstore.dev"
-                        }
-                    ],
-                    "required": [
-                        "defaulting",
-                        "validating"
-                    ],
                     "properties": {
                         "defaulting": {
-                            "$id": "#/properties/policywebhook/properties/webhookNames/properties/defaulting",
-                            "type": "string",
-                            "title": "The defaulting schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "defaulting.clusterimagepolicy.sigstore.dev"
-                            ]
+                            "type": "string"
                         },
                         "validating": {
-                            "$id": "#/properties/policywebhook/properties/webhookNames/properties/validating",
-                            "type": "string",
-                            "title": "The validating schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "validating.clusterimagepolicy.sigstore.dev"
-                            ]
+                            "type": "string"
                         }
-                    },
-                    "additionalProperties": true
-                }
-            },
-            "additionalProperties": true
-        },
-        "serviceMonitor": {
-            "$id": "#/properties/serviceMonitor",
-            "type": "object",
-            "title": "The serviceMonitor schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": {},
-            "examples": [
-                {
-                    "enabled": false
-                }
-            ],
-            "required": [
-                "enabled"
-            ],
-            "properties": {
-                "enabled": {
-                    "$id": "#/properties/serviceMonitor/properties/enabled",
-                    "type": "boolean",
-                    "title": "The enabled schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": false,
-                    "examples": [
-                        false
-                    ]
-                }
-            },
-            "additionalProperties": true
-        },
-        "webhook": {
-            "$id": "#/properties/webhook",
-            "type": "object",
-            "title": "The webhook schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": {},
-            "examples": [
-                {
-                    "env": {},
-                    "extraArgs": {},
-                    "image": {
-                        "pullPolicy": "IfNotPresent",
-                        "repository": "gcr.io/projectsigstore/policy-controller",
-                        "version": "sha256:766698b7c472ee4c37133a92203def72c90c3c49e2b334130e6e3a100254911e"
-                    },
-                    "name": "webhook",
-                    "podSecurityContext": {
-                        "enabled": true,
-                        "allowPrivilegeEscalation": false,
-                        "capabilities": {
-                            "drop": [
-                                "all"
-                            ]
-                        },
-                        "readOnlyRootFilesystem": true,
-                        "runAsUser": 1000
-                    },
-                    "resources": {
-                        "limits": {
-                            "cpu": "100m",
-                            "memory": "256Mi"
-                        },
-                        "requests": {
-                            "cpu": "100m",
-                            "memory": "128Mi"
-                        }
-                    },
-                    "securityContext": {
-                        "enabled": false,
-                        "runAsUser": 65532
-                    },
-                    "service": {
-                        "annotations": {},
-                        "port": 443,
-                        "type": "ClusterIP"
-                    },
-                    "serviceAccount": {
-                        "annotations": {}
                     }
                 }
-            ],
-            "required": [
-                "env",
-                "extraArgs",
-                "image",
-                "name",
-                "podSecurityContext",
-                "resources",
-                "securityContext",
-                "service",
-                "serviceAccount"
-            ],
+            }
+        },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "webhook": {
+            "type": "object",
             "properties": {
                 "env": {
-                    "$id": "#/properties/webhook/properties/env",
-                    "type": "object",
-                    "title": "The env schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {}
-                    ],
-                    "required": [],
-                    "additionalProperties": true
+                    "type": "object"
                 },
                 "extraArgs": {
-                    "$id": "#/properties/webhook/properties/extraArgs",
-                    "type": "object",
-                    "title": "The extraArgs schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {}
-                    ],
-                    "required": [],
-                    "additionalProperties": true
+                    "type": "object"
                 },
                 "image": {
-                    "$id": "#/properties/webhook/properties/image",
                     "type": "object",
-                    "title": "The image schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "pullPolicy": "IfNotPresent",
-                            "repository": "gcr.io/projectsigstore/policy-controller",
-                            "version": "sha256:766698b7c472ee4c37133a92203def72c90c3c49e2b334130e6e3a100254911e"
-                        }
-                    ],
-                    "required": [
-                        "pullPolicy",
-                        "repository",
-                        "version"
-                    ],
                     "properties": {
                         "pullPolicy": {
-                            "$id": "#/properties/webhook/properties/image/properties/pullPolicy",
-                            "type": "string",
-                            "title": "The pullPolicy schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "IfNotPresent"
-                            ]
+                            "type": "string"
                         },
                         "repository": {
-                            "$id": "#/properties/webhook/properties/image/properties/repository",
-                            "type": "string",
-                            "title": "The repository schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "gcr.io/projectsigstore/policy-controller"
-                            ]
+                            "type": "string"
                         },
                         "version": {
-                            "$id": "#/properties/webhook/properties/image/properties/version",
-                            "type": "string",
-                            "title": "The version schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "sha256:766698b7c472ee4c37133a92203def72c90c3c49e2b334130e6e3a100254911e"
-                            ]
+                            "type": "string"
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "name": {
-                    "$id": "#/properties/webhook/properties/name",
-                    "type": "string",
-                    "title": "The name schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": "",
-                    "examples": [
-                        "webhook"
-                    ]
+                    "type": "string"
                 },
                 "podSecurityContext": {
-                    "$id": "#/properties/webhook/properties/podSecurityContext",
                     "type": "object",
-                    "title": "The podSecurityContext schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "allowPrivilegeEscalation": false,
-                            "capabilities": {
-                                "drop": [
-                                    "all"
-                                ]
-                            },
-                            "readOnlyRootFilesystem": true,
-                            "runAsUser": 1000
-                        }
-                    ],
-                    "required": [
-                        "enabled",
-                        "allowPrivilegeEscalation",
-                        "capabilities",
-                        "readOnlyRootFilesystem",
-                        "runAsUser"
-                    ],
                     "properties": {
-                        "enabled": {
-                            "$id": "#/properties/webhook/properties/podSecurityContext/properties/enabled",
-                            "type": "boolean",
-                            "title": "The enabled schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": true,
-                            "examples": [
-                                true
-                            ]
-                        },
                         "allowPrivilegeEscalation": {
-                            "$id": "#/properties/webhook/properties/podSecurityContext/properties/allowPrivilegeEscalation",
-                            "type": "boolean",
-                            "title": "The allowPrivilegeEscalation schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": false,
-                            "examples": [
-                                false
-                            ]
+                            "type": "boolean"
                         },
                         "capabilities": {
-                            "$id": "#/properties/webhook/properties/podSecurityContext/properties/capabilities",
                             "type": "object",
-                            "title": "The capabilities schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {
-                                    "drop": [
-                                        "all"
-                                    ]
-                                }
-                            ],
-                            "required": [
-                                "drop"
-                            ],
                             "properties": {
                                 "drop": {
-                                    "$id": "#/properties/webhook/properties/podSecurityContext/properties/capabilities/properties/drop",
                                     "type": "array",
-                                    "title": "The drop schema",
-                                    "description": "An explanation about the purpose of this instance.",
-                                    "default": [],
-                                    "examples": [
-                                        [
-                                            "all"
-                                        ]
-                                    ],
-                                    "additionalItems": true,
                                     "items": {
-                                        "$id": "#/properties/webhook/properties/podSecurityContext/properties/capabilities/properties/drop/items",
-                                        "anyOf": [
-                                            {
-                                                "$id": "#/properties/webhook/properties/podSecurityContext/properties/capabilities/properties/drop/items/anyOf/0",
-                                                "type": "string",
-                                                "title": "The first anyOf schema",
-                                                "description": "An explanation about the purpose of this instance.",
-                                                "default": "",
-                                                "examples": [
-                                                    "all"
-                                                ]
-                                            }
-                                        ]
+                                        "type": "string"
                                     }
                                 }
-                            },
-                            "additionalProperties": true
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "readOnlyRootFilesystem": {
-                            "$id": "#/properties/webhook/properties/podSecurityContext/properties/readOnlyRootFilesystem",
-                            "type": "boolean",
-                            "title": "The readOnlyRootFilesystem schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": false,
-                            "examples": [
-                                true
-                            ]
+                            "type": "boolean"
                         },
                         "runAsUser": {
-                            "$id": "#/properties/webhook/properties/podSecurityContext/properties/runAsUser",
-                            "type": "integer",
-                            "title": "The runAsUser schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": 0,
-                            "examples": [
-                                1000
-                            ]
+                            "type": "integer"
                         }
-                    },
-                    "additionalProperties": true
+                    }
+                },
+                "replicaCount": {
+                    "type": "integer"
                 },
                 "resources": {
-                    "$id": "#/properties/webhook/properties/resources",
                     "type": "object",
-                    "title": "The resources schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "limits": {
-                                "cpu": "100m",
-                                "memory": "256Mi"
-                            },
-                            "requests": {
-                                "cpu": "100m",
-                                "memory": "128Mi"
-                            }
-                        }
-                    ],
-                    "required": [
-                        "limits",
-                        "requests"
-                    ],
                     "properties": {
                         "limits": {
-                            "$id": "#/properties/webhook/properties/resources/properties/limits",
                             "type": "object",
-                            "title": "The limits schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {
-                                    "cpu": "100m",
-                                    "memory": "256Mi"
-                                }
-                            ],
-                            "required": [
-                                "cpu",
-                                "memory"
-                            ],
                             "properties": {
                                 "cpu": {
-                                    "$id": "#/properties/webhook/properties/resources/properties/limits/properties/cpu",
-                                    "type": "string",
-                                    "title": "The cpu schema",
-                                    "description": "An explanation about the purpose of this instance.",
-                                    "default": "",
-                                    "examples": [
-                                        "100m"
-                                    ]
+                                    "type": "string"
                                 },
                                 "memory": {
-                                    "$id": "#/properties/webhook/properties/resources/properties/limits/properties/memory",
-                                    "type": "string",
-                                    "title": "The memory schema",
-                                    "description": "An explanation about the purpose of this instance.",
-                                    "default": "",
-                                    "examples": [
-                                        "256Mi"
-                                    ]
+                                    "type": "string"
                                 }
-                            },
-                            "additionalProperties": true
+                            }
                         },
                         "requests": {
-                            "$id": "#/properties/webhook/properties/resources/properties/requests",
                             "type": "object",
-                            "title": "The requests schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {
-                                    "cpu": "100m",
-                                    "memory": "128Mi"
-                                }
-                            ],
-                            "required": [
-                                "cpu",
-                                "memory"
-                            ],
                             "properties": {
                                 "cpu": {
-                                    "$id": "#/properties/webhook/properties/resources/properties/requests/properties/cpu",
-                                    "type": "string",
-                                    "title": "The cpu schema",
-                                    "description": "An explanation about the purpose of this instance.",
-                                    "default": "",
-                                    "examples": [
-                                        "100m"
-                                    ]
+                                    "type": "string"
                                 },
                                 "memory": {
-                                    "$id": "#/properties/webhook/properties/resources/properties/requests/properties/memory",
-                                    "type": "string",
-                                    "title": "The memory schema",
-                                    "description": "An explanation about the purpose of this instance.",
-                                    "default": "",
-                                    "examples": [
-                                        "128Mi"
-                                    ]
+                                    "type": "string"
                                 }
-                            },
-                            "additionalProperties": true
+                            }
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "securityContext": {
-                    "$id": "#/properties/webhook/properties/securityContext",
                     "type": "object",
-                    "title": "The securityContext schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "enabled": false,
-                            "runAsUser": 65532
-                        }
-                    ],
-                    "required": [
-                        "enabled",
-                        "runAsUser"
-                    ],
                     "properties": {
                         "enabled": {
-                            "$id": "#/properties/webhook/properties/securityContext/properties/enabled",
-                            "type": "boolean",
-                            "title": "The enabled schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": false,
-                            "examples": [
-                                false
-                            ]
+                            "type": "boolean"
                         },
                         "runAsUser": {
-                            "$id": "#/properties/webhook/properties/securityContext/properties/runAsUser",
-                            "type": "integer",
-                            "title": "The runAsUser schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": 0,
-                            "examples": [
-                                65532
-                            ]
+                            "type": "integer"
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "service": {
-                    "$id": "#/properties/webhook/properties/service",
                     "type": "object",
-                    "title": "The service schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "annotations": {},
-                            "port": 443,
-                            "type": "ClusterIP"
-                        }
-                    ],
-                    "required": [
-                        "annotations",
-                        "port",
-                        "type"
-                    ],
                     "properties": {
                         "annotations": {
-                            "$id": "#/properties/webhook/properties/service/properties/annotations",
-                            "type": "object",
-                            "title": "The annotations schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {}
-                            ],
-                            "required": [],
-                            "additionalProperties": true
+                            "type": "object"
                         },
                         "port": {
-                            "$id": "#/properties/webhook/properties/service/properties/port",
-                            "type": "integer",
-                            "title": "The port schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": 0,
-                            "examples": [
-                                443
-                            ]
+                            "type": "integer"
                         },
                         "type": {
-                            "$id": "#/properties/webhook/properties/service/properties/type",
-                            "type": "string",
-                            "title": "The type schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": "",
-                            "examples": [
-                                "ClusterIP"
-                            ]
+                            "type": "string"
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "serviceAccount": {
-                    "$id": "#/properties/webhook/properties/serviceAccount",
                     "type": "object",
-                    "title": "The serviceAccount schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "default": {},
-                    "examples": [
-                        {
-                            "annotations": {}
-                        }
-                    ],
-                    "required": [
-                        "annotations"
-                    ],
                     "properties": {
                         "annotations": {
-                            "$id": "#/properties/webhook/properties/serviceAccount/properties/annotations",
-                            "type": "object",
-                            "title": "The annotations schema",
-                            "description": "An explanation about the purpose of this instance.",
-                            "default": {},
-                            "examples": [
-                                {}
-                            ],
-                            "required": [],
-                            "additionalProperties": true
+                            "type": "object"
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 }
-            },
-            "additionalProperties": true
+            }
         }
-    },
-    "additionalProperties": true
+    }
 }

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -6,6 +6,7 @@ cosign:
   webhookName: "policy.sigstore.dev"
 
 policywebhook:
+  replicaCount: 1
   image:
     repository: gcr.io/projectsigstore/policy-webhook
     version: sha256:5ddc8c4c7f609a6a8396f469fde685e8774f7ee3aa4ef56f18adcb90b546a48c
@@ -41,6 +42,7 @@ policywebhook:
     validating: "validating.clusterimagepolicy.sigstore.dev"
 
 webhook:
+  replicaCount: 1
   name: webhook
   image:
     repository: gcr.io/projectsigstore/policy-controller


### PR DESCRIPTION
Signed-off-by: hectorj2f <hectorf@vmware.com>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

 **Description of the change**

<!-- Describe the change being requested. -->

The replica field wasn't configurable via values.yaml

I used `helm schema-gen` plugin to generate the schema.

 **Existing or Associated Issue(s)**

<!-- List any related issues. -->

 **Additional Information**

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
