### PR TITLE
add support for ttlSecondsAfterFinished in fulcio createcerts Job

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -4,7 +4,7 @@ description: Fulcio
 
 type: application
 
-version: 0.4.10
+version: 0.4.11
 appVersion: 0.5.3
 
 keywords:
@@ -18,7 +18,7 @@ maintainers:
 
 dependencies:
   - name: ctlog
-    version: 0.2.24
+    version: 0.2.27
     repository: https://sigstore.github.io/helm-charts
     condition: ctlog.enabled
 

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -1,6 +1,6 @@
 # fulcio
 
-![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.3](https://img.shields.io/badge/AppVersion-0.5.3-informational?style=flat-square)
+![Version: 0.4.11](https://img.shields.io/badge/Version-0.4.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.3](https://img.shields.io/badge/AppVersion-0.5.3-informational?style=flat-square)
 
 [Fulcio](https://docs.sigstore.dev/fulcio/overview/) is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -1,6 +1,6 @@
 # fulcio
 
-![Version: 0.4.9](https://img.shields.io/badge/Version-0.4.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.3](https://img.shields.io/badge/AppVersion-0.5.3-informational?style=flat-square)
+![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.3](https://img.shields.io/badge/AppVersion-0.5.3-informational?style=flat-square)
 
 [Fulcio](https://docs.sigstore.dev/fulcio/overview/) is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -58,7 +58,7 @@ The previous command removes the previously installed chart.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://sigstore.github.io/helm-charts | ctlog | 0.2.24 |
+| https://sigstore.github.io/helm-charts | ctlog | 0.2.27 |
 
 ## Parameters
 

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -1,5 +1,7 @@
 # fulcio
 
+![Version: 0.4.9](https://img.shields.io/badge/Version-0.4.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.3](https://img.shields.io/badge/AppVersion-0.5.3-informational?style=flat-square)
+
 [Fulcio](https://docs.sigstore.dev/fulcio/overview/) is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 
 The following components are also included as either direct components or through chart dependencies:
@@ -52,17 +54,19 @@ helm uninstall [RELEASE_NAME]
 
 The previous command removes the previously installed chart.
 
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://sigstore.github.io/helm-charts | ctlog | 0.2.24 |
+
 ## Parameters
 
 The following table lists the configurable parameters of the Fulcio chart and their default values.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config.contents.MetaIssuers."https://kubernetes.*.svc".ClientID | string | `"sigstore"` |  |
-| config.contents.MetaIssuers."https://kubernetes.*.svc".Type | string | `"kubernetes"` |  |
-| config.contents.OIDCIssuers."https://kubernetes.default.svc".ClientID | string | `"sigstore"` |  |
-| config.contents.OIDCIssuers."https://kubernetes.default.svc".IssuerURL | string | `"https://kubernetes.default.svc"` |  |
-| config.contents.OIDCIssuers."https://kubernetes.default.svc".Type | string | `"kubernetes"` |  |
+| config.contents | object | `{}` |  |
 | createcerts.enabled | bool | `true` |  |
 | createcerts.image.pullPolicy | string | `"IfNotPresent"` |  |
 | createcerts.image.registry | string | `"ghcr.io"` |  |
@@ -70,10 +74,13 @@ The following table lists the configurable parameters of the Fulcio chart and th
 | createcerts.image.version | string | `"sha256:73e7ac35d0e5169bd14a5cb6caed2e7d44277dec3d1de92e08f4d055523089a1"` |  |
 | createcerts.name | string | `"createcerts"` |  |
 | createcerts.replicaCount | int | `1` |  |
+| createcerts.securityContext.runAsNonRoot | bool | `true` |  |
+| createcerts.securityContext.runAsUser | int | `65533` |  |
 | createcerts.serviceAccount.annotations | object | `{}` |  |
 | createcerts.serviceAccount.create | bool | `true` |  |
 | createcerts.serviceAccount.mountToken | bool | `true` |  |
 | createcerts.serviceAccount.name | string | `""` |  |
+| createcerts.ttlSecondsAfterFinished | int | `3600` |  |
 | ctlog.createcerts.fullnameOverride | string | `"ctlog-createcerts"` |  |
 | ctlog.createcerts.name | string | `"ctlog-createcerts"` |  |
 | ctlog.createctconfig.logPrefix | string | `"fulcio"` |  |
@@ -90,40 +97,46 @@ The following table lists the configurable parameters of the Fulcio chart and th
 | namespace.name | string | `"fulcio-system"` |  |
 | server.args.aws_hsm_root_ca_path | string | `nil` |  |
 | server.args.certificateAuthority | string | `"fileca"` |  |
+| server.args.gcp_private_ca_parent | string | `"projects/test/locations/us-east1/caPools/test"` |  |
+| server.args.grpcPort | int | `5554` |  |
+| server.args.hsm_caroot_id | string | `nil` |  |
 | server.args.kms_resource | string | `nil` | URI for KMS backend if using `kmsca` certificate authority |
 | server.args.kms_cert_chain | string | `nil` | PEM encoded certificate chain if using `kmsca` certificate authority |
-| server.args.gcp_private_ca_parent | string | `"projects/test/locations/us-east1/caPools/test"` |  |
-| server.args.hsm_caroot_id | string | `nil` |  |
 | server.args.port | int | `5555` |  |
+| server.grpcSvcPort | int | `5554` |  |
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"gcr.io"` |  |
 | server.image.repository | string | `"projectsigstore/fulcio"` |  |
-| server.image.version | string | `"sha256:c0e8d940ec4ca6b474af9f7a04e05787677ec5bb3db12444ba69c89818ecfdd5"` |  |
-| server.ingress.grpc.annotations | object | `{}` |  |
-| server.ingress.grpc.className | object | `""` |  |
-| server.ingress.grpc.enabled | bool | `true` |  |
-| server.ingress.grpc.hosts | array | [] |  |
-| server.ingress.grpc.hosts.host | string |  |  |
-| server.ingress.grpc.hosts.path | string | `"/"` |  |
-| server.ingress.grpc.hosts.service_name | string |  |  |
-| server.ingress.grpc.tls | array | `[]` |  |
-| server.ingress.grpc.tls.hosts | array | `[]` |  |
-| server.ingress.grpc.tls.secretName | string | `` |  |
+| server.image.version | string | `"sha256:61081295a8f75ed7537b5d1f8c7320e078dc00e4562c0bf605fbefa062c690de"` |  |
+| server.ingress.grpc.annotations."nginx.ingress.kubernetes.io/backend-protocol" | string | `"GRPC"` |  |
+| server.ingress.grpc.className | string | `""` |  |
+| server.ingress.grpc.enabled | bool | `false` |  |
+| server.ingress.grpc.hosts[0].host | string | `"fulcio.localhost"` |  |
+| server.ingress.grpc.hosts[0].path | string | `"/dev.sigstore.fulcio.v2.CA"` |  |
+| server.ingress.grpc.tls[0].hosts[0] | string | `"fulcio.localhost"` |  |
+| server.ingress.grpc.tls[0].secretName | string | `"fulcio-grpc-ingress-tls"` |  |
 | server.ingress.http.annotations | object | `{}` |  |
-| server.ingress.http.className | object | `""` |  |
+| server.ingress.http.className | string | `"nginx"` |  |
 | server.ingress.http.enabled | bool | `true` |  |
-| server.ingress.http.hosts | array | [] |  |
-| server.ingress.http.hosts.host | string |  |  |
-| server.ingress.http.hosts.path | string | `"/"` |  |
-| server.ingress.http.hosts.service_name | string |  |  |
-| server.ingress.http.tls | array | `[]` |  |
-| server.ingress.http.tls.hosts | array | `[]` |  |
-| server.ingress.http.tls.secretName | string | `` |  |
+| server.ingress.http.hosts[0].host | string | `"fulcio.localhost"` |  |
+| server.ingress.http.hosts[0].path | string | `"/"` |  |
+| server.ingress.http.tls | list | `[]` |  |
+| server.name | string | `"server"` |  |
 | server.replicaCount | int | `1` |  |
-| server.service.ports[0].name | string | `"80-tcp"` |  |
+| server.securityContext.runAsNonRoot | bool | `true` |  |
+| server.securityContext.runAsUser | int | `65533` |  |
+| server.service.ports[0].name | string | `"http"` |  |
 | server.service.ports[0].port | int | `80` |  |
 | server.service.ports[0].protocol | string | `"TCP"` |  |
 | server.service.ports[0].targetPort | int | `5555` |  |
+| server.service.ports[1].name | string | `"grpc"` |  |
+| server.service.ports[1].port | int | `5554` |  |
+| server.service.ports[1].protocol | string | `"TCP"` |  |
+| server.service.ports[1].targetPort | int | `5554` |  |
+| server.service.ports[2].name | string | `"2112-tcp"` |  |
+| server.service.ports[2].port | int | `2112` |  |
+| server.service.ports[2].protocol | string | `"TCP"` |  |
+| server.service.ports[2].targetPort | int | `2112` |  |
 | server.service.type | string | `"ClusterIP"` |  |
 | server.serviceAccount.annotations | object | `{}` |  |
 | server.serviceAccount.create | bool | `true` |  |
@@ -136,3 +149,5 @@ The following table lists the configurable parameters of the Fulcio chart and th
 ## Ingress
 
 To enabled access from external resources, an Ingress resource is created. The configuration necessary for each Ingress resource is primarily dependent on the specific Ingress Controller being used. In most cases, implementation specific configuration is specified as annotations on the Ingress resources. These can be applied using the `server.ingress.annotations` parameter.
+
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/fulcio/templates/createcerts-job.yaml
+++ b/charts/fulcio/templates/createcerts-job.yaml
@@ -11,6 +11,9 @@ metadata:
 {{ toYaml .Values.createcerts.annotations | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.createcerts.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.createcerts.ttlSecondsAfterFinished }}
+{{- end }}
   template:
     spec:
       serviceAccountName: {{ template "fulcio.serviceAccountName.createcerts" . }}

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -993,6 +993,14 @@
                         }
                     ]
                 },
+                "ttlSecondsAfterFinished": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The ttlSecondsAfterFinished Schema",
+                    "examples": [
+                        3600
+                    ]
+                },
                 "serviceAccount": {
                     "type": "object",
                     "default": {},

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -82,6 +82,7 @@ createcerts:
     pullPolicy: IfNotPresent
     # v0.3.0
     version: "sha256:73e7ac35d0e5169bd14a5cb6caed2e7d44277dec3d1de92e08f4d055523089a1"
+  ttlSecondsAfterFinished: 3600
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->
add support for ttlSecondsAfterFinished in fulcio createcerts Job

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
