### PR TITLE
WIP: Incorporated ctlog with new common chart

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -16,6 +16,11 @@ home: https://sigstore.dev/
 maintainers:
   - name: The Sigstore Authors
 
+dependencies:
+  - name: common
+    version: 0.1.0
+    repository: https://sigstore.github.io/helm-charts
+
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |

--- a/charts/ctlog/templates/_helpers.tpl
+++ b/charts/ctlog/templates/_helpers.tpl
@@ -1,106 +1,16 @@
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "ctlog.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "ctlog.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
-Define the raw ctlog.namespace template if set with forceNamespace or .Release.Namespace is set
-*/}}
-{{- define "ctlog.rawnamespace" -}}
-{{- if .Values.forceNamespace -}}
-{{ print .Values.forceNamespace }}
-{{- else -}}
-{{ print .Release.Namespace }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Define the ctlog.namespace template if set with forceNamespace or .Release.Namespace is set
-*/}}
-{{- define "ctlog.namespace" -}}
-{{ printf "namespace: %s" (include "ctlog.rawnamespace" .) }}
-{{- end -}}
-
-{{/*
 Create a fully qualified createctconfig name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "ctlog.createctconfig.fullname" -}}
-{{- if .Values.createctconfig.fullnameOverride -}}
-{{- .Values.createctconfig.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.createctconfig.name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.createctconfig.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{  include "common.names.managedfullname" (dict "content" .Values.createctconfig "context" $) }}
 {{- end -}}
 
 {{/*
 Create a fully qualified createtree name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "ctlog.createtree.fullname" -}}
-{{- if .Values.createtree.fullnameOverride -}}
-{{- .Values.createtree.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.createtree.name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.createtree.name | trunc 63 | trimSuffix "-" -}}
+{{  include "common.names.managedfullname" (dict "content" .Values.createtree "context" $) }}
 {{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "ctlog.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Common labels
-*/}}
-{{- define "ctlog.labels" -}}
-helm.sh/chart: {{ include "ctlog.chart" . }}
-{{ include "ctlog.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "ctlog.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "ctlog.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
 
 {{/*
 Server Arguments
@@ -125,58 +35,49 @@ Server Arguments
 Create the name of the service account to use
 */}}
 {{- define "ctlog.serviceAccountName" -}}
-{{- if .Values.server.serviceAccount.create }}
-{{- default (include "ctlog.fullname" .) .Values.server.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.server.serviceAccount.name }}
-{{- end }}
+{{  include "common.names.serviceAccountName" (dict "serviceAccount" .Values.server.serviceAccount "context" $) }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use for the createctconfig component
 */}}
 {{- define "ctlog.serviceAccountName.createctconfig" -}}
-{{- if .Values.createctconfig.serviceAccount.create -}}
-    {{ default (include "ctlog.createctconfig.fullname" .) .Values.createctconfig.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.createctconfig.serviceAccount.name }}
-{{- end -}}
+{{  include "common.names.serviceAccountName" (dict "serviceAccount" .Values.createctconfig.serviceAccount "context" $) }}
 {{- end -}}
 
 {{/*
 Create the name of the service account to use for the createtree component
 */}}
 {{- define "ctlog.serviceAccountName.createtree" -}}
-{{- if .Values.createtree.serviceAccount.create -}}
-    {{ default (include "ctlog.createtree.fullname" .) .Values.createtree.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.createtree.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the image path for the passed in image field
-*/}}
-{{- define "ctlog.image" -}}
-{{- if eq (substr 0 7 .version) "sha256:" -}}
-{{- printf "%s/%s@%s" .registry .repository .version -}}
-{{- else -}}
-{{- printf "%s/%s:%s" .registry .repository .version -}}
-{{- end -}}
+{{  include "common.names.serviceAccountName" (dict "serviceAccount" .Values.createtree.serviceAccount "context" $) }}
 {{- end -}}
 
 {{/*
 Create the name of the config
 */}}
 {{- define "ctlog.config" -}}
-{{ printf "%s-config" (include "ctlog.fullname" .) }}
+{{  include "common.names.fullnameSuffix" (dict "suffix" "config" "context" $) }}
+{{- end }}
+
+{{/*
+Create the name of the cm-operator
+*/}}
+{{- define "ctlog.cm-operator" -}}
+{{  include "common.names.fullnameSuffix" (dict "suffix" "cm-operator" "context" $) }}
+{{- end }}
+
+{{/*
+Create the name of the secret-operator
+*/}}
+{{- define "ctlog.secret-operator" -}}
+{{  include "common.names.fullnameSuffix" (dict "suffix" "secret-operator" "context" $) }}
 {{- end }}
 
 {{/*
 Create the name of the secret
 */}}
 {{- define "ctlog.secret" -}}
-{{ printf "%s-secret" (include "ctlog.fullname" .) }}
+{{  include "common.names.fullnameSuffix" (dict "suffix" "secret" "context" $) }}
 {{- end }}
 
 {{/*
@@ -194,7 +95,7 @@ Return the appropriate apiVersion for ingress.
 */}}
 {{- define "ctlog.server.ingress.backend" -}}
 service:
-  name: {{ template "ctlog.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   port:
     number: {{ (index .Values.server.service.ports 0).port | int }}
 {{- end -}}

--- a/charts/ctlog/templates/cm-operator-role.yaml
+++ b/charts/ctlog/templates/cm-operator-role.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "ctlog.fullname" . }}-cm-operator
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "ctlog.cm-operator" . }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["configmaps"]

--- a/charts/ctlog/templates/cm-operator-rolebinding.yaml
+++ b/charts/ctlog/templates/cm-operator-rolebinding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "ctlog.fullname" . }}-cm-operator
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "ctlog.cm-operator" . }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "ctlog.fullname" . }}-cm-operator
+  name: {{ template "ctlog.cm-operator" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "ctlog.serviceAccountName.createtree" . }}
-{{ include "ctlog.namespace" . | indent 4 }}
+{{ include "common.names.namespace" . | indent 4 }}

--- a/charts/ctlog/templates/createctconfig-job.yaml
+++ b/charts/ctlog/templates/createctconfig-job.yaml
@@ -2,9 +2,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "ctlog.createctconfig.fullname" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 {{- if .Values.createctconfig.annotations }}
   annotations:
 {{ toYaml .Values.createctconfig.annotations | indent 4 }}
@@ -21,7 +21,7 @@ spec:
       automountServiceAccountToken: {{ .Values.createctconfig.serviceAccount.mountToken }}
       initContainers:
         - name: "wait-for-createtree-configmap"
-          image: "{{ template "ctlog.image" .Values.createctconfig.initContainerImage.curl }}"
+          image: "{{ template "common.images.image" .Values.createctconfig.initContainerImage.curl }}"
           imagePullPolicy: {{ .Values.createctconfig.initContainerImage.curl.imagePullPolicy }}
           command: ["sh", "-c", "until curl --fail --header \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --max-time 10 https://kubernetes.default.svc/api/v1/namespaces/$(NAMESPACE)/configmaps/{{ template "ctlog.config" . }} | grep '\"treeID\":'; do echo waiting for Configmap {{ template "ctlog.config" . }}; sleep 5; done;"]
           env:
@@ -31,7 +31,7 @@ spec:
                   fieldPath: metadata.namespace
       containers:
         - name: {{ template "ctlog.createctconfig.fullname" . }}
-          image: "{{ template "ctlog.image" .Values.createctconfig.image }}"
+          image: "{{ template "common.images.image" .Values.createctconfig.image }}"
           imagePullPolicy: "{{ .Values.createctconfig.image.pullPolicy }}"
           args: [
             "--configmap={{ template "ctlog.config" . }}",

--- a/charts/ctlog/templates/createctconfig-serviceaccount.yaml
+++ b/charts/ctlog/templates/createctconfig-serviceaccount.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "ctlog.serviceAccountName.createctconfig" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
   annotations:
 {{ toYaml .Values.createctconfig.serviceAccount.annotations | indent 4 }}

--- a/charts/ctlog/templates/createtree-job.yaml
+++ b/charts/ctlog/templates/createtree-job.yaml
@@ -2,9 +2,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "ctlog.createtree.fullname" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 {{- if .Values.createtree.annotations }}
   annotations:
 {{ toYaml .Values.createtree.annotations | indent 4 }}
@@ -20,7 +20,7 @@ spec:
       automountServiceAccountToken: {{ .Values.createtree.serviceAccount.mountToken }}
       containers:
         - name: {{ template "ctlog.createtree.fullname" . }}
-          image: "{{ template "ctlog.image" .Values.createtree.image }}"
+          image: "{{ template "common.images.image" .Values.createtree.image }}"
           imagePullPolicy: "{{ .Values.createtree.image.pullPolicy }}"
           env:
           - name: NAMESPACE

--- a/charts/ctlog/templates/createtree-serviceaccount.yaml
+++ b/charts/ctlog/templates/createtree-serviceaccount.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "ctlog.serviceAccountName.createtree" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
   annotations:
 {{ toYaml .Values.createtree.serviceAccount.annotations | indent 4 }}

--- a/charts/ctlog/templates/ctlog-configmap.yaml
+++ b/charts/ctlog/templates/ctlog-configmap.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "ctlog.config" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 data:
   __placeholder: |
     ###################################################################

--- a/charts/ctlog/templates/ctlog-deployment.yaml
+++ b/charts/ctlog/templates/ctlog-deployment.yaml
@@ -1,15 +1,15 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "ctlog.fullname" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "common.names.fullname" . }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.server.replicaCount }}
   selector:
     matchLabels:
-      {{- include "ctlog.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -18,12 +18,12 @@ spec:
         {{- toYaml .Values.server.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "ctlog.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "ctlog.serviceAccountName" . }}
       containers:
-        - name: {{ template "ctlog.fullname" . }}
-          image: "{{ template "ctlog.image" .Values.server.image }}"
+        - name: {{ template "common.names.fullname" . }}
+          image: "{{ template "common.images.image" .Values.server.image }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           args:
 {{  include "ctlog.server.args" . | indent 12 }}

--- a/charts/ctlog/templates/ctlog-ingress.yaml
+++ b/charts/ctlog/templates/ctlog-ingress.yaml
@@ -3,9 +3,9 @@ apiVersion: "networking.k8s.io/v1"
 kind: Ingress
 metadata:
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
-  name: {{ template "ctlog.fullname" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}
+{{ include "common.names.namespace" . | indent 2 }}
   annotations:
 {{ toYaml .Values.server.ingress.annotations | indent 4 }}
 spec:

--- a/charts/ctlog/templates/ctlog-service.yaml
+++ b/charts/ctlog/templates/ctlog-service.yaml
@@ -6,15 +6,15 @@ metadata:
 {{ toYaml .Values.server.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 {{- if .Values.server.service.labels }}
 {{ toYaml .Values.server.service.labels | indent 4 }}
 {{- end }}
-  name: {{ template "ctlog.fullname" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "common.names.fullname" . }}
+{{ include "common.names.namespace" . | indent 2 }}
 spec:
   ports:
     {{- tpl (toYaml .Values.server.service.ports) . | nindent 4 }}
   selector:
-    {{- include "ctlog.selectorLabels" . | nindent 4 }}
+    {{- include "common.labels.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.server.service.type }}"

--- a/charts/ctlog/templates/ctlog-serviceaccount.yaml
+++ b/charts/ctlog/templates/ctlog-serviceaccount.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "ctlog.serviceAccountName" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
   annotations:
 {{ toYaml .Values.server.serviceAccount.annotations | indent 4 }}

--- a/charts/ctlog/templates/secret-operator-role.yaml
+++ b/charts/ctlog/templates/secret-operator-role.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "ctlog.fullname" . }}-secret-operator
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "ctlog.secret-operator" . }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["configmaps"]

--- a/charts/ctlog/templates/secret-operator-rolebinding.yaml
+++ b/charts/ctlog/templates/secret-operator-rolebinding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "ctlog.fullname" . }}-secret-operator
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "ctlog.secret-operator" . }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "ctlog.fullname" . }}-secret-operator
+  name: {{ template "ctlog.secret-operator" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "ctlog.serviceAccountName.createctconfig" . }}
-{{ include "ctlog.namespace" . | indent 4 }}
+{{ include "common.names.namespace" . | indent 4 }}


### PR DESCRIPTION
## Description of the change

Incorporation of `ctlog` chart with newly created `common` chart to demonstrate integration

## Existing or Associated Issue(s)

#416 #337 

## Additional Information

Requires #416 be merged first

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
