### PR TITLE
Fix template error in rekor chart

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.0.2
 
 keywords:

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -71,6 +71,7 @@ server:
     className: "nginx"
     hosts:
       - path: /
+        host: root
     annotations: {}
     tls: []
   service:


### PR DESCRIPTION
The ingress host name is required, so we should have a default value for the name since we have a default ingress rule.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

