### PR TITLE
Trillian: Add ability to specify custom storage system

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.1.13
+version: 0.1.14
 
 keywords:
   - security

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
@@ -167,3 +167,5 @@ helm uninstall [RELEASE_NAME]
 | mysql.strategy.type | string | `"Recreate"` |  |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"trillian-system"` |  |
+| storageSystem.driver | string | `"mysql"` |  |
+| storageSystem.envCredentials | string | `nil` |  |

--- a/charts/trillian/templates/trillian-log-server/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-server/deployment.yaml
@@ -68,25 +68,7 @@ spec:
           args:
 {{  include "trillian.logServer.args" . | indent 12 }}
           env:
-            - name: MYSQL_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "mysql.secretName" . }}
-                  key: mysql-user
-            - name: MYSQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "mysql.secretName" . }}
-                  key: mysql-password
-            - name: MYSQL_DATABASE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "mysql.secretName" . }}
-                  key: mysql-database
-            - name: MYSQL_HOSTNAME
-              value: {{ template "mysql.hostname" . }}
-            - name: MYSQL_PORT
-              value: {{ .Values.mysql.port | quote }}
+{{- include "trillian.storageSystem.envCredentials" . | indent 12}}
           ports:
 {{- include "trillian.containerPorts" .Values.logServer.service.ports | indent 12 }}
 {{- if .Values.logServer.livenessProbe }}

--- a/charts/trillian/templates/trillian-log-signer/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-signer/deployment.yaml
@@ -68,25 +68,7 @@ spec:
           args:
 {{  include "trillian.logSigner.args" . | indent 12 }}
           env:
-            - name: MYSQL_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "mysql.secretName" . }}
-                  key: mysql-user
-            - name: MYSQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "mysql.secretName" . }}
-                  key: mysql-password
-            - name: MYSQL_DATABASE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "mysql.secretName" . }}
-                  key: mysql-database
-            - name: MYSQL_HOSTNAME
-              value: {{ template "mysql.hostname" . }}
-            - name: MYSQL_PORT
-              value: {{ .Values.mysql.port | quote }}
+{{- include "trillian.storageSystem.envCredentials" . | indent 12}}
           ports:
 {{- include "trillian.containerPorts" .Values.logSigner.service.ports | indent 12 }}
 {{- if .Values.logSigner.livenessProbe }}

--- a/charts/trillian/values.schema.json
+++ b/charts/trillian/values.schema.json
@@ -195,5 +195,9 @@
             "annotations": {}
         }
     },
-    "forceNamespace": ""
+    "forceNamespace": "",
+    "storageSystem": {
+        "driver": "mysql",
+        "envCredentials": null
+    }
 }

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -15,6 +15,9 @@ initContainerImage:
     version: "sha256:7d921b6d368fb1736cb0832c6f57e426c161593c075847af3378eb3185801cea"
     imagePullPolicy: IfNotPresent
 
+storageSystem:
+  driver: mysql
+  envCredentials: null
 mysql:
   gcp:
     enabled: false


### PR DESCRIPTION
## Description of the change

Trillian: Add ability to specify custom storage system

Currently, the Trillian installation is hard-coded to use the mysql
storage system. While this is mostly fine (it is the most common and
used storage system for Trillian after all!), this makes it non trivial
to try custom backends for Trillian.

There is work on the way to introduce [a CockroachDB storage system for
Trillian](https://github.com/google/trillian/pull/2834). And, while this
is currently not usable using the mainline Trillian image, it is
possible to try out if one specifies a custom image for trillian.

To enable this, some variables were introduced:

* `storageSystem.driver`: defines the storage backend to use for both the log
  signer and the log server. Defaults to `mysql`.

* `storageSystem.envCredentials`: is the kubernetes deployment
  definition of environment variables to aide the log signer in connecting to the
  desired database. When set to `null` it defaults to the environment
  variables used by MySQL:

A values file that would take this work into use would look as follows:

```yaml
storageSystem:
  driver: crdb
  envCredentials:
    - name: CRDB_USER
      valueFrom:
        secretKeyRef:
          name: mySecret
          key: crdb-user
    - name: CRDB_PASSWORD
      valueFrom:
        secretKeyRef:
          name: mySecret
          key: crdb-password
    - name: CRDB_HOST
      value: crdb.trillian.svc.cluster.local
logServer:
  image:
    registry: ghcr.io
    repository: equinixmetal-security/trillian-log-server
    version: latest
  extraArgs:
    - "--crdb-uri=postgres://$(CRDB_USER):$(CRDB_PASSWORD)@$(CRDB_HOST):26257/"
logSigner:
  image:
    registry: ghcr.io
    repository: equinixmetal-security/trillian-log-signer
    version: latest
  extraArgs:
    - "--crdb-uri=postgres://$(CRDB_USER):$(CRDB_PASSWORD)@$(CRDB_HOST):26257/"
mysql:
  enabled: false
```

## Existing or Associated Issue(s)

## Additional Information

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
