### PR TITLE
Expose write-prober flag through sigstore-prober helm-chart.

### DIFF
--- a/charts/sigstore-prober/Chart.yaml
+++ b/charts/sigstore-prober/Chart.yaml
@@ -4,8 +4,8 @@ description: Sigstore API Endpoint Prober
 
 type: application
 
-version: 0.0.2
-appVersion: 0.4.3
+version: 0.0.3
+appVersion: 0.4.6
 
 
 keywords:
@@ -21,4 +21,4 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: sigstore-prober
-      image: ghcr.io/sigstore/scaffolding/prober@sha256:59093231a8048aafcdd43a2b6b3bca29069f97a5737850f336118abb560f857e
+      image: ghcr.io/sigstore/scaffolding/prober@sha256:d16b6489228e30cccda4395086148375f2f1aff395aa0b66dc54cfd46cf6309f

--- a/charts/sigstore-prober/README.md
+++ b/charts/sigstore-prober/README.md
@@ -24,6 +24,7 @@ Sigstore API Endpoint Prober
 | spec.args.frequency | int | `10` |  |
 | spec.args.fulcioHost | string | `"https://fulcio.sigstore.dev"` |  |
 | spec.args.rekorHost | string | `"https://rekor.sigstore.dev"` |  |
+| spec.args.writeProber | bool | `false` |  |
 | spec.image | string | `"gcr.io/priya-chainguard/prober-37ee855f344691c13c5769b1675cc9e0@sha256:a601f7de3c572bb65b2cebd431ee8fc0cbd409b2edb5836718f09973400538c8"` |  |
 | spec.imagePullPolicy | string | `"Always"` |  |
 | spec.matchLabels.app | string | `"sigstore-prober"` |  |

--- a/charts/sigstore-prober/templates/_helpers.tpl
+++ b/charts/sigstore-prober/templates/_helpers.tpl
@@ -28,4 +28,7 @@ Create args for sigstore prober components
 {{- if .Values.spec.args.fulcioHost }}
 - "-fulcio-url={{ .Values.spec.args.fulcioHost }}"
 {{- end }}
+{{- if .Values.spec.args.writeProber }}
+- "-write-prober={{ .Values.spec.args.writeProber }}"
+{{- end }}
 {{- end -}}

--- a/charts/sigstore-prober/values.schema.json
+++ b/charts/sigstore-prober/values.schema.json
@@ -35,6 +35,9 @@
                         },
                         "rekorHost": {
                             "type": "string"
+                        },
+                        "writeProber": {
+                            "type": "boolean"
                         }
                     }
                 },

--- a/charts/sigstore-prober/values.yaml
+++ b/charts/sigstore-prober/values.yaml
@@ -14,5 +14,6 @@ spec:
     fulcioHost: https://fulcio.sigstore.dev
     rekorHost: https://rekor.sigstore.dev
     frequency: 10
+    writeProber: false
 prometheus:
   port: 8080


### PR DESCRIPTION
Also bumps the prober version to latest.

Signed-off-by: Simon Kent <simek@google.com>
