### PR TITLE
Add resources to createtree-job

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.3.15
+version: 0.3.16
 appVersion: 0.11.0
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the Rekor chart and the
 | createtree.image.repository | string | `"sigstore/scaffolding/createtree"` |  |
 | createtree.image.version | string | `"sha256:03e7b3b068e61f65a730b7a95f498c76a02ddecb4f7a65e09b2753b66ac8399f"` |  |
 | createtree.name | string | `"createtree"` |  |
+| createtree.resources | object | `{}` |  |
 | createtree.securityContext.runAsNonRoot | bool | `true` |  |
 | createtree.securityContext.runAsUser | int | `65533` |  |
 | createtree.serviceAccount.annotations | object | `{}` |  |

--- a/charts/rekor/templates/server/createtree-job.yaml
+++ b/charts/rekor/templates/server/createtree-job.yaml
@@ -29,6 +29,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          resources:
+{{ toYaml .Values.createtree.resources | indent 12 }}
     {{- if .Values.createtree.securityContext }}
       securityContext:
 {{ toYaml .Values.createtree.securityContext | indent 8 }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -656,7 +656,7 @@
                             "default": "",
                             "title": "The version Schema",
                             "examples": [
-                                "sha256:af91aee88c6d8efb3175b441420a4c61691ec5d6a72303c8ef47750c1dfd2325"
+                                "sha256:06adc81497b31200ac76a880698f7a950255841766b19cb8d8e592f63192b59b"
                             ]
                         }
                     },
@@ -664,7 +664,7 @@
                         "registry": "gcr.io",
                         "repository": "projectsigstore/rekor-server",
                         "pullPolicy": "IfNotPresent",
-                        "version": "sha256:af91aee88c6d8efb3175b441420a4c61691ec5d6a72303c8ef47750c1dfd2325"
+                        "version": "sha256:06adc81497b31200ac76a880698f7a950255841766b19cb8d8e592f63192b59b"
                     }]
                 },
                 "logging": {
@@ -1464,7 +1464,7 @@
                     "registry": "gcr.io",
                     "repository": "projectsigstore/rekor-server",
                     "pullPolicy": "IfNotPresent",
-                    "version": "sha256:af91aee88c6d8efb3175b441420a4c61691ec5d6a72303c8ef47750c1dfd2325"
+                    "version": "sha256:06adc81497b31200ac76a880698f7a950255841766b19cb8d8e592f63192b59b"
                 },
                 "logging": {
                     "production": false
@@ -1571,7 +1571,8 @@
                 "force",
                 "image",
                 "serviceAccount",
-                "securityContext"
+                "securityContext",
+                "resources"
             ],
             "properties": {
                 "name": {
@@ -1712,6 +1713,14 @@
                         "runAsNonRoot": true,
                         "runAsUser": 65533
                     }]
+                },
+                "resources": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The resources Schema",
+                    "required": [],
+                    "properties": {},
+                    "examples": [{}]
                 }
             },
             "examples": [{
@@ -1731,7 +1740,8 @@
                 "securityContext": {
                     "runAsNonRoot": true,
                     "runAsUser": 65533
-                }
+                },
+                "resources": {}
             }]
         },
         "trillian": {
@@ -2021,7 +2031,7 @@
                 "registry": "gcr.io",
                 "repository": "projectsigstore/rekor-server",
                 "pullPolicy": "IfNotPresent",
-                "version": "sha256:af91aee88c6d8efb3175b441420a4c61691ec5d6a72303c8ef47750c1dfd2325"
+                "version": "sha256:06adc81497b31200ac76a880698f7a950255841766b19cb8d8e592f63192b59b"
             },
             "logging": {
                 "production": false
@@ -2135,7 +2145,8 @@
             "securityContext": {
                 "runAsNonRoot": true,
                 "runAsUser": 65533
-            }
+            },
+            "resources": {}
         },
         "trillian": {
             "enabled": true,

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -154,6 +154,7 @@ createtree:
   securityContext:
     runAsNonRoot: true
     runAsUser: 65533
+  resources: {}
 
 # Configure Trillian dependency
 trillian:


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

 **Description of the change**

Adds resources block to the createtree-job.

 **Existing or Associated Issue(s)**

N.A.

 **Additional Information**

Our cluster has some kyverno policies in place that requires to define resources on any object.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [x] JSON Schema generated
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
