### PR TITLE
add support for ttlSecondsAfterFinished for rekor createtree job

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 0.3.19
+version: 0.3.20
 appVersion: 0.12.1
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -47,6 +47,7 @@ The following table lists the configurable parameters of the Rekor chart and the
 | createtree.serviceAccount.annotations | object | `{}` |  |
 | createtree.serviceAccount.create | bool | `true` |  |
 | createtree.serviceAccount.name | string | `""` |  |
+| createtree.ttlSecondsAfterFinished | int | `3600` |  |
 | forceNamespace | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainerImage.curl.imagePullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/rekor/templates/server/createtree-job.yaml
+++ b/charts/rekor/templates/server/createtree-job.yaml
@@ -10,6 +10,9 @@ metadata:
 {{- end }}
 {{ include "rekor.namespace" . | indent 2 }}
 spec:
+{{- if .Values.createtree.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.createtree.ttlSecondsAfterFinished }}
+{{- end }}
   template:
     spec:
       serviceAccountName: {{ template "rekor.serviceAccountName.createtree" . }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -1736,6 +1736,14 @@
                         }
                     ]
                 },
+                "ttlSecondsAfterFinished": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The ttlSecondsAfterFinished Schema",
+                    "examples": [
+                        3600
+                    ]
+                },
                 "serviceAccount": {
                     "title": "The serviceAccount Schema",
                     "type": "object",

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -147,6 +147,7 @@ createtree:
     pullPolicy: IfNotPresent
     # v0.4.2
     version: "sha256:03e7b3b068e61f65a730b7a95f498c76a02ddecb4f7a65e09b2753b66ac8399f"
+  ttlSecondsAfterFinished: 3600
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->
add support for ttlSecondsAfterFinished for rekor createtree job

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
