### PR TITLE
Add chart for createdb job, bump trillian version.

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.1.10
+version: 0.1.11
 
 keywords:
   - security
@@ -35,3 +35,5 @@ annotations:
       image: gcr.io/projectsigstore/trillian_log_signer@sha256:87699af429d79440f7e0a487d215c2129bf97b37698370d050a68822996f93f0
     - name: cloud_proxy
       image: gcr.io/cloudsql-docker/gce-proxy@sha256:7755f632c090289b8e0fa67218fc9d8b9ab7e0758ea58c48786617a79ff715dc
+    - name: createdb
+      image: ghcr.io/sigstore/scaffolding/createdb@sha256:5ec1b95581d238dfbbd8e412422500cc242123078de8aaad23e5f9c65eaf2ba5

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
@@ -40,6 +40,14 @@ helm uninstall [RELEASE_NAME]
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| createdb.dbname | string | `"trillian"` |  |
+| createdb.image.pullPolicy | string | `"IfNotPresent"` |  |
+| createdb.image.registry | string | `"ghcr.io"` |  |
+| createdb.image.repository | string | `"sigstore/scaffolding/createdb"` |  |
+| createdb.image.version | string | `"sha256:5ec1b95581d238dfbbd8e412422500cc242123078de8aaad23e5f9c65eaf2ba5"` | v0.4.11 |
+| createdb.serviceAccount.annotations | object | `{}` |  |
+| createdb.serviceAccount.create | bool | `false` |  |
+| createdb.serviceAccount.name | string | `""` |  |
 | forceNamespace | string | `""` |  |
 | initContainerImage.curl.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainerImage.curl.registry | string | `"docker.io"` |  |

--- a/charts/trillian/templates/_helpers.tpl
+++ b/charts/trillian/templates/_helpers.tpl
@@ -54,6 +54,22 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create a fully qualified createdb job name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "trillian.createdb.fullname" -}}
+{{- if .Values.createdb.fullnameOverride -}}
+{{- .Values.createdb.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.createdb.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.createdb.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Create a fully qualified Log Server name.
@@ -117,6 +133,17 @@ Create the name of the service account to use for the mysql component
     {{ default (include "trillian.mysql.fullname" .) .Values.mysql.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.mysql.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for the Trillian createdb job.
+*/}}
+{{- define "trillian.serviceAccountName.createdb" -}}
+{{- if .Values.createdb.serviceAccount.create -}}
+    {{ default (include "trillian.createdb.fullname" .) .Values.createdb.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.createdb.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/trillian/templates/createdb/createdb-job.yaml
+++ b/charts/trillian/templates/createdb/createdb-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "trillian.mysql.fullname" . }}
+  name: {{ template "trillian.createdb.fullname" . }}
 {{ include "trillian.namespace" . | indent 2 }}
   labels:
     {{- include "trillian.mysql.labels" . | nindent 4 }}

--- a/charts/trillian/templates/createdb/createdb-job.yaml
+++ b/charts/trillian/templates/createdb/createdb-job.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "trillian.mysql.fullname" . }}
+{{ include "trillian.namespace" . | indent 2 }}
+  labels:
+    {{- include "trillian.mysql.labels" . | nindent 4 }}
+{{- if .Values.createdb.annotations }}
+  annotations:
+{{ toYaml .Values.createdb.annotations | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.createdb.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.createdb.ttlSecondsAfterFinished }}
+{{- end }}
+  template:
+    spec:
+      serviceAccountName: {{ template "trillian.serviceAccountName.logServer" . }}
+      restartPolicy: Never
+      automountServiceAccountToken: {{ .Values.createdb.serviceAccount.mountToken }}
+      containers:
+        {{- if .Values.mysql.gcp.enabled }}
+        - name: cloud-sql-proxy
+          image: "{{ template "trillian.image" .Values.mysql.gcp.cloudsql }}"
+          command:
+            - "/cloud_sql_proxy"
+            - "-instances={{ .Values.mysql.gcp.instance }}=tcp:{{ .Values.mysql.port }}"
+    {{- if .Values.mysql.gcp.cloudsql.securityContext }}
+          securityContext:
+{{ toYaml .Values.mysql.gcp.cloudsql.securityContext | indent 12 }}
+    {{- end }}
+          resources:
+{{ toYaml .Values.mysql.gcp.cloudsql.resources | indent 12 }}
+        {{- end }}
+        - name: {{ template "trillian.createdb.fullname" . }}
+          image: "{{ template "trillian.image" .Values.createdb.image }}"
+          imagePullPolicy: "{{ .Values.createdb.image.pullPolicy }}"
+          env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: MYSQL_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "mysql.secretName" . }}
+                key: mysql-user
+          - name: MYSQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "mysql.secretName" . }}
+                key: mysql-password
+          - name: MYSQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "mysql.secretName" . }}
+                key: mysql-database
+          - name: MYSQL_HOSTNAME
+            value: {{ template "mysql.hostname" . }}
+          - name: MYSQL_PORT
+            value: {{ .Values.mysql.port | quote }}
+          args: [
+            "--db_name=$(MYSQL_DATABASE)",
+            "--mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOSTNAME):3306)/$(MYSQL_DATABASE)"
+          ]
+    {{- if .Values.createdb.securityContext }}
+      securityContext:
+{{ toYaml .Values.createdb.securityContext | indent 8 }}
+    {{- end }}

--- a/charts/trillian/templates/createdb/createdb-job.yaml
+++ b/charts/trillian/templates/createdb/createdb-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.createdb.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -67,3 +68,4 @@ spec:
       securityContext:
 {{ toYaml .Values.createdb.securityContext | indent 8 }}
     {{- end }}
+{{- end }}

--- a/charts/trillian/templates/createdb/serviceaccount.yaml
+++ b/charts/trillian/templates/createdb/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.createdb.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "trillian.mysql.labels" . | nindent 4 }}
+  name: {{ template "trillian.serviceAccountName.createdb" . }}
+{{ include "trillian.namespace" . | indent 2 }}
+  annotations:
+{{ toYaml .Values.createdb.serviceAccount.annotations | indent 4 }}
+{{- end }}

--- a/charts/trillian/templates/createdb/serviceaccount.yaml
+++ b/charts/trillian/templates/createdb/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.createdb.enabled }}
 {{- if .Values.createdb.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -8,4 +9,5 @@ metadata:
 {{ include "trillian.namespace" . | indent 2 }}
   annotations:
 {{ toYaml .Values.createdb.serviceAccount.annotations | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -159,6 +159,7 @@ logSigner:
     name: ""
     annotations: {}
 createdb:
+  enabled: true
   dbname: trillian
   ttlSecondsAfterFinished: 3600
   name: createdb

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -158,5 +158,17 @@ logSigner:
     create: true
     name: ""
     annotations: {}
+createdb:
+  dbname: trillian
+  image:
+    registry: ghcr.io
+    repository: sigstore/scaffolding/createdb
+    pullPolicy: IfNotPresent
+    # -- v0.4.11
+    version: sha256:5ec1b95581d238dfbbd8e412422500cc242123078de8aaad23e5f9c65eaf2ba5
+  serviceAccount:
+    create: false
+    name: ""
+    annotations: {}
 # Force namespace of namespaced resources
 forceNamespace: ""

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -160,6 +160,8 @@ logSigner:
     annotations: {}
 createdb:
   dbname: trillian
+  ttlSecondsAfterFinished: 3600
+  name: createdb
   image:
     registry: ghcr.io
     repository: sigstore/scaffolding/createdb


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change
Add a chart inside trillian for createdb which will initialize a Trillian DB schema.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ x ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
