### PR TITLE
Refactor GH workflows (#1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Lint Charts
+name: Test Charts
 
 on:
   pull_request:
@@ -13,8 +13,6 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           fetch-depth: 0
-
-      - uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # pin@v2.5.0
 
       - name: Set up Helm
         uses: azure/setup-helm@f382f75448129b3be48f8121b9857be18d815a82 # pin@v3.4


### PR DESCRIPTION
* Removing redundant step
* Rename workflow to match steps

Signed-off-by: Tahir Raza <1529130+tahirraza@users.noreply.github.com>

## Description of the change

- Removing cosign install step as it was not being used.
- Updated the name of workflow `Lint Chart` -> `Test Chart`,  since it was doing `linting` plus ` install` of helm charts.

**Suggestion**: Perhaps, break down the workflow into separate `lint.yaml` and `e2e.yaml`.

## Existing or Associated Issue(s)
None

## Additional Information
Refactoring of test workflow

## Test Result
````bash
------------------------------------------------------------------------------------------------------------------------
 ✔︎ ctlog => (version: "0.2.34", path: "charts/ctlog")
 ✔︎ fulcio => (version: "2.0.0", path: "charts/fulcio")
 ✔︎ policy-controller => (version: "0.3.4", path: "charts/policy-controller")
 ✔︎ rekor => (version: "1.0.0", path: "charts/rekor")
 ✔︎ scaffold => (version: "0.4.1", path: "charts/scaffold")
 ✔︎ sigstore-prober => (version: "0.0.9", path: "charts/sigstore-prober")
 ✔︎ trillian => (version: "0.1.13", path: "charts/trillian")
 ✔︎ tuf => (version: "0.1.4", path: "charts/tuf")
 ✔︎ updatetree => (version: "0.0.4", path: "charts/updatetree")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
````