### PR TITLE
Add createctconfig.secret option to ctlog helm chart

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.34
+version: 0.2.35
 appVersion: 0.3.0
 
 keywords:

--- a/charts/ctlog/templates/createctconfig-job.yaml
+++ b/charts/ctlog/templates/createctconfig-job.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: "{{ .Values.createctconfig.image.pullPolicy }}"
           args: [
             "--configmap={{ template "ctlog.config" . }}",
-            "--secret={{ template "ctlog.secret" . }}",
+            "--secret={{ .Values.createctconfig.secret}}",
           {{- if .Values.createctconfig.privateSecret }}
             "--private-secret={{ .Values.createctconfig.privateSecret }}",
           {{- end }}

--- a/charts/ctlog/values.schema.json
+++ b/charts/ctlog/values.schema.json
@@ -833,6 +833,11 @@
                         true
                     ]
                 },
+               "secret":  {
+                    "type": "string",
+                    "default": "ctlog-secret",
+                    "title": "The secret passed in to the createctconfig job via the --secret flag"
+                },
                 "replicaCount": {
                     "type": "integer",
                     "default": 0,

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -71,6 +71,7 @@ createtree:
 
 createctconfig:
   enabled: true
+  secret: ctlog-secret-233
   replicaCount: 1
   backoffLimit: 6
   name: createctconfig


### PR DESCRIPTION
Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

cc @pwelch @vaikas I think just putting the secret option under createctconfig might be easier, but wanted to make sure it'll work with the different shards?
