### PR TITLE
Add prober option to use alternative rekor public key

### DIFF
--- a/charts/sigstore-prober/Chart.yaml
+++ b/charts/sigstore-prober/Chart.yaml
@@ -4,7 +4,7 @@ description: Sigstore API Endpoint Prober
 
 type: application
 
-version: 0.0.6
+version: 0.0.7
 appVersion: 0.4.10
 
 

--- a/charts/sigstore-prober/README.md
+++ b/charts/sigstore-prober/README.md
@@ -1,6 +1,6 @@
 # sigstore-prober
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.10](https://img.shields.io/badge/AppVersion-0.4.10-informational?style=flat-square)
 
 Sigstore API Endpoint Prober
 
@@ -23,12 +23,12 @@ Sigstore API Endpoint Prober
 | serviceAccount.name | string | `"default"` |  |
 | spec.args.frequency | int | `10` |  |
 | spec.args.fulcioHost | string | `"https://fulcio.sigstore.dev"` |  |
+| spec.args.fulcioRequests | list | `[]` |  |
 | spec.args.rekorHost | string | `"https://rekor.sigstore.dev"` |  |
+| spec.args.rekorRequests | list | `[]` |  |
+| spec.args.trustRekorAPIPublicKey | bool | `false` |  |
 | spec.args.writeProber | bool | `false` |  |
-| spec.args.rekorRequests | array | `[]` |  |
-| spec.args.fulcioRequests | array | `[]` |  |
 | spec.image | string | `"ghcr.io/sigstore/scaffolding/prober@sha256:101a6a79e25944797a2ae06c2b330995995e32a35b8616db1400206e69d2a340"` |  |
 | spec.imagePullPolicy | string | `"Always"` |  |
 | spec.matchLabels.app | string | `"sigstore-prober"` |  |
 | spec.replicaCount | int | `1` |  |
-

--- a/charts/sigstore-prober/templates/deployment.yaml
+++ b/charts/sigstore-prober/templates/deployment.yaml
@@ -18,6 +18,19 @@ spec:
         prometheus.io/port: "{{ .Values.prometheus.port }}"
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- if .Values.spec.args.trustRekorAPIPublicKey }}
+      initContainers:
+      - name: public-key-fetcher
+        image: docker.io/curlimages/curl@sha256:9fab1b73f45e06df9506d947616062d7e8319009257d3a05d970b0de80a41ec5
+        args:
+          - "--output"
+          - "/var/run/sigstore/public-key.pem"
+          - "{{ .Values.spec.args.rekorHost }}/api/v1/log/publicKey"
+        env:
+        volumeMounts:
+        - name: sigstore
+          mountPath: "/var/run/sigstore"
+      {{- end }}
       containers:
       - name: {{ template "sigstore-prober.name" . }}
         image: "{{ .Values.spec.image }}"
@@ -26,3 +39,15 @@ spec:
           {{- include "sigstore-prober.args" . | nindent 8 }}
         ports:
         - containerPort: {{ .Values.prometheus.port }} # metrics
+      {{- if .Values.spec.args.trustRekorAPIPublicKey }}
+        env:
+        - name: SIGSTORE_REKOR_PUBLIC_KEY
+          value: "/var/run/sigstore/public-key.pem"
+        volumeMounts:
+        - name: sigstore
+          mountPath: "/var/run/sigstore"
+          readOnly: true
+      volumes:
+        - name: sigstore
+          emptyDir: {}
+      {{- end }}

--- a/charts/sigstore-prober/values.schema.json
+++ b/charts/sigstore-prober/values.schema.json
@@ -39,6 +39,9 @@
                         "writeProber": {
                             "type": "boolean"
                         },
+                        "trustRekorAPIPublicKey": {
+                            "type": "boolean"
+                        },
                         "rekorRequests": {
                             "type": "array",
                             "items": {"$ref": "#/$defs/proberCheck"}

--- a/charts/sigstore-prober/values.yaml
+++ b/charts/sigstore-prober/values.yaml
@@ -17,5 +17,6 @@ spec:
     writeProber: false
     rekorRequests: []
     fulcioRequests: []
+    trustRekorAPIPublicKey: false
 prometheus:
   port: 8080


### PR DESCRIPTION


<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Right now the [verification prober](https://github.com/sigstore/scaffolding/pull/390) is failing in staging due to an incorrect public key (`error running rekor write prober: rekor log public key not found for payload`). For verification in staging, we need to use the Rekor public key for the staging instance.

Cosign has a [couple of environment variables](https://pkg.go.dev/github.com/sigstore/cosign/pkg/cosign#GetRekorPubs) that can be used to configure this: `SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY` and `SIGSTORE_REKOR_PUBLIC_KEY `. We could just add a flag to enable `SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY`, but [during a slack discussion, Hayden mentioned that he would like to deprecate it](https://sigstore.slack.com/archives/C03R5G3CU2H/p1664572468492409).

This PR just adds an optional initContainer to fetch the public key from the configured Rekor instance and provide it via `SIGSTORE_REKOR_PUBLIC_KEY`.

Signed-off-by: Cody Soyland <codysoyland@github.com>

## Existing or Associated Issue(s)

https://github.com/sigstore/scaffolding/issues/351

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
