### PR TITLE
fix: add 'enabled' as property for subchart configuration

### DIFF
--- a/charts/tuf/Chart.yaml
+++ b/charts/tuf/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tuf
 description: A framework for securing software update systems - the scaffolding implementation
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.4.6"
 
 home: https://sigstore.dev/

--- a/charts/tuf/README.md
+++ b/charts/tuf/README.md
@@ -1,6 +1,6 @@
 # tuf
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.6](https://img.shields.io/badge/AppVersion-0.4.6-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.6](https://img.shields.io/badge/AppVersion-0.4.6-informational?style=flat-square)
 
 A framework for securing software update systems - the scaffolding implementation
 
@@ -27,6 +27,7 @@ A framework for securing software update systems - the scaffolding implementatio
 | deployment.replicas | int | `1` |  |
 | deployment.repository | string | `"sigstore/scaffolding/server"` |  |
 | deployment.version | string | `"sha256:719ea3fe44c52af5a5fedab2168429872e37e97b9f063977fc164d60a5a14b53"` |  |
+| enabled | bool | `true` |  |
 | forceNamespace | string | `""` |  |
 | fullnameOverride | string | `"tuf"` |  |
 | imagePullSecrets | list | `[]` |  |
@@ -38,21 +39,18 @@ A framework for securing software update systems - the scaffolding implementatio
 | namespace.name | string | `"fulcio-system"` |  |
 | roleBindingName | string | `"tuf"` |  |
 | roleName | string | `"tuf"` |  |
+| secrets.ctlog.create | bool | `false` |  |
 | secrets.ctlog.key | string | `"key"` |  |
 | secrets.ctlog.name | string | `"ctlog-public-key"` |  |
 | secrets.ctlog.path | string | `"ctlog-pubkey"` |  |
-| secrets.ctlog.value | string |  |  |
-| secrets.ctlog.create | boolean | `false` |  |
+| secrets.fulcio.create | bool | `false` |  |
 | secrets.fulcio.key | string | `"cert"` |  |
 | secrets.fulcio.name | string | `"fulcio-server-secret"` |  |
 | secrets.fulcio.path | string | `"fulcio-cert"` |  |
-| secrets.fulcio.value | string |  |  |
-| secrets.fulcio.create | boolean | `false` |  |
+| secrets.rekor.create | bool | `false` |  |
 | secrets.rekor.key | string | `"public"` |  |
 | secrets.rekor.name | string | `"rekor-public-key"` |  |
 | secrets.rekor.path | string | `"rekor-pubkey"` |  |
-| secrets.rekor.value | string |  |  |
-| secrets.rekor.create | boolean | `false` |  |
 | service.name | string | `"tuf-server"` |  |
 | service.port | int | `80` |  |
 | serviceAccountName | string | `"tuf"` |  |

--- a/charts/tuf/values.schema.json
+++ b/charts/tuf/values.schema.json
@@ -25,6 +25,10 @@
               "fullnameOverride": {
                   "type": "string"
               },
+              "enabled": {
+                "description": "Usually used when using tuf as a subchart.",
+                "type": "boolean"
+              },
               "deployment": {
                   "$ref": "#/definitions/Deployment"
               },

--- a/charts/tuf/values.yaml
+++ b/charts/tuf/values.yaml
@@ -4,6 +4,7 @@ serviceAccountName: tuf
 roleName: tuf
 roleBindingName: tuf
 fullnameOverride: tuf
+enabled: true
 
 deployment:
   name: tuf


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

`scaffold` chart fails to use `tuf` as subchart as it does not allow `additionalProperties`, so we can specify `enabled` for the `tuf` subchart in `scaffold`

Explicitly add `enabled` as property to address this.
We can follow up whether we should set `additionalProperties` to `true` or `false` for schema validation as a follow up.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
