### PR TITLE
Configure ctlog resources

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.38
+version: 0.2.39
 appVersion: 0.3.0
 
 keywords:

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -28,11 +28,13 @@ Certificate Log
 | createctconfig.initContainerImage.curl.registry | string | `"docker.io"` |  |
 | createctconfig.initContainerImage.curl.repository | string | `"curlimages/curl"` |  |
 | createctconfig.initContainerImage.curl.version | string | `"sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498"` | 7.82.0 |
+| createctconfig.initContainerResources | string | `""` | |
 | createctconfig.logPrefix | string | `"sigstorescaffolding"` |  |
 | createctconfig.name | string | `"createctconfig"` |  |
 | createctconfig.privateKeyPasswordSecretName | string | `""` |  |
 | createctconfig.privateSecret | string | `""` |  |
 | createctconfig.pubkeysecret | string | `"ctlog-public-key"` |  |
+| createctconfig.resources | string | `""` |  |
 | createctconfig.replicaCount | int | `1` |  |
 | createctconfig.securityContext.runAsNonRoot | bool | `true` |  |
 | createctconfig.securityContext.runAsUser | int | `65533` |  |
@@ -76,6 +78,7 @@ Certificate Log
 | server.podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
 | server.portHTTP | int | `6962` |  |
 | server.portHTTPMetrics | int | `6963` |  |
+| server.resources | string | `""` |  |
 | server.replicaCount | int | `1` |  |
 | server.securityContext.runAsNonRoot | bool | `true` |  |
 | server.securityContext.runAsUser | int | `65533` |  |

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -51,6 +51,7 @@ Certificate Log
 | createtree.image.repository | string | `"sigstore/scaffolding/createtree"` |  |
 | createtree.image.version | string | `"sha256:d5776d8a43632291e1c5a22a9266608db0daa0a11663445d701e327f2205974c"` |  |
 | createtree.name | string | `"createtree"` |  |
+| createtree.resources | string | `""` |  |
 | createtree.securityContext.runAsNonRoot | bool | `true` |  |
 | createtree.securityContext.runAsUser | int | `65533` |  |
 | createtree.serviceAccount.annotations | object | `{}` |  |

--- a/charts/ctlog/templates/createctconfig-job.yaml
+++ b/charts/ctlog/templates/createctconfig-job.yaml
@@ -29,6 +29,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+    {{- if .Values.createctconfig.initContainerResources }}
+          resources:
+{{ toYaml .Values.createctconfig.initContainerResources | indent 12 }}
+    {{- end }}
       containers:
         - name: {{ template "ctlog.createctconfig.fullname" . }}
           image: "{{ template "ctlog.image" .Values.createctconfig.image }}"
@@ -61,6 +65,10 @@ spec:
                   name: {{ .Values.createctconfig.privateKeyPasswordSecretName  }}
                   key: password
           {{- end }}
+    {{- if .Values.createctconfig.resources }}
+          resources:
+{{ toYaml .Values.createctconfig.resources | indent 12 }}
+    {{- end }}
     {{- if .Values.createctconfig.securityContext }}
       securityContext:
 {{ toYaml .Values.createctconfig.securityContext | indent 8 }}

--- a/charts/ctlog/templates/createtree-job.yaml
+++ b/charts/ctlog/templates/createtree-job.yaml
@@ -33,6 +33,10 @@ spec:
             "--display_name={{ .Values.createtree.displayName }}",
             "--admin_server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace }}:{{ .Values.trillian.logServer.portRPC}}"
           ]
+    {{- if .Values.createtree.resources }}
+          resources:
+{{ toYaml .Values.createtree.resources | indent 12 }}
+    {{- end }}
     {{- if .Values.createtree.securityContext }}
       securityContext:
 {{ toYaml .Values.createtree.securityContext | indent 8 }}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Adding ability to configure k8s resource requests and limits in all the components of ctlog.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

At present, we cannot configure resource requests and limits for some components like one time jobs, initContainers and some deployments via Sigstore helm charts. This becomes a problem when `ResourceQuota` is defined for namespaces and prevents pods to spin up. It is a best practice to define resource requests and limits for all k8s resources.

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.