### PR TITLE
Added common chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ NOTE: The public key that was used to sign a particular chart may not be identic
 
 ## Charts
 
+* [common](charts/common)
 * [ctlog](charts/ctlog)
 * [fulcio](charts/fulcio)
 * [policy-controller](charts/policy-controller)

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: common
+description: A Library Helm Chart containing common logic for use by Sigstore charts
+
+type: library
+
+version: 0.1.0
+
+keywords:
+  - common
+  - helper
+  - template
+  - function
+
+home: https://sigstore.dev/
+
+maintainers:
+  - name: The Sigstore Authors
+
+annotations:
+  artifacthub.io/license: Apache-2.0

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,0 +1,80 @@
+# common
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+
+A Library Helm Chart containing common logic for use by Sigstore charts
+
+**Homepage:** <https://sigstore.dev/>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| The Sigstore Authors |  |  |
+
+----------------------------------------------
+
+
+## Named Templates
+
+### Images
+
+| Name                  | Description                                                                      |      Expected Input                |
+|-----------------------|----------------------------------------------------------------------------------|------------------------------------|
+| `common.images.image` | Create a fully qualified image reference. see [Image](#image) for the structure. | `.Values.image` Reference to Image |
+
+### Labels
+
+| Name                           | Description                                 | Expected Input        |
+|--------------------------------|---------------------------------------------|-----------------------|
+| `common.labels.labels`         | Returns standard Kubernetes labels          | `.` Chart context     |
+| `common.labels.selectorLabels` | Returns specific labels used for selectors  | `.` Chart context     |
+
+### Names
+
+| Name                              | Description                                                                                       | Expected Input                                       |
+|-----------------------------------|---------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| `common.names.name`               | Returns the name of the chart                                                                     | `.` Chart context                                    |
+| `common.names.chart`              | Returns the name of the chart used by the chart label                                             | `.` Chart context                                    |
+| `common.names.fullname`           | Returns the fully qualified application name                                                      | `.` Chart context                                    |
+| `common.names.managedfullname`    | Returns the fully qualified application name by providing a context to use                        | `dict "content" .Values.content "context" $`         |
+| `common.names.fullnameSuffix`     | Returns the fully qualified application name appended by a provided suffix                        | `dict "suffix" "suffix-value "context" $`            |
+| `common.names.rawnamespace`       | Returns the raw namespace if set with forceNamespace or .Release.Namespace is set                 | `.` Chart context                                    |
+| `common.names.serviceAccountName` | Returns the name of the Service account. See [ServiceAccount](#serviceaccount) for the structure. | `.Values.serviceAccount` Reference to ServiceAccount |
+
+## Input Schemas 
+
+The following are a set of schemas that are expected within applicable Named Templates
+
+### Image
+
+```yaml
+registry:
+  type: string
+  description: Registry where the image is located
+  example: gcr.io
+
+repository:
+  type: string
+  description: Repository and image name
+  example: sigstore/scaffolding/ct_server
+
+version:
+  type: string
+  description: image tag or digest
+  example: 1.0.0
+```
+
+### ServiceAccount
+
+```yaml
+name:
+  type: string
+  description: Name of the ServiceAccount
+  example: myApp
+
+create:
+  type: boolean
+  description: Create a dedicated ServiceAccount
+  example: true
+```

--- a/charts/common/templates/_images.tpl
+++ b/charts/common/templates/_images.tpl
@@ -1,0 +1,10 @@
+{{/*
+Create the image path for the passed in image field
+*/}}
+{{- define "common.images.image" -}}
+{{- if eq (substr 0 7 .version) "sha256:" -}}
+{{- printf "%s/%s@%s" .registry .repository .version -}}
+{{- else -}}
+{{- printf "%s/%s:%s" .registry .repository .version -}}
+{{- end -}}
+{{- end -}}

--- a/charts/common/templates/_labels.tpl
+++ b/charts/common/templates/_labels.tpl
@@ -1,0 +1,19 @@
+{{/*
+Common labels
+*/}}
+{{- define "common.labels.labels" -}}
+helm.sh/chart: {{ include "common.names.chart" . }}
+{{ include "common.labels.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "common.labels.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/common/templates/_names.tpl
+++ b/charts/common/templates/_names.tpl
@@ -1,0 +1,103 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "common.names.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "common.names.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "common.names.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name by providing content that should be used to produce the final value.
+
+Usage:
+{{ include "common.names.managedfullname" (dict "content" .Values.content "context" $) }}
+*/}}
+{{- define "common.names.managedfullname" -}}
+{{- if .content.fullnameOverride -}}
+{{- .content.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .context.Chart.Name .content.nameOverride -}}
+{{- if contains $name .context.Release.Name -}}
+{{- printf "%s-%s" .context.Release.Name .content.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .context.Release.Name $name .content.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Append a provided suffix to a fully qualified app name.
+
+Usage:
+{{ include "common.names.fullnameSuffix" (dict "suffix" "suffix-value "context" $) }}
+*/}}
+{{- define "common.names.fullnameSuffix" -}}
+{{- (printf "%s-%s" (include "common.names.fullname" .context) .suffix) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Define the raw namespace template if set with forceNamespace or .Release.Namespace is set
+*/}}
+{{- define "common.names.rawnamespace" -}}
+{{- if .Values.forceNamespace -}}
+{{ print .Values.forceNamespace }}
+{{- else -}}
+{{ print .Release.Namespace }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define the common.names.namespace template if set with forceNamespace or .Release.Namespace is set
+*/}}
+{{- define "common.names.namespace" -}}
+{{ printf "namespace: %s" (include "common.names.rawnamespace" .) }}
+{{- end -}}
+
+
+{{/*
+Create the name of the service account to use
+
+Usage:
+
+To specify a value other than using the fullname, a dict of values must be provided
+{{ include "common.names.serviceAccountName" (dict "serviceAccount" .Values.serviceAccount "context" $) }}
+*/}}
+{{- define "common.names.serviceAccountName" -}}
+{{- if .serviceAccount }}
+{{- if .serviceAccount.create }}
+{{- default (include "common.names.fullname" (default $ .context)) .serviceAccount.name }}
+{{- else }}
+{{- default "default" .serviceAccount.name }}
+{{- end }}
+{{- else }}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/ct-install.yaml
+++ b/ct-install.yaml
@@ -1,6 +1,7 @@
 chart-dirs:
   - charts
 excluded-charts:
+  - common
   - ctlog
   - fulcio
   - scaffold


### PR DESCRIPTION
## Description of the change

Adds a common chart of reusable partials

## Existing or Associated Issue(s)

#337 

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
