### PR TITLE
Limit trillian to amd64

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.1.15
+version: 0.1.16
 
 keywords:
   - security

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -68,6 +68,7 @@ helm uninstall [RELEASE_NAME]
 | logServer.image.version | string | `"sha256:75dbbfc4c0b64334b985c4971fe58c30b9dd73d7aa54b15cee61223ff92aebf3"` | v0.9.1 |
 | logServer.livenessProbe | object | `{}` |  |
 | logServer.name | string | `"log-server"` |  |
+| logServer.nodeSelector | object | `{"kubernetes.io/arch":"amd64"}` | Trillian images currently only support amd64 due to the toolbelt/netcat container |
 | logServer.portHTTP | int | `8090` |  |
 | logServer.portRPC | int | `8091` |  |
 | logServer.readinessProbe | object | `{}` |  |
@@ -94,6 +95,7 @@ helm uninstall [RELEASE_NAME]
 | logSigner.image.version | string | `"sha256:b56ed0b7b5e9813c91b208ba6041c9342f9a53162d96943374e59b5289090f1f"` | v0.9.1 |
 | logSigner.livenessProbe | object | `{}` |  |
 | logSigner.name | string | `"log-signer"` |  |
+| logSigner.nodeSelector | object | `{"kubernetes.io/arch":"amd64"}` | Trillian images currently only support amd64 due to the toolbelt/netcat container |
 | logSigner.portHTTP | int | `8090` |  |
 | logSigner.portRPC | int | `8091` |  |
 | logSigner.readinessProbe | object | `{}` |  |

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -20,6 +20,7 @@ storageSystem:
   envCredentials: null
 quotaSystem:
   driver: mysql
+
 mysql:
   gcp:
     enabled: false
@@ -104,6 +105,7 @@ mysql:
     create: true
     name: ""
     annotations: {}
+
 logServer:
   enabled: true
   replicaCount: 1
@@ -116,6 +118,11 @@ logServer:
     pullPolicy: IfNotPresent
     # -- v0.9.1
     version: sha256:75dbbfc4c0b64334b985c4971fe58c30b9dd73d7aa54b15cee61223ff92aebf3
+
+  # -- Trillian images currently only support amd64 due to the toolbelt/netcat container
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
   service:
     type: ClusterIP
     ports:
@@ -135,6 +142,7 @@ logServer:
     create: true
     name: ""
     annotations: {}
+
 logSigner:
   enabled: true
   replicaCount: 1
@@ -148,6 +156,11 @@ logSigner:
     pullPolicy: IfNotPresent
     # -- v0.9.1
     version: sha256:b56ed0b7b5e9813c91b208ba6041c9342f9a53162d96943374e59b5289090f1f
+
+  # -- Trillian images currently only support amd64 due to the toolbelt/netcat container
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
   service:
     type: ClusterIP
     ports:
@@ -163,6 +176,7 @@ logSigner:
     create: true
     name: ""
     annotations: {}
+
 createdb:
   enabled: true
   dbname: trillian


### PR DESCRIPTION
- Limit trillian to amd64
- Bump trillian chart version to v0.1.16

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Due to the toolbelt/netcat initContainer amd64 is the only supported architecture

## Existing or Associated Issue(s)

Resolves #376

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
