### PR TITLE
Allow CRDs to be installed independently

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.3.6
+version: 0.3.7
 appVersion: 0.4.2
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -26,6 +26,7 @@ The Helm chart for Policy  Controller
 | cosign.cosignPub | string | `""` |  |
 | cosign.webhookName | string | `"policy.sigstore.dev"` |  |
 | imagePullSecrets | list | `[]` |  |
+| installCRDs | bool | `true` |  |
 | policywebhook.env | object | `{}` |  |
 | policywebhook.configData | object | `{}` | Set the data of the `policy-config-controller` configmap |
 | policywebhook.extraArgs | object | `{}` |  |

--- a/charts/policy-controller/templates/crds/clusterimagepolicy.yaml
+++ b/charts/policy-controller/templates/crds/clusterimagepolicy.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -471,3 +472,4 @@ spec:
                       type: string
                     url:
                       type: string
+{{- end }}

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -22,6 +22,9 @@
         "imagePullSecrets": {
             "type": "array"
         },
+        "installCRDs": {
+            "type": "boolean"
+        },
         "policywebhook": {
             "type": "object",
             "properties": {

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -3,6 +3,8 @@ cosign:
   cosignPub: ""
   webhookName: "policy.sigstore.dev"
 
+installCRDs: true
+
 imagePullSecrets: []
 
 policywebhook:


### PR DESCRIPTION
Signed-off-by: slimm609 <dbrian@vmware.com>

## Description of the change

Allow CRDs to be skipped during the helm chart install. Helm has certain restrictions and issues with installing CRDs so allowing them to be installed independently of the helm chart is very common. https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations

A common and documented approach is to use a different chart entirely.  https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-2-separate-charts 

Allowing users to copy the CRD out of this chart and install as part of a separate chart and disable inside the policy-controller chart provides flexibility with the documented approach

## Existing or Associated Issue(s)

n/a

## Additional Information

This is a very common approach for multiple different charts and allowing policy-controller the same flexibility would be very beneficial

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [X] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [X] JSON Schema generated.
- [X] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
