### PR TITLE
Update trillian template to correctly parse extra args

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -4,7 +4,7 @@ description: Trillian
 
 type: application
 
-version: 0.1.8
+version: 0.1.9
 
 keywords:
   - security

--- a/charts/trillian/templates/_helpers.tpl
+++ b/charts/trillian/templates/_helpers.tpl
@@ -151,15 +151,9 @@ Log Server Arguments
 - {{ printf "--rpc_endpoint=0.0.0.0:%d" (.Values.logServer.portRPC | int) | quote }}
 - {{ printf "--http_endpoint=0.0.0.0:%d" (.Values.logServer.portHTTP | int) | quote }}
 - "--alsologtostderr"
-{{- if .Values.logServer.extraArgs -}}
-{{- range $key, $value := .Values.logServer.extraArgs }}
-{{- if $value }}
-- {{ printf "%v=%v" $key $value | quote }}
-{{- else }}
-- {{ printf $key | quote }}
-{{- end }}
-{{- end }}
-{{- end -}}
+{{-  range .Values.logServer.extraArgs }}
+- {{ . | quote }}
+{{ end }}
 {{- end -}}
 
 {{/*
@@ -172,15 +166,9 @@ Log Signer Arguments
 - {{ printf "--http_endpoint=0.0.0.0:%d" (.Values.logSigner.portHTTP | int) | quote }}
 - {{ printf "--force_master=%t" (default true .Values.logSigner.forceMaster) | quote }}
 - "--alsologtostderr"
-{{- if .Values.logSigner.extraArgs -}}
-{{- range $key, $value := .Values.logSigner.extraArgs }}
-{{- if $value }}
-- {{ printf "%v=%v" $key $value | quote }}
-{{- else }}
-- {{ printf $key | quote }}
-{{- end }}
-{{- end }}
-{{- end -}}
+{{-  range .Values.logSigner.extraArgs }}
+- {{ . | quote }}
+{{ end }}
 {{- end -}}
 
 


### PR DESCRIPTION
Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

Right now the current parsing looks like this:

values.yaml
```yaml
logServer:
  extraArgs:
    - "--tracing=true"
```

it being evaluated as:

```yaml
      - args:
        - --storage_system=mysql
        - --mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOSTNAME):$(MYSQL_PORT))/$(MYSQL_DATABASE)
        - --rpc_endpoint=0.0.0.0:8090
        - --http_endpoint=0.0.0.0:8091
        - --alsologtostderr
        - 0=--tracing=true
```

this should fix it