### PR TITLE
Bump trillian to 0.11, run helm-docs so picks up fulcio/rekor too.

### DIFF
--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.3.28
+version: 0.3.29
 
 keywords:
   - security
@@ -25,7 +25,7 @@ dependencies:
     repository: https://sigstore.github.io/helm-charts
     condition: rekor.enabled
   - name: trillian
-    version: 0.1.10
+    version: 0.1.11
     repository: https://sigstore.github.io/helm-charts
     condition: trillian.enabled
   - name: ctlog

--- a/charts/scaffold/README.md
+++ b/charts/scaffold/README.md
@@ -1,6 +1,6 @@
 # scaffold
 
-![Version: 0.3.26](https://img.shields.io/badge/Version-0.3.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.29](https://img.shields.io/badge/Version-0.3.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Scaffolding the components of the sigstore architecture
 
@@ -17,9 +17,9 @@ Scaffolding the components of the sigstore architecture
 | Repository | Name | Version |
 |------------|------|---------|
 | https://sigstore.github.io/helm-charts | ctlog | 0.2.29 |
-| https://sigstore.github.io/helm-charts | fulcio | 1.0.0-rc.1 |
-| https://sigstore.github.io/helm-charts | rekor | 1.0.0-rc.2 |
-| https://sigstore.github.io/helm-charts | trillian | 0.1.10 |
+| https://sigstore.github.io/helm-charts | fulcio | 1.0.0 |
+| https://sigstore.github.io/helm-charts | rekor | 1.0.0 |
+| https://sigstore.github.io/helm-charts | trillian | 0.1.11 |
 
 ## Quick Installation
 


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change
Bump scaffolding to depend on trillian 0.1.11.
fulcio/rekor changes are unrelated to this change, just looks like helm-docs was not run last time.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ X ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
