### PR TITLE
Add --force flag to rekor createtree Job for sharding

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.3.8
+version: 0.3.9
 appVersion: 0.10.0
 
 keywords:

--- a/charts/rekor/templates/server/createtree-job.yaml
+++ b/charts/rekor/templates/server/createtree-job.yaml
@@ -14,7 +14,12 @@ spec:
       containers:
         - name: {{ template "rekor.createtree.fullname" . }}
           image: "{{ template "rekor.image" .Values.createtree.image }}"
-          args: ["--namespace=$(NAMESPACE)", "--configmap={{ template "rekor.config" . }}", "--display_name=rekortree","--admin_server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.forceNamespace }}:{{ .Values.trillian.logServer.portRPC}}"]
+          args: ["--namespace=$(NAMESPACE)",
+            "--configmap={{ template "rekor.config" . }}",
+            "--display_name=rekortree",
+            "--admin_server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.forceNamespace }}:{{ .Values.trillian.logServer.portRPC}}",
+            "--force={{ .Values.createtree.force }}"
+          ]
           env:
           - name: NAMESPACE
             valueFrom:

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -140,6 +140,7 @@ server:
     annotations: {}
 createtree:
   name: createtree
+  force: false
   image:
     registry: ghcr.io
     repository: sigstore/scaffolding/createtree

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -145,8 +145,8 @@ createtree:
     registry: ghcr.io
     repository: sigstore/scaffolding/createtree
     pullPolicy: IfNotPresent
-    # v0.2.6
-    version: "sha256:f20a73f4c581c0b13daf9ede832b5b6b838acfeb04fe5f2690722c2146d9d8d7"
+    # v0.4.2
+    version: "sha256:03e7b3b068e61f65a730b7a95f498c76a02ddecb4f7a65e09b2753b66ac8399f"
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
We can force the Job to create a new Trillian tree, which is useful for sharding.

ref https://github.com/sigstore/public-good-instance/issues/404

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

