### PR TITLE
set default value for createctconfig.secret to preserve historical be…

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.36
+version: 0.2.37
 appVersion: 0.3.0
 
 keywords:

--- a/charts/ctlog/templates/createctconfig-job.yaml
+++ b/charts/ctlog/templates/createctconfig-job.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: "{{ .Values.createctconfig.image.pullPolicy }}"
           args: [
             "--configmap={{ template "ctlog.config" . }}",
-            "--secret={{ .Values.createctconfig.secret}}",
+            "--secret={{ .Values.createctconfig.secret | default (printf "%s-secret" (include "ctlog.fullname" .)) }}",
           {{- if .Values.createctconfig.privateSecret }}
             "--private-secret={{ .Values.createctconfig.privateSecret }}",
           {{- end }}


### PR DESCRIPTION
set default value for createctconfig.secret to preserve historical behavior

Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->
set default value for createctconfig.secret to preserve historical behavior

this will avoid the behavior where if `createctconfig.secret` is not specified, `--secret=` is passed

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
