### PR TITLE
Configure tuf resources

### DIFF
--- a/charts/tuf/Chart.yaml
+++ b/charts/tuf/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tuf
 description: A framework for securing software update systems - the scaffolding implementation
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.4.6"
 
 home: https://sigstore.dev/

--- a/charts/tuf/README.md
+++ b/charts/tuf/README.md
@@ -26,6 +26,7 @@ A framework for securing software update systems - the scaffolding implementatio
 | deployment.registry | string | `"ghcr.io"` |  |
 | deployment.replicas | int | `1` |  |
 | deployment.repository | string | `"sigstore/scaffolding/server"` |  |
+| deployment.resources | string | `""` |  |
 | deployment.version | string | `"sha256:719ea3fe44c52af5a5fedab2168429872e37e97b9f063977fc164d60a5a14b53"` |  |
 | enabled | bool | `true` |  |
 | forceNamespace | string | `""` |  |

--- a/charts/tuf/templates/deployment.yaml
+++ b/charts/tuf/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           - name: tuf-secrets
             mountPath: "/var/run/tuf-secrets"
             readOnly: true
+    {{- if .Values.deployment.resources }}
+        resources:
+{{ toYaml .Values.deployment.resources | indent 10 }}
+    {{- end }}
       volumes:
       - name: tuf-secrets
         projected:


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Adding ability to configure k8s resource requests and limits in all the components of tuf.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

At present, we cannot configure resource requests and limits for some components like one time jobs, initContainers and some deployments via Sigstore helm charts. This becomes a problem when `ResourceQuota` is defined for namespaces and prevents pods to spin up. It is a best practice to define resource requests and limits for all k8s resources.

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.