### PR TITLE
Add contributing.md with some guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,21 +9,21 @@ Please remember to:
 
  -->
 
- **Description of the change**
+## Description of the change
 
 <!-- Describe the change being requested. -->
 
- **Existing or Associated Issue(s)**
+## Existing or Associated Issue(s)
 
 <!-- List any related issues. -->
 
- **Additional Information**
+## Additional Information
 
  <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->
 
-**Checklist**
+## Checklist
 
 - [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
-- [ ] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
-- [ ] JSON Schema generated
-- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
+- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
+- [ ] JSON Schema generated.
+- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# CONTRIBUTING
+
+:tada: Thanks for your interest in contributing to this project. In this document we outline a few guidelines to ease the way your contributions flow into this project.
+
+## Commit style
+
+Ensure you have clear and concise commits, written in the present tense. See [Kubernetes commit message guidelines](https://www.kubernetes.dev/docs/guide/pull-requests/#commit-message-guidelines) for a more detailed explanation of our approach.
+
+```diff
++ git commit -m "Bump rekor chart to version 1.0.0"
+- git commit -m "Bumped rekor chart to version 1.0.0"
+```
+
+## PRs
+
+Stick with one feature/chart per branch. This allows us to make small controlled releases of the charts and makes it easy for us to review PRs.
+
+Ensure your branch is rebased on top of main before issuing your PR. This to keep a clean Git history and to ensure your changes are working with the latest main branch changes.
+
+```bash
+git checkout main
+git pull
+git checkout «your-branch»
+git rebase main
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,13 @@ $ crane digest ghcr.io/sigstore/scaffolding/createtree:v0.4.6
 sha256:c293fcb546619a71eabba16f231e0262d7614f2bb90fb53dda2713bbef71dac5
 ```
 
+## Bumping helm chart dependencies
+
+When bumping any dependency in Chart.yaml ensure you also update the Chart.lock file.
+
+```shell
+helm dependecy update charts/«chart-name»
+helm dependecy build charts/«chart-name»
+```
+
 [crane]: https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md "Crane is a tool for managing container images"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,21 @@ git pull
 git checkout «your-branch»
 git rebase main
 ```
+
+## Bumping image versions
+
+When bumping image versions it is important you use the image digest as opposed to the tag.
+
+See below a easy workflow to figure out the image digest and latest available tags using [crane][].
+
+```shell
+$ crane ls ghcr.io/sigstore/scaffolding/createtree
+…
+sha256-6c0722e2140d14982a9addbeffd6a5fc6c53ecd44d138138c2eebc14129ab3e8.sbom
+v0.4.6
+sha256-c293fcb546619a71eabba16f231e0262d7614f2bb90fb53dda2713bbef71dac5.sig
+$ crane digest ghcr.io/sigstore/scaffolding/createtree:v0.4.6
+sha256:c293fcb546619a71eabba16f231e0262d7614f2bb90fb53dda2713bbef71dac5
+```
+
+[crane]: https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md "Crane is a tool for managing container images"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,4 +49,13 @@ helm dependecy update charts/«chart-name»
 helm dependecy build charts/«chart-name»
 ```
 
+## Generating documentation
+
+Any changes to Chart.yaml or values.yaml require an update of the README.md. This update can easily be generated using [helm-docs][].
+
+```shell
+helm-docs -g charts/«chart-name»
+```
+
 [crane]: https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md "Crane is a tool for managing container images"
+[helm-docs]: https://github.com/norwoodj/helm-docs "The helm-docs tool auto-generates documentation from helm charts into markdown files."

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Charts are available in the following formats:
 * [Chart Repository](https://helm.sh/docs/topics/chart_repository/)
 * [OCI Artifacts](https://helm.sh/docs/topics/registries/)
 
+## Contribute
+
+:heart: Planning to contribute? Please following our [contributing guidelines](CONTRIBUTING.md) to have your contribution smoothly flowing into this project.
+
 ### Installing from the Chart Repository
 
 The following command can be used to add the chart repository:


### PR DESCRIPTION
**Description of the change**

Add [CONTRIBUTING.md](https://github.com/marcofranssen/sigstore-helm-charts/blob/simplify-contributing/CONTRIBUTING.md) to ease contributions by community and having docs to point to when a PR does not comply with these guidelines.
Will also add the README.md.gotmpl templates for other charts once #297 and #299 are merged in this PR. Secondly I will ensure all charts have a lock file in place and committed.

 **Existing or Associated Issue(s)**

Resolves #298 

 **Additional Information**

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

**Checklist**

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. THe [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content
- [ ] JSON Schema generated
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command
