### PR TITLE
Fix the secret mounting to work without specifying keys.

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.33
+version: 0.2.34
 appVersion: 0.3.0
 
 keywords:

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -1,6 +1,6 @@
 # ctlog
 
-![Version: 0.2.33](https://img.shields.io/badge/Version-0.2.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 0.2.34](https://img.shields.io/badge/Version-0.2.34-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 Certificate Log
 
@@ -60,7 +60,6 @@ Certificate Log
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"ctlog-system"` |  |
 | server.config.key | string | `"treeID"` |  |
-| server.config.secret.enabled | bool | `false` |  |
 | server.config.secret.name | string | `"ctlog-config"` |  |
 | server.config.treeID | string | `""` |  |
 | server.extraArgs | list | `[]` |  |

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -60,7 +60,6 @@ Certificate Log
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"ctlog-system"` |  |
 | server.config.key | string | `"treeID"` |  |
-| server.config.secret.name | string | `"ctlog-config"` |  |
 | server.config.treeID | string | `""` |  |
 | server.extraArgs | list | `[]` |  |
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/ctlog/templates/_helpers.tpl
+++ b/charts/ctlog/templates/_helpers.tpl
@@ -108,7 +108,7 @@ Server Arguments
 {{- define "ctlog.server.args" -}}
 - {{ printf "--http_endpoint=0.0.0.0:%d" (.Values.server.portHTTP | int) | quote }}
 - {{ printf "--metrics_endpoint=0.0.0.0:%d" (.Values.server.portHTTPMetrics | int) | quote }}
-- "--log_config=/ctfe-config/ct_server.cfg"
+- "--log_config=/ctfe-keys/config"
 - "--alsologtostderr"
 {{- if .Values.server.extraArgs -}}
 {{- range $key, $value := .Values.server.extraArgs }}

--- a/charts/ctlog/templates/ctlog-deployment.yaml
+++ b/charts/ctlog/templates/ctlog-deployment.yaml
@@ -31,9 +31,6 @@ spec:
             - name: keys
               mountPath: "/ctfe-keys"
               readOnly: true
-            - name: config
-              mountPath: "/ctfe-config"
-              readOnly: true
           ports:
 {{- include "ctlog.containerPorts" .Values.server.service.ports | indent 12 }}
     {{- if .Values.server.resources }}
@@ -48,24 +45,3 @@ spec:
         - name: keys
           secret:
             secretName: {{ template "ctlog.secret" . }}
-            items:
-              - key: private
-                path: privkey.pem
-              - key: public
-                path: pubkey.pem
-              - key: rootca
-                path: roots.pem
-        - name: config
-          {{- if .Values.server.config.secret.enabled }}
-          secret:
-            secretName: {{ template "ctlog.secret" . }}
-            items:
-              - key: config
-                path: ct_server.cfg
-          {{ else }}
-          configMap:
-            name: {{ template "ctlog.config" . }}
-            items:
-              - key: config
-                path: ct_server.cfg
-          {{- end }}

--- a/charts/ctlog/values.schema.json
+++ b/charts/ctlog/values.schema.json
@@ -77,34 +77,10 @@
                     "default": {},
                     "title": "The config Schema",
                     "required": [
-                        "secret",
                         "key",
                         "treeID"
                     ],
                     "properties": {
-                        "secret": {
-                            "type": "object",
-                            "default": {},
-                            "title": "The secret Schema",
-                            "required": [
-                                "name"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "The name Schema",
-                                    "examples": [
-                                        "ctlog-config"
-                                    ]
-                                }
-                            },
-                            "examples": [
-                                {
-                                    "name": "ctlog-config"
-                                }
-                            ]
-                        },
                         "key": {
                             "type": "string",
                             "default": "",
@@ -124,9 +100,6 @@
                     },
                     "examples": [
                         {
-                            "secret": {
-                                "name": "ctlog-config"
-                            },
                             "key": "treeID",
                             "treeID": ""
                         }
@@ -559,9 +532,6 @@
                 {
                     "replicaCount": 1,
                     "config": {
-                        "secret": {
-                            "name": "ctlog-config"
-                        },
                         "key": "treeID",
                         "treeID": ""
                     },
@@ -1261,9 +1231,6 @@
             "server": {
                 "replicaCount": 1,
                 "config": {
-                    "secret": {
-                        "name": "ctlog-config"
-                    },
                     "key": "treeID",
                     "treeID": ""
                 },

--- a/charts/ctlog/values.schema.json
+++ b/charts/ctlog/values.schema.json
@@ -87,18 +87,9 @@
                             "default": {},
                             "title": "The secret Schema",
                             "required": [
-                                "enabled",
                                 "name"
                             ],
                             "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "default": false,
-                                    "title": "The enabled Schema",
-                                    "examples": [
-                                        false
-                                    ]
-                                },
                                 "name": {
                                     "type": "string",
                                     "default": "",
@@ -110,7 +101,6 @@
                             },
                             "examples": [
                                 {
-                                    "enabled": false,
                                     "name": "ctlog-config"
                                 }
                             ]
@@ -135,7 +125,6 @@
                     "examples": [
                         {
                             "secret": {
-                                "enabled": false,
                                 "name": "ctlog-config"
                             },
                             "key": "treeID",
@@ -571,7 +560,6 @@
                     "replicaCount": 1,
                     "config": {
                         "secret": {
-                            "enabled": false,
                             "name": "ctlog-config"
                         },
                         "key": "treeID",
@@ -1274,7 +1262,6 @@
                 "replicaCount": 1,
                 "config": {
                     "secret": {
-                        "enabled": false,
                         "name": "ctlog-config"
                     },
                     "key": "treeID",

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -5,8 +5,6 @@ namespace:
 server:
   replicaCount: 1
   config:
-    secret:
-      name: ctlog-config
     key: treeID
     treeID: ""
   image:

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -6,7 +6,6 @@ server:
   replicaCount: 1
   config:
     secret:
-      enabled: false
       name: ctlog-config
     key: treeID
     treeID: ""


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Previously each key in the secret for ctlog was explicitly specified. But in order to support multiple Fulcios, they were moved to `fulcio-XXX` where XXX specifies the index we mount everything from the secret.
Also, we always write the config in secret, so there's no need to mount the config map anymore.

Relevant PRs from scaffolding:
This in particular:
https://github.com/sigstore/scaffolding/pull/352/files#diff-dc1ec6e1748d93e1822f7b79815b687dc9e2effb36adfc168dc1354b740164c0

https://github.com/sigstore/scaffolding/pull/334/files
https://github.com/sigstore/scaffolding/pull/341/files


<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
