### PR TITLE
chore: set a path name on the root ingress configuration

### DIFF
--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -71,6 +71,7 @@ server:
     className: "nginx"
     hosts:
       - path: /
+        host: root-path
     annotations: {}
     tls: []
   service:


### PR DESCRIPTION
This is a follow-up PR for https://github.com/sigstore/helm-charts/pull/283 and https://github.com/sigstore/helm-charts/pull/282.
I still encountered the following error after those two PRs, and this small change fixes that.

```
(base) λ ~/code/sigstore-helm-charts/charts/scaffold/ main* helm install scaffold . 
Error: INSTALLATION FAILED: execution error at (scaffold/charts/rekor/templates/server/ingress.yaml:17:15): An Ingress hostname is required
```