### PR TITLE
Trillian: Make quota system configurable

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.1.14
+version: 0.1.15
 
 keywords:
   - security

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -167,5 +167,6 @@ helm uninstall [RELEASE_NAME]
 | mysql.strategy.type | string | `"Recreate"` |  |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"trillian-system"` |  |
+| quotaSystem.driver | string | `"mysql"` |  |
 | storageSystem.driver | string | `"mysql"` |  |
 | storageSystem.envCredentials | string | `nil` |  |

--- a/charts/trillian/templates/_helpers.tpl
+++ b/charts/trillian/templates/_helpers.tpl
@@ -24,10 +24,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
-Return the 
+Return the configured storage system
 */}}
 {{- define "trillian.storageSystem" -}}
 {{- default "mysql" .Values.storageSystem.driver }}
+{{- end -}}
+
+{{/*
+Return the configured quota system
+*/}}
+{{- define "trillian.quotaSystem" -}}
+{{- default "mysql" .Values.quotaSystem.driver }}
 {{- end -}}
 
 {{/*
@@ -181,6 +188,7 @@ Log Server Arguments
 */}}
 {{- define "trillian.logServer.args" -}}
 - {{ printf "--storage_system=%s" (include "trillian.storageSystem" .) | quote }}
+- {{ printf "--quota_system=%s" (include "trillian.quotaSystem" .) | quote }}
 {{- if eq (include "trillian.storageSystem" .) "mysql" }}
 - "--mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOSTNAME):$(MYSQL_PORT))/$(MYSQL_DATABASE)"
 {{- end }}
@@ -197,6 +205,7 @@ Log Signer Arguments
 */}}
 {{- define "trillian.logSigner.args" -}}
 - {{ printf "--storage_system=%s" (include "trillian.storageSystem" .) | quote }}
+- {{ printf "--quota_system=%s" (include "trillian.quotaSystem" .) | quote }}
 {{- if eq (include "trillian.storageSystem" .) "mysql" }}
 - "--mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOSTNAME):$(MYSQL_PORT))/$(MYSQL_DATABASE)"
 {{- end }}

--- a/charts/trillian/values.schema.json
+++ b/charts/trillian/values.schema.json
@@ -199,5 +199,8 @@
     "storageSystem": {
         "driver": "mysql",
         "envCredentials": null
+    },
+    "quotaSystem": {
+        "driver": "mysql"
     }
 }

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -18,6 +18,8 @@ initContainerImage:
 storageSystem:
   driver: mysql
   envCredentials: null
+quotaSystem:
+  driver: mysql
 mysql:
   gcp:
     enabled: false


### PR DESCRIPTION
## Description of the change

Similarly to the storage system, one is able to configure the quota
system with different drivers. This enables configuring that through
this helm chart.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
