### PR TITLE
Configure trillian resources

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 
 keywords:
   - security

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -47,11 +47,13 @@ helm uninstall [RELEASE_NAME]
 | createdb.image.repository | string | `"sigstore/scaffolding/createdb"` |  |
 | createdb.image.version | string | `"sha256:5ec1b95581d238dfbbd8e412422500cc242123078de8aaad23e5f9c65eaf2ba5"` | v0.4.11 |
 | createdb.name | string | `"createdb"` |  |
+| createdb.resources | string | `""` |  |
 | createdb.serviceAccount.annotations | object | `{}` |  |
 | createdb.serviceAccount.create | bool | `false` |  |
 | createdb.serviceAccount.name | string | `""` |  |
 | createdb.ttlSecondsAfterFinished | int | `3600` |  |
 | forceNamespace | string | `""` |  |
+| initContainerResources | string | `""` |  |
 | initContainerImage.curl.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainerImage.curl.registry | string | `"docker.io"` |  |
 | initContainerImage.curl.repository | string | `"curlimages/curl"` |  |

--- a/charts/trillian/templates/createdb/createdb-job.yaml
+++ b/charts/trillian/templates/createdb/createdb-job.yaml
@@ -75,6 +75,10 @@ spec:
           volumeMounts:
             - name: exit-dir
               mountPath: "/var/exitdir"
+    {{- if .Values.createdb.resources }}
+          resources:
+{{ toYaml .Values.createdb.resources | indent 12 }}
+    {{- end }}
     {{- if .Values.createdb.securityContext }}
       securityContext:
 {{ toYaml .Values.createdb.securityContext | indent 8 }}

--- a/charts/trillian/templates/trillian-log-server/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-server/deployment.yaml
@@ -41,6 +41,10 @@ spec:
           image: "{{ template "trillian.image" .Values.initContainerImage.netcat }}"
           imagePullPolicy: {{ .Values.initContainerImage.netcat.imagePullPolicy }}
           command: ["sh", "-c", "until nc -z -w 10 {{ template "mysql.hostname" . }} {{ .Values.mysql.port }}; do echo waiting for {{ template "mysql.hostname" . }}; sleep 5; done;"]
+      {{- if .Values.initContainerResources }}
+          resources:
+{{ toYaml .Values.initContainerResources | indent 12 }}
+      {{- end }}
       {{- if .Values.logServer.extraInitContainers }}
 {{ toYaml .Values.logServer.extraInitContainers | indent 8 }}
       {{- end }}

--- a/charts/trillian/templates/trillian-log-signer/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-signer/deployment.yaml
@@ -41,6 +41,10 @@ spec:
           image: "{{ template "trillian.image" .Values.initContainerImage.netcat }}"
           imagePullPolicy: {{ .Values.initContainerImage.netcat.imagePullPolicy }}
           command: ["sh", "-c", "until nc -z -w 10 {{ template "mysql.hostname" . }} {{ .Values.mysql.port }}; do echo waiting for {{ template "mysql.hostname" . }}; sleep 5; done;"]
+      {{- if .Values.initContainerResources }}
+          resources:
+{{ toYaml .Values.initContainerResources | indent 12 }}
+      {{- end }}
       {{- if .Values.logSigner.extraInitContainers }}
 {{ toYaml .Values.logSigner.extraInitContainers | indent 8 }}
       {{- end }}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Adding ability to configure k8s resource requests and limits in all the components of trillian.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

At present, we cannot configure resource requests and limits for some components like one time jobs, initContainers and some deployments via Sigstore helm charts. This becomes a problem when `ResourceQuota` is defined for namespaces and prevents pods to spin up. It is a best practice to define resource requests and limits for all k8s resources.

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.