### PR TITLE
update fulcio image to use release v0.6.0

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -4,8 +4,8 @@ description: Fulcio
 
 type: application
 
-version: 0.4.12
-appVersion: 0.5.3
+version: 0.5.0
+appVersion: 0.6.0
 
 keywords:
   - security
@@ -26,6 +26,6 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: fulcio
-      image: gcr.io/projectsigstore/fulcio@sha256:61081295a8f75ed7537b5d1f8c7320e078dc00e4562c0bf605fbefa062c690de
+      image: gcr.io/projectsigstore/fulcio@sha256:5d16364a5be4e75c98672f789d44ab4775554fe189a6217725a63a06de6fbc42
     - name: createcerts
       image: ghcr.io/sigstore/scaffolding/createcerts@sha256:73e7ac35d0e5169bd14a5cb6caed2e7d44277dec3d1de92e08f4d055523089a1

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -107,7 +107,7 @@ The following table lists the configurable parameters of the Fulcio chart and th
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"gcr.io"` |  |
 | server.image.repository | string | `"projectsigstore/fulcio"` |  |
-| server.image.version | string | `"sha256:61081295a8f75ed7537b5d1f8c7320e078dc00e4562c0bf605fbefa062c690de"` |  |
+| server.image.version | string | `"sha256:5d16364a5be4e75c98672f789d44ab4775554fe189a6217725a63a06de6fbc42"` | `v0.6.0` |
 | server.ingress.grpc.annotations."nginx.ingress.kubernetes.io/backend-protocol" | string | `"GRPC"` |  |
 | server.ingress.grpc.className | string | `""` |  |
 | server.ingress.grpc.enabled | bool | `false` |  |

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -14,8 +14,8 @@ server:
     registry: gcr.io
     repository: projectsigstore/fulcio
     pullPolicy: IfNotPresent
-    # crane digest gcr.io/projectsigstore/fulcio:v0.5.3
-    version: "sha256:61081295a8f75ed7537b5d1f8c7320e078dc00e4562c0bf605fbefa062c690de"
+    # crane digest gcr.io/projectsigstore/fulcio:v0.6.0
+    version: "sha256:5d16364a5be4e75c98672f789d44ab4775554fe189a6217725a63a06de6fbc42"
   args:
     port: 5555
     grpcPort: 5554


### PR DESCRIPTION
## Description of the change

- update fulcio image to use release v0.6.0

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
