### PR TITLE
Add rekor-createtree helm chart for creating a new tree for rekor

### DIFF
--- a/charts/rekor-createtree/.helmignore
+++ b/charts/rekor-createtree/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/rekor-createtree/Chart.yaml
+++ b/charts/rekor-createtree/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: rekor-createtree
+description: Part of the sigstore project, rekor-createtree is used to create new Trillian trees for Rekor.
+
+type: application
+
+version: 0.0.1
+
+keywords:
+  - security
+  - transparency logs
+
+home: https://sigstore.dev/
+maintainers:
+  - name: The Sigstore Authors
+
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/images: |
+    - name: createtree
+      image: ghcr.io/sigstore/scaffolding/createtree@sha256:f20a73f4c581c0b13daf9ede832b5b6b838acfeb04fe5f2690722c2146d9d8d7

--- a/charts/rekor-createtree/README.md
+++ b/charts/rekor-createtree/README.md
@@ -1,0 +1,41 @@
+# rekor-createtree
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Part of the sigstore project, rekor-createtree is used to create new Trillian trees for Rekor.
+
+**Homepage:** <https://sigstore.dev/>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| The Sigstore Authors |  |  |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| createtree.configMap | string | `"rekor-config"` |  |
+| createtree.force | bool | `true` |  |
+| createtree.image.pullPolicy | string | `"IfNotPresent"` |  |
+| createtree.image.registry | string | `"ghcr.io"` |  |
+| createtree.image.repository | string | `"sigstore/scaffolding/createtree"` |  |
+| createtree.image.version | string | `"sha256:03e7b3b068e61f65a730b7a95f498c76a02ddecb4f7a65e09b2753b66ac8399f"` |  |
+| createtree.name | string | `"createtree"` |  |
+| createtree.securityContext.runAsNonRoot | bool | `true` |  |
+| createtree.securityContext.runAsUser | int | `65533` |  |
+| createtree.serviceAccount.create | bool | `false` |  |
+| createtree.serviceAccount.name | string | `"rekor-createtree"` |  |
+| namespace | string | `"rekor-system"` |  |
+| trillian.adminServer | string | `"trillian-logserver.trillian-system:8091"` |  |
+| trillian.enabled | bool | `true` |  |
+| trillian.forceNamespace | string | `"trillian-system"` |  |
+| trillian.fullnameOverride | string | `"trillian"` |  |
+| trillian.logServer.fullnameOverride | string | `"trillian-logserver"` |  |
+| trillian.logServer.name | string | `"trillian-logserver"` |  |
+| trillian.logServer.portHTTP | int | `8090` |  |
+| trillian.logServer.portRPC | int | `8091` |  |
+| trillian.namespace.create | bool | `true` |  |
+| trillian.namespace.name | string | `"trillian-system"` |  |
+

--- a/charts/rekor-createtree/ci/ci-values.yaml
+++ b/charts/rekor-createtree/ci/ci-values.yaml
@@ -1,0 +1,2 @@
+---
+namespace: default

--- a/charts/rekor-createtree/templates/_helpers.tpl
+++ b/charts/rekor-createtree/templates/_helpers.tpl
@@ -1,0 +1,38 @@
+{{/*
+Create the image path for the passed in image field
+*/}}
+{{- define "rekor.image" -}}
+{{- if eq (substr 0 7 .version) "sha256:" -}}
+{{- printf "%s/%s@%s" .registry .repository .version -}}
+{{- else -}}
+{{- printf "%s/%s:%s" .registry .repository .version -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified Rekor createtree name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "rekor.createtree.fullname" -}}
+{{- if .Values.createtree.fullnameOverride -}}
+{{- .Values.createtree.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.createtree.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.createtree.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the createtree component
+*/}}
+{{- define "rekor.serviceAccountName.createtree" -}}
+{{- if .Values.createtree.serviceAccount.create -}}
+    {{ default (include "rekor.createtree.fullname" .) .Values.createtree.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.createtree.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/rekor-createtree/templates/createtree-job.yaml
+++ b/charts/rekor-createtree/templates/createtree-job.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: createtree
+  namespace: {{ .Values.namespace }}
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ template "rekor.serviceAccountName.createtree" . }}
+      restartPolicy: Never
+      automountServiceAccountToken: true
+      containers:
+        - name: createtree
+          image: "{{ template "rekor.image" .Values.createtree.image }}"
+          args: ["--namespace=$(NAMESPACE)",
+            "--configmap={{ .Values.createtree.configMap }}",
+            "--display_name=rekortree",
+            {{- if .Values.trillian.adminServer }}
+            "--admin_server={{ .Values.trillian.adminServer }}",
+            {{- else }}
+            "--admin_server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.forceNamespace }}:{{ .Values.trillian.logServer.portRPC}}",
+            {{- end }}
+            "--force={{ .Values.createtree.force }}",
+          ]
+          env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+    {{- if .Values.createtree.securityContext }}
+      securityContext:
+{{ toYaml .Values.createtree.securityContext | indent 8 }}
+    {{- end }}

--- a/charts/rekor-createtree/templates/createtree-serviceaccount.yaml
+++ b/charts/rekor-createtree/templates/createtree-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "rekor.serviceAccountName.createtree" . }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+{{ toYaml .Values.createtree.serviceAccount.annotations | indent 4 }}

--- a/charts/rekor-createtree/values.yaml
+++ b/charts/rekor-createtree/values.yaml
@@ -1,0 +1,32 @@
+namespace: "rekor-system"
+createtree:
+  name: createtree
+  force: true
+  image:
+    registry: ghcr.io
+    repository: sigstore/scaffolding/createtree
+    pullPolicy: IfNotPresent
+    # v0.4.2
+    version: "sha256:03e7b3b068e61f65a730b7a95f498c76a02ddecb4f7a65e09b2753b66ac8399f"
+  serviceAccount:
+    create: false
+    name: "rekor-createtree"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65533
+  configMap: "rekor-config"
+
+# Configure Trillian dependency
+trillian:
+  enabled: true
+  namespace:
+    name: trillian-system
+    create: true
+  forceNamespace: trillian-system
+  fullnameOverride: trillian
+  adminServer: "trillian-logserver.trillian-system:8091"
+  logServer:
+    name: trillian-logserver
+    fullnameOverride: trillian-logserver
+    portHTTP: 8090
+    portRPC: 8091


### PR DESCRIPTION
This will be used for sharding. Initially, I thought we could just force the `createtree` Job through the rekor Chart.
But, it looks like that will automatically restart the rekor server, which might lead to a race between updating the Rekor configmap with the new tree ID and starting up the server.

With a separate Chart, we can create a new tree, update the ConfigMap, but still  control when we actually restart the rekor server to pick up that change.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>
