### PR TITLE
policy-controller webhook deployment volumes

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.3.3
+version: 0.3.4
 appVersion: 0.4.1
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -1,6 +1,6 @@
 # policy-controller
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1](https://img.shields.io/badge/AppVersion-0.4.1-informational?style=flat-square)
 
 The Helm chart for Policy  Controller
 
@@ -72,6 +72,8 @@ The Helm chart for Policy  Controller
 | webhook.service.port | int | `443` |  |
 | webhook.service.type | string | `"ClusterIP"` |  |
 | webhook.serviceAccount.annotations | object | `{}` |  |
+| webhook.volumeMounts | list | `[]` |  |
+| webhook.volumes | list | `[]` |  |
 
 ### Deploy `policy-controller` Helm Chart
 

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -112,6 +112,9 @@ spec:
           # Failing to provide a writable $HOME can cause TUF client initialization to panic
           - mountPath: /home/nonroot
             name: writable-home-dir
+          {{- with .Values.webhook.volumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- if .Values.webhook.securityContext.enabled }}
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
@@ -126,3 +129,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: writable-home-dir
+      {{- with .Values.webhook.volumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -273,6 +273,18 @@
                             "type": "object"
                         }
                     }
+                },
+                "volumeMounts": {
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "volumes": {
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 }
             }
         }

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -79,6 +79,8 @@ webhook:
     # For nodeport, specify the following:
     #   type: NodePort
     #   nodePort: <port-number>
+  volumeMounts: []
+  volumes: []
 
 ## common node selector for all the pods
 commonNodeSelector: {}


### PR DESCRIPTION
Add optional additional volume configuration to policy-controller webhook deployment

## Description of the change

Add additional vomues and volumeMounts options to allow for things such as CA Certs to be added to the policy-controller webhook deployment

## Existing or Associated Issue(s)

Resolves #396

## Additional Information

Validated in an environment with a mirrored sigstore-tuf-root that is available over https with a certificate signed by a custom Root CA. By mounting the custom root CA certificate under `/etc/ssl/certs` the mirror x509 cert can be trusted

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
