### PR TITLE
Backfillredis helm chart.

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,8 +4,8 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.0.1
-appVersion: 1.0.1
+version: 1.0.2
+appVersion: 1.0.2
 
 keywords:
   - security

--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -34,3 +34,5 @@ annotations:
       image: gcr.io/projectsigstore/rekor-server:v1.0.1@sha256:f7e6975041b9b6f3afdc7d6a1a87de43098ce8d83eb1958ea097ebfcb5537658
     - name: redis
       image: docker.io/redis@sha256:6c42cce2871e8dc5fb3e843ed5c4e7939d312faf5e53ff0ff4ca955a7e0b2b39
+    - name: backfill-redis
+      image: ghcr.io/sigstore/rekor/backfill-redis@sha256:15f070c4b853f38773d253ebd39957de5c3beffc1699ba574db98e3679336af1

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.0.0-rc.2](https://img.shields.io/badge/Version-1.0.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0-rc.2](https://img.shields.io/badge/AppVersion-1.0.0--rc.2-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 
@@ -26,6 +26,19 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| backfillredis.enabled | bool | `false` |  |
+| backfillredis.endIndex | int | `-1` |  |
+| backfillredis.image.pullPolicy | string | `"IfNotPresent"` |  |
+| backfillredis.image.registry | string | `"ghcr.io"` |  |
+| backfillredis.image.repository | string | `"sigstore/rekor/backfill-redis"` |  |
+| backfillredis.image.version | string | `"sha256:15f070c4b853f38773d253ebd39957de5c3beffc1699ba574db98e3679336af1"` | `"v1.0.1"` |
+| backfillredis.name | string | `"backfillredis"` |  |
+| backfillredis.rekorAddress | string | `"rekor.rekor-system.svc"` |  |
+| backfillredis.resources | object | `{}` |  |
+| backfillredis.securityContext.runAsNonRoot | bool | `true` |  |
+| backfillredis.securityContext.runAsUser | int | `65533` |  |
+| backfillredis.startIndex | int | `-1` |  |
+| backfillredis.ttlSecondsAfterFinished | int | `3600` |  |
 | createtree.annotations | object | `{}` |  |
 | createtree.force | bool | `false` |  |
 | createtree.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -178,4 +191,4 @@ To disable the deployment of Redis or MySQL, pass the `redis.enabled=false` and/
 
 ## Ingress
 
-To enabled access from external resources, an Ingress resource is created. The configuration necessary for each Ingress resource is primarily dependent on the specific Ingress Controller being used. In most cases, implementation specific configuration is specified as annotations on the Ingress resources. These can be applied using the `server.ingress.annotations` parameter.
+To enable access from external resources, an Ingress resource is created. The configuration necessary for each Ingress resource is primarily dependent on the specific Ingress Controller being used. In most cases, implementation specific configuration is specified as annotations on the Ingress resources. These can be applied using the `server.ingress.annotations` parameter.

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.2](https://img.shields.io/badge/AppVersion-1.0.2-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 
@@ -109,7 +109,7 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"gcr.io"` |  |
 | server.image.repository | string | `"projectsigstore/rekor-server"` |  |
-| server.image.version | string | `"sha256:441da6a9c40ace07f72ed88790f2248a64c266a7e56ccfd7914080ee61432342"` | `"v1.0.0"` |
+| server.image.version | string | `"sha256:f7e6975041b9b6f3afdc7d6a1a87de43098ce8d83eb1958ea097ebfcb5537658"` | `"v1.0.1"` |
 | server.ingress.annotations | object | `{}` |  |
 | server.ingress.className | string | `"nginx"` |  |
 | server.ingress.enabled | bool | `true` |  |

--- a/charts/rekor/templates/_helpers.tpl
+++ b/charts/rekor/templates/_helpers.tpl
@@ -47,6 +47,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create a fully qualified Rekor backfillredis name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "rekor.backfillredis.fullname" -}}
+{{- if .Values.backfillredis.fullnameOverride -}}
+{{- .Values.backfillredis.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.backfillredis.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.backfillredis.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 Create a fully qualified Rekor server name.
@@ -117,7 +134,7 @@ Return the hostname for redis
 */}}
 {{- define "redis.hostname" -}}
 {{- default (include "rekor.redis.fullname" .) .Values.redis.hostname }}
-{{- end -}} 
+{{- end -}}
 
 {{/*
 Create labels for rekor components
@@ -226,8 +243,6 @@ Create the name of the service account to use for the createtree component
     {{ default "default" .Values.createtree.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
-
-
 
 {{/*
 Create the name of the service account to use for the server component

--- a/charts/rekor/templates/backfillredis/backfill-job.yaml
+++ b/charts/rekor/templates/backfillredis/backfill-job.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.backfillredis.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "rekor.backfillredis.fullname" . }}
+{{ include "rekor.namespace" . | indent 2 }}
+  labels:
+    {{- include "rekor.labels" . | nindent 4 }}
+{{- if .Values.backfillredis.annotations }}
+  annotations:
+{{ toYaml .Values.backfillredis.annotations | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.backfillredis.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.backfillredis.ttlSecondsAfterFinished }}
+{{- end }}
+  template:
+    spec:
+      serviceAccountName: {{ template "rekor.serviceAccountName.server" . }}
+      restartPolicy: Never
+      containers:
+        - name: {{ template "rekor.backfillredis.fullname" . }}
+          image: "{{ template "rekor.image" .Values.backfillredis.image }}"
+          imagePullPolicy: "{{ .Values.backfillredis.image.pullPolicy }}"
+          args: [
+            "--hostname={{ template "redis.hostname" . }}",
+            "--port={{ .Values.redis.port }}",
+            "--rekor-address={{ .Values.backfillredis.rekorAddress }}",
+            "--start={{ .Values.backfillredis.startIndex }}",
+            "--end={{ .Values.backfillredis.endIndex }}",
+          ]
+    {{- if .Values.backfillredis.securityContext }}
+      securityContext:
+{{ toYaml .Values.backfillredis.securityContext | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -157,6 +157,24 @@ createtree:
     runAsUser: 65533
   resources: {}
   annotations: {}
+# Configure backfillredis to repair indices that were not inserted into Redis.
+backfillredis:
+  name: backfillredis
+  enabled: false
+  image:
+    registry: ghcr.io
+    repository: sigstore/rekor/backfill-redis
+    pullPolicy: IfNotPresent
+    # v1.0.1
+    version: "sha256:15f070c4b853f38773d253ebd39957de5c3beffc1699ba574db98e3679336af1"
+  ttlSecondsAfterFinished: 3600
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65533
+  rekorAddress: rekor.rekor-system.svc
+  startIndex: -1
+  endIndex: -1
+  resources: {}
 
 # Configure Trillian dependency
 trillian:


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

We need to run a job in the cluster to backfill redis. The code is here:
https://github.com/sigstore/rekor/pull/1163

So this wraps it in a helm chart

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
