### PR TITLE
policy-controller: Make webhook namespace selector configurable

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.3.6
+version: 0.3.7
 appVersion: 0.4.2
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -75,6 +75,9 @@ The Helm chart for Policy  Controller
 | webhook.serviceAccount.annotations | object | `{}` |  |
 | webhook.volumeMounts | list | `[]` |  |
 | webhook.volumes | list | `[]` |  |
+| webhook.namespaceSelector.matchExpressions[0].key | string | `"policy.sigstore.dev/include"` |  |
+| webhook.namespaceSelector.matchExpressions[0].operator | string | `"In"` |  |
+| webhook.namespaceSelector.matchExpressions[0].values[0] | string | `"true"` |  |
 
 ### Deploy `policy-controller` Helm Chart
 

--- a/charts/policy-controller/templates/_helpers.tpl
+++ b/charts/policy-controller/templates/_helpers.tpl
@@ -126,3 +126,16 @@ Create the image path for the passed in policy-webhook image field
 {{- printf "%s:%s" .repository .version -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+*/}}
+{{- define "policy-controller.webhook.namespaceSelector" -}}
+{{- if .Values.webhook.namespaceSelector }}
+{{ toYaml .Values.webhook.namespaceSelector }}
+{{- else }}
+matchExpressions:
+  - key: policy.sigstore.dev/include
+    operator: In
+    values: ["true"]
+{{- end }}
+{{- end -}}

--- a/charts/policy-controller/templates/webhook/webhook_mutating.yaml
+++ b/charts/policy-controller/templates/webhook/webhook_mutating.yaml
@@ -5,11 +5,7 @@ metadata:
 webhooks:
 - name: {{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
   namespaceSelector:
-    # The webhook should only apply to things that opt-in
-    matchExpressions:
-    - key: policy.sigstore.dev/include
-      operator: In
-      values: ["true"]
+{{- include "policy-controller.webhook.namespaceSelector" . | indent 4 }}
   admissionReviewVersions: [v1]
   clientConfig:
     service:

--- a/charts/policy-controller/templates/webhook/webhook_validating.yaml
+++ b/charts/policy-controller/templates/webhook/webhook_validating.yaml
@@ -5,11 +5,7 @@ metadata:
 webhooks:
 - name: {{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
   namespaceSelector:
-    # The webhook should only apply to things that opt-in
-    matchExpressions:
-    - key: policy.sigstore.dev/include
-      operator: In
-      values: ["true"]
+{{- include "policy-controller.webhook.namespaceSelector" . | indent 4 }}
   admissionReviewVersions: [v1]
   clientConfig:
     service:

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -290,6 +290,9 @@
                 },
                 "volumes": {
                     "type": "array"
+                },
+                "namespaceSelector": {
+                    "type": "object"
                 }
             }
         }

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -82,6 +82,11 @@ webhook:
     #   nodePort: <port-number>
   volumeMounts: []
   volumes: []
+  namespaceSelector:
+    matchExpressions:
+      - key: policy.sigstore.dev/include
+        operator: In
+        values: ["true"]
 
 ## common node selector for all the pods
 commonNodeSelector: {}


### PR DESCRIPTION
## Description of the change

This allows for more flexibility when setting up the namespace selector.
e.g. folks are able to set up whatever configuration they see fit for
their deployments.

This introduces two new components to the helmm chart:

* A `policy-controller.webhook.namespaceSelector` template which may be
  leveraged as an `include` statement.

* A new key with the path `webhook.namespaceSelector` which allows for
  configuring the aforementioned namespace selector.

The default is left as it was before, this way it won't affect new
deployments and upgrades will be seamless.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
