### PR TITLE
bump image versions for trillian

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -33,3 +33,5 @@ annotations:
       image: gcr.io/projectsigstore/trillian_log_server@sha256:4599a3f037234423d13ff84755679a56da62363e7ed07c70bc556078fd73986d
     - name: log_signer
       image: gcr.io/projectsigstore/trillian_log_signer@sha256:87699af429d79440f7e0a487d215c2129bf97b37698370d050a68822996f93f0
+    - name: cloud_proxy
+      image: gcr.io/cloudsql-docker/gce-proxy@sha256:7755f632c090289b8e0fa67218fc9d8b9ab7e0758ea58c48786617a79ff715dc

--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: trillian
-description: Trillian
+description: |
+  Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
 type: application
 
@@ -11,9 +12,13 @@ keywords:
   - pki
 
 home: https://sigstore.dev/
+sources:
+  - https://github.com/google/trillian
+  - https://github.com/sigstore/helm-charts/tree/main/charts/trillian
 
 maintainers:
   - name: The Sigstore Authors
+    url: https://sigstore.dev/
 
 annotations:
   artifacthub.io/license: Apache-2.0

--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -4,7 +4,7 @@ description: Trillian
 
 type: application
 
-version: 0.1.9
+version: 0.1.10
 
 keywords:
   - security

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -110,7 +110,7 @@ helm uninstall [RELEASE_NAME]
 | mysql.gcp.cloudsql.securityContext.capabilities.drop[0] | string | `"all"` |  |
 | mysql.gcp.cloudsql.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | mysql.gcp.cloudsql.securityContext.runAsNonRoot | bool | `true` |  |
-| mysql.gcp.cloudsql.version | string | `"1.29.0"` |  |
+| mysql.gcp.cloudsql.version | string | `"sha256:7755f632c090289b8e0fa67218fc9d8b9ab7e0758ea58c48786617a79ff715dc"` | v1.32.2 |
 | mysql.gcp.enabled | bool | `false` |  |
 | mysql.gcp.instance | string | `""` |  |
 | mysql.hostname | string | `""` |  |

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -44,7 +44,7 @@ helm uninstall [RELEASE_NAME]
 | initContainerImage.curl.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainerImage.curl.registry | string | `"docker.io"` |  |
 | initContainerImage.curl.repository | string | `"curlimages/curl"` |  |
-| initContainerImage.curl.version | string | `"sha256:e83fef2d5a036d40df4ded829141e8c0ec41871490d252fb8c81cb4580ebb35b"` | 7.83.1 |
+| initContainerImage.curl.version | string | `"sha256:9fab1b73f45e06df9506d947616062d7e8319009257d3a05d970b0de80a41ec5"` | 7.85.0 |
 | initContainerImage.netcat.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainerImage.netcat.registry | string | `"docker.io"` |  |
 | initContainerImage.netcat.repository | string | `"toolbelt/netcat"` |  |

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -1,26 +1,42 @@
-# Trillian
+# trillian
 
-[Trillian](https://github.com/google/trillian) is a log that stores an accurate, immutable and verifiable history of activity.
+<!-- This README.md is generated. Please edit README.md.gotmpl -->
+
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Trillian is a log that stores an accurate, immutable and verifiable history of activity.
+
+**Homepage:** <https://sigstore.dev/>
 
 ## Quick Installation
+
+To install the helm chart with default values run following command.
+The [Values](#Values) section describes the configuration options for this chart.
 
 ```shell
 helm install [RELEASE_NAME] .
 ```
 
-This command deploys the default configuration for the trillian chart. The [Parameters] section describes the various ways in which the chart can be configured.
-
 ## Uninstallation
+
+To uninstall the Helm chart run following command.
 
 ```shell
 helm uninstall [RELEASE_NAME]
 ```
 
-The previous command removes the previously installed chart.
+## Maintainers
 
-## Parameters
+| Name | Email | Url |
+| ---- | ------ | --- |
+| The Sigstore Authors |  | <https://sigstore.dev/> |
 
-The following table lists the configurable parameters of the trilian chart and their default values.
+## Source Code
+
+* <https://github.com/google/trillian>
+* <https://github.com/sigstore/helm-charts/tree/main/charts/trillian>
+
+## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -28,19 +44,19 @@ The following table lists the configurable parameters of the trilian chart and t
 | initContainerImage.curl.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainerImage.curl.registry | string | `"docker.io"` |  |
 | initContainerImage.curl.repository | string | `"curlimages/curl"` |  |
-| initContainerImage.curl.version | string | `"sha256:faaba66e89c87fd3fb51336857142ee6ce78fa8d8f023a5713d2bf4957f1aca8"` |  |
+| initContainerImage.curl.version | string | `"sha256:e83fef2d5a036d40df4ded829141e8c0ec41871490d252fb8c81cb4580ebb35b"` | 7.83.1 |
 | initContainerImage.netcat.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainerImage.netcat.registry | string | `"docker.io"` |  |
 | initContainerImage.netcat.repository | string | `"toolbelt/netcat"` |  |
-| initContainerImage.netcat.version | string | `"sha256:99a582fa45fe1b50c97c652c9ada24b96c80d7071283227bd9a9f8eaa1c7a12b"` |  |
+| initContainerImage.netcat.version | string | `"sha256:7d921b6d368fb1736cb0832c6f57e426c161593c075847af3378eb3185801cea"` | 2022-05-23 |
 | logServer.enabled | bool | `true` |  |
 | logServer.extraArgs | list | `[]` |  |
 | logServer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | logServer.image.registry | string | `"gcr.io"` |  |
 | logServer.image.repository | string | `"projectsigstore/trillian_log_server"` |  |
-| logServer.image.version | string | `"sha256:f850a0defd089ea844822030c67ae05bc93c91168a7dd4aceb0b6648c39f696b"` |  |
+| logServer.image.version | string | `"sha256:75dbbfc4c0b64334b985c4971fe58c30b9dd73d7aa54b15cee61223ff92aebf3"` | v0.9.1 |
 | logServer.livenessProbe | object | `{}` |  |
-| logServer.name | string | `"trillian-log-server"` |  |
+| logServer.name | string | `"log-server"` |  |
 | logServer.portHTTP | int | `8090` |  |
 | logServer.portRPC | int | `8091` |  |
 | logServer.readinessProbe | object | `{}` |  |
@@ -60,12 +76,13 @@ The following table lists the configurable parameters of the trilian chart and t
 | logServer.serviceAccount.name | string | `""` |  |
 | logSigner.enabled | bool | `true` |  |
 | logSigner.extraArgs | list | `[]` |  |
+| logSigner.forceMaster | bool | `true` |  |
 | logSigner.image.pullPolicy | string | `"IfNotPresent"` |  |
 | logSigner.image.registry | string | `"gcr.io"` |  |
 | logSigner.image.repository | string | `"projectsigstore/trillian_log_signer"` |  |
-| logSigner.image.version | string | `"sha256:fe90d523f6617974f70878918e4b31d49b2b46a86024bb2d6b01d2bbfed8edbf"` |  |
+| logSigner.image.version | string | `"sha256:b56ed0b7b5e9813c91b208ba6041c9342f9a53162d96943374e59b5289090f1f"` | v0.9.1 |
 | logSigner.livenessProbe | object | `{}` |  |
-| logSigner.name | string | `"trillian-log-signer"` |  |
+| logSigner.name | string | `"log-signer"` |  |
 | logSigner.portHTTP | int | `8090` |  |
 | logSigner.portRPC | int | `8091` |  |
 | logSigner.readinessProbe | object | `{}` |  |
@@ -87,14 +104,20 @@ The following table lists the configurable parameters of the trilian chart and t
 | mysql.enabled | bool | `true` |  |
 | mysql.gcp.cloudsql.registry | string | `"gcr.io"` |  |
 | mysql.gcp.cloudsql.repository | string | `"cloudsql-docker/gce-proxy"` |  |
-| mysql.gcp.cloudsql.version | string | `"1.28.1"` |  |
-| mysql.gcp.enabled | string | `""` |  |
+| mysql.gcp.cloudsql.resources.requests.cpu | string | `"1"` |  |
+| mysql.gcp.cloudsql.resources.requests.memory | string | `"2Gi"` |  |
+| mysql.gcp.cloudsql.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| mysql.gcp.cloudsql.securityContext.capabilities.drop[0] | string | `"all"` |  |
+| mysql.gcp.cloudsql.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| mysql.gcp.cloudsql.securityContext.runAsNonRoot | bool | `true` |  |
+| mysql.gcp.cloudsql.version | string | `"1.29.0"` |  |
+| mysql.gcp.enabled | bool | `false` |  |
 | mysql.gcp.instance | string | `""` |  |
 | mysql.hostname | string | `""` |  |
 | mysql.image.pullPolicy | string | `"IfNotPresent"` |  |
 | mysql.image.registry | string | `"gcr.io"` |  |
 | mysql.image.repository | string | `"trillian-opensource-ci/db_server"` |  |
-| mysql.image.version | string | `"sha256:0794abd3bdf44a567f5d6ef18a0b76802f388611b63aae33eaf28c3b0c5964d8"` |  |
+| mysql.image.version | string | `"sha256:22b7fddcb4bafc5692760d84dca5e86294363a94e8f0ecb8f5c39364d436e6d5"` | v1.5.0 |
 | mysql.livenessProbe.exec.command[0] | string | `"/etc/init.d/mysql"` |  |
 | mysql.livenessProbe.exec.command[1] | string | `"status"` |  |
 | mysql.livenessProbe.failureThreshold | int | `3` |  |
@@ -133,5 +156,3 @@ The following table lists the configurable parameters of the trilian chart and t
 | mysql.strategy.type | string | `"Recreate"` |  |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"trillian-system"` |  |
-
-----------------------------------------------

--- a/charts/trillian/README.md.gotmpl
+++ b/charts/trillian/README.md.gotmpl
@@ -1,0 +1,36 @@
+{{ template "chart.header" . }}
+
+<!-- This README.md is generated. Please edit README.md.gotmpl -->
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Quick Installation
+
+To install the helm chart with default values run following command. 
+The [Values](#Values) section describes the configuration options for this chart.
+
+```shell
+helm install [RELEASE_NAME] .
+```
+
+## Uninstallation
+
+To uninstall the Helm chart run following command.
+
+```shell
+helm uninstall [RELEASE_NAME]
+```
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -22,7 +22,8 @@ mysql:
     cloudsql:
       registry: gcr.io
       repository: cloudsql-docker/gce-proxy
-      version: "1.29.0"
+      # -- v1.32.2
+      version: sha256:7755f632c090289b8e0fa67218fc9d8b9ab7e0758ea58c48786617a79ff715dc
       resources:
         requests:
           memory: "2Gi"

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -5,8 +5,8 @@ initContainerImage:
   curl:
     registry: docker.io
     repository: curlimages/curl
-    # -- 7.83.1
-    version: "sha256:e83fef2d5a036d40df4ded829141e8c0ec41871490d252fb8c81cb4580ebb35b"
+    # -- 7.85.0
+    version: sha256:9fab1b73f45e06df9506d947616062d7e8319009257d3a05d970b0de80a41ec5
     imagePullPolicy: IfNotPresent
   netcat:
     registry: docker.io

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -5,13 +5,13 @@ initContainerImage:
   curl:
     registry: docker.io
     repository: curlimages/curl
-    # 7.83.1
+    # -- 7.83.1
     version: "sha256:e83fef2d5a036d40df4ded829141e8c0ec41871490d252fb8c81cb4580ebb35b"
     imagePullPolicy: IfNotPresent
   netcat:
     registry: docker.io
     repository: toolbelt/netcat
-    # 2022-05-23
+    # -- 2022-05-23
     version: "sha256:7d921b6d368fb1736cb0832c6f57e426c161593c075847af3378eb3185801cea"
     imagePullPolicy: IfNotPresent
 
@@ -45,8 +45,8 @@ mysql:
     registry: gcr.io
     repository: trillian-opensource-ci/db_server
     pullPolicy: IfNotPresent
-    # v1.4.1
-    version: "sha256:ae4043e9c5e4de522fb4958e92d592aa97c7fc294a12849b902fd1facd7122c6"
+    # -- v1.5.0
+    version: sha256:22b7fddcb4bafc5692760d84dca5e86294363a94e8f0ecb8f5c39364d436e6d5
   resources: {}
   args:
     - "--ignore-db-dir=lost+found"
@@ -108,8 +108,8 @@ logServer:
     registry: gcr.io
     repository: projectsigstore/trillian_log_server
     pullPolicy: IfNotPresent
-    # v0.7.0
-    version: "sha256:4599a3f037234423d13ff84755679a56da62363e7ed07c70bc556078fd73986d"
+    # -- v0.9.1
+    version: sha256:75dbbfc4c0b64334b985c4971fe58c30b9dd73d7aa54b15cee61223ff92aebf3
   service:
     type: ClusterIP
     ports:
@@ -140,8 +140,8 @@ logSigner:
     registry: gcr.io
     repository: projectsigstore/trillian_log_signer
     pullPolicy: IfNotPresent
-    # v0.7.0
-    version: "sha256:87699af429d79440f7e0a487d215c2129bf97b37698370d050a68822996f93f0"
+    # -- v0.9.1
+    version: sha256:b56ed0b7b5e9813c91b208ba6041c9342f9a53162d96943374e59b5289090f1f
   service:
     type: ClusterIP
     ports:


### PR DESCRIPTION
**Description of the change**

<!-- Describe the change being requested. -->

Bumps the rekor and trillian images to most recent versions.

The current version of the rekor and trillian charts have an issue with the 

mysql and redis container both reporting following error.

```shell
exec /usr/local/bin/docker-entrypoint.sh: exec format error
```

Bumping the images to latest versions at least resolves this.

> **Note**: Also included helm-docs template for rekor and trillian to ease updating the README.md. In values.yaml I also fixed some comments so they count as helm-docs to they show up in the README.md

 **Additional Information**

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [x] JSON Schema generated (N.A.)
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
