### PR TITLE
Adjustments to account for home directory and adjusting probe for Policy Controller

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.2.1
 
 maintainers:

--- a/charts/policy-controller/templates/policy-webhook/deployment_policy_webhook.yaml
+++ b/charts/policy-controller/templates/policy-webhook/deployment_policy_webhook.yaml
@@ -106,7 +106,7 @@ spec:
           # Failing to provide a writable $HOME can cause TUF client initialization to panic
           - mountPath: /home/nonroot
             name: writable-home-dir
-        readinessProbe: &probe
+        readinessProbe:
           failureThreshold: 6
           initialDelaySeconds: 30
           periodSeconds: 1
@@ -116,8 +116,16 @@ spec:
             httpHeaders:
             - name: k-kubelet-probe
               value: "policy-webhook"
-        livenessProbe: *probe
-
+        livenessProbe:
+          failureThreshold: 6
+          initialDelaySeconds: 30
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "policy-webhook"
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.
       terminationGracePeriodSeconds: 300

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -54,6 +54,8 @@ spec:
           value: sigstore.dev/policy
         - name: WEBHOOK_NAME
           value: webhook
+        - name: HOME
+          value: /home/nonroot
 {{- if .Values.webhook.env }}
 {{- range $key, $value := .Values.webhook.env }}
         - name: "{{ $key }}"
@@ -113,6 +115,10 @@ spec:
         {{- omit . "enabled" | toYaml | nindent 10}}
         {{- end }}
 {{- end }}
+        volumeMounts:
+          # Failing to provide a writable $HOME can cause TUF client initialization to panic
+          - mountPath: /home/nonroot
+            name: writable-home-dir
       {{- if .Values.webhook.securityContext.enabled }}
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
@@ -124,3 +130,6 @@ spec:
         {{- toYaml . | nindent 8}}
         {{- end }}
       {{- end }}
+      volumes:
+      - emptyDir: {}
+        name: writable-home-dir


### PR DESCRIPTION
Corrections to handle permissions within Policy Controller

* Add `emptyDir` for ephemeral storage
* Set `HOME` environment variable so that all containers respect the `emptyDir` volume for ephemeral storage
* Correction to probes


Resolves #263 