### PR TITLE
Add updatetree Helm Chart to mark old shards as frozen

### DIFF
--- a/charts/updatetree/.helmignore
+++ b/charts/updatetree/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/updatetree/Chart.yaml
+++ b/charts/updatetree/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: updatetree
+description: Update the status of an existing Trillian tree
+
+type: application
+
+version: 0.0.1
+appVersion: 0.4.3
+
+
+keywords:
+  - security
+  - trillian
+  - updatetree
+
+home: https://sigstore.dev/
+
+maintainers:
+  - name: The Sigstore Authors
+
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/images: |
+    - name: updatetree
+      image: ghcr.io/sigstore/scaffolding/updatetree@sha256:22c653b44aef3dc0de4e1bc398a435699b06a01a9b8fdef7880933cb0d79c8ee

--- a/charts/updatetree/README.md
+++ b/charts/updatetree/README.md
@@ -21,6 +21,7 @@ Update the status of an existing Trillian tree
 | namespace.name | string | `"trillian-system"` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.runAsUser | int | `65533` |  |
+| serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `"trillian-logserver"` |  |
 | spec.image | string | `"ghcr.io/sigstore/scaffolding/updatetree@sha256:22c653b44aef3dc0de4e1bc398a435699b06a01a9b8fdef7880933cb0d79c8ee"` |  |

--- a/charts/updatetree/README.md
+++ b/charts/updatetree/README.md
@@ -17,7 +17,7 @@ Update the status of an existing Trillian tree
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | args.treeID | string | `nil` |  |
-| args.treeState | string | `nil` |  |
+| args.treeState | string | `nil` | valid tree states are ACTIVE, FROZEN and DRAINING |
 | namespace.name | string | `"trillian-system"` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.runAsUser | int | `65533` |  |

--- a/charts/updatetree/README.md
+++ b/charts/updatetree/README.md
@@ -1,0 +1,32 @@
+# updatetree
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
+
+Update the status of an existing Trillian tree
+
+**Homepage:** <https://sigstore.dev/>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| The Sigstore Authors |  |  |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| args.treeID | string | `nil` |  |
+| args.treeState | string | `nil` |  |
+| namespace.name | string | `"trillian-system"` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `65533` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `"trillian-logserver"` |  |
+| spec.image | string | `"ghcr.io/sigstore/scaffolding/updatetree@sha256:22c653b44aef3dc0de4e1bc398a435699b06a01a9b8fdef7880933cb0d79c8ee"` |  |
+| spec.replicaCount | int | `1` |  |
+| trillian.adminServer | string | `""` |  |
+| trillian.logServer.name | string | `"trillian-logserver"` |  |
+| trillian.logServer.portRPC | int | `8091` |  |
+| trillian.namespace | string | `"trillian-system"` |  |
+

--- a/charts/updatetree/ci/ci-values.yaml
+++ b/charts/updatetree/ci/ci-values.yaml
@@ -1,0 +1,3 @@
+---
+namespace:
+  name: default

--- a/charts/updatetree/templates/_helpers.tpl
+++ b/charts/updatetree/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "updatetree.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/charts/updatetree/templates/job.yaml
+++ b/charts/updatetree/templates/job.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "updatetree.name" . }}
+  namespace: {{ .Values.namespace.name }}
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      restartPolicy: Never
+      containers:
+        - name: updatetree
+          image: "{{ .Values.spec.image}}"
+          args: [
+            "--tree_id={{ .Values.args.treeID }}",
+            "--tree_state={{ .Values.args.treeState }}",
+            {{- if .Values.trillian.adminServer }}
+            "--admin_server={{ .Values.trillian.adminServer }}",
+            {{- else }}
+            "--admin_server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace }}:{{ .Values.trillian.logServer.portRPC}}"
+            {{- end }}
+          ]
+    {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+    {{- end }}

--- a/charts/updatetree/templates/namespace.yaml
+++ b/charts/updatetree/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name }}
+{{- end }}

--- a/charts/updatetree/templates/sa.yaml
+++ b/charts/updatetree/templates/sa.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "sigstore-prober.common.matchLabels" . | nindent 4 }}
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Values.namespace.name }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}

--- a/charts/updatetree/templates/sa.yaml
+++ b/charts/updatetree/templates/sa.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    {{- include "sigstore-prober.common.matchLabels" . | nindent 4 }}
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Values.namespace.name }}
   annotations:

--- a/charts/updatetree/values.schema.json
+++ b/charts/updatetree/values.schema.json
@@ -1,0 +1,110 @@
+{
+    "namespace": {
+        "create": {
+            "type": "boolean",
+            "default": false
+        },
+        "name": {
+            "type": "string"
+        }
+    },
+    "serviceAccount": {
+        "name": {
+            "type": "string"
+        },
+        "create": {
+            "type": "boolean",
+            "default": false
+        }
+    },
+    "spec": {
+        "replicaCount": {
+            "type": "integer",
+            "default": 1
+        },
+        "image": {
+            "type": "string"
+        }
+    },
+    "securityContext": {
+        "runAsNonRoot": {
+            "type": "boolean",
+            "default": {
+                "type": "boolean",
+                "default": false
+            }
+        },
+        "runAsUser": {
+            "type": "integer",
+            "default": 65533
+        }
+    },
+    "args": {
+        "type": "object",
+        "required": [
+            "treeID",
+            "treeState"
+        ],
+        "treeID": {
+            "type": "string"
+        },
+        "treeState": {
+            "type": "string"
+        }
+    },
+    "trillian": {
+        "type": "object",
+        "default": {},
+        "title": "The trillian Schema",
+        "required": [
+            "namespace",
+            "logServer"
+        ],
+        "properties": {
+            "adminServer": {
+                "type": "string"
+            },
+            "namespace": {
+                "type": "string",
+                "default": "trillian-system"
+            },
+            "logServer": {
+                "type": "object",
+                "default": {},
+                "title": "The logServer Schema",
+                "required": [
+                    "name",
+                    "fullnameOverride",
+                    "portHTTP",
+                    "portRPC"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "default": "",
+                        "title": "The name Schema",
+                        "examples": [
+                            "trillian-logserver"
+                        ]
+                    },
+                    "portRPC": {
+                        "type": "integer",
+                        "default": 0,
+                        "title": "The portRPC Schema",
+                        "examples": [
+                            8091
+                        ]
+                    }
+                },
+                "examples": [
+                    {
+                        "name": "trillian-logserver",
+                        "fullnameOverride": "trillian-logserver",
+                        "portHTTP": 8090,
+                        "portRPC": 8091
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/charts/updatetree/values.schema.json
+++ b/charts/updatetree/values.schema.json
@@ -49,7 +49,12 @@
             "type": "string"
         },
         "treeState": {
-            "type": "string"
+            "type": "string",
+            "examples": [
+                "ACTIVE", 
+                "FROZEN",
+                "DRAINING"
+            ]
         }
     },
     "trillian": {

--- a/charts/updatetree/values.yaml
+++ b/charts/updatetree/values.yaml
@@ -1,0 +1,22 @@
+namespace:
+  name: trillian-system
+serviceAccount:
+  name: trillian-logserver
+  create: false
+spec:
+  replicaCount: 1
+  image: ghcr.io/sigstore/scaffolding/updatetree@sha256:22c653b44aef3dc0de4e1bc398a435699b06a01a9b8fdef7880933cb0d79c8ee  # v0.4.3
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65533
+args:
+  treeID:
+  treeState:
+
+# Configure Trillian dependency
+trillian:
+  namespace: trillian-system
+  adminServer: ""
+  logServer:
+    name: trillian-logserver
+    portRPC: 8091

--- a/charts/updatetree/values.yaml
+++ b/charts/updatetree/values.yaml
@@ -2,6 +2,7 @@ namespace:
   name: trillian-system
 serviceAccount:
   name: trillian-logserver
+  annotations: {}
   create: false
 spec:
   replicaCount: 1

--- a/charts/updatetree/values.yaml
+++ b/charts/updatetree/values.yaml
@@ -11,6 +11,7 @@ securityContext:
   runAsUser: 65533
 args:
   treeID:
+   # -- valid tree states are ACTIVE, FROZEN and DRAINING
   treeState:
 
 # Configure Trillian dependency


### PR DESCRIPTION
This can be used to mark old shards as FROZEN, or as ACTIVE if we ever need to rollback sharding.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

 **Description of the change**

<!-- Describe the change being requested. -->

 **Existing or Associated Issue(s)**

<!-- List any related issues. -->

 **Additional Information**

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
