### PR TITLE
Configure fulcio resources

### DIFF
--- a/charts/fulcio/Chart.lock
+++ b/charts/fulcio/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ctlog
   repository: https://sigstore.github.io/helm-charts
-  version: 0.2.37
-digest: sha256:07c6f42ecb37aee8b5fd7b73e75eebfdcebfd457694c83ab44923ebff465726c
-generated: "2022-11-29T13:30:52.48609-08:00"
+  version: 0.2.39
+digest: sha256:f3628318c3b7cba12d61a10bb97008e31d20a561fea8ab8d64ce43010eb7a0ec
+generated: "2023-01-17T22:38:27.900918Z"

--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.0.0
 
 keywords:

--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -19,7 +19,7 @@ maintainers:
 
 dependencies:
   - name: ctlog
-    version: 0.2.37
+    version: 0.2.39
     repository: https://sigstore.github.io/helm-charts
     condition: ctlog.enabled
 

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -86,6 +86,7 @@ helm uninstall [RELEASE_NAME]
 | createcerts.image.version | string | `"sha256:73e7ac35d0e5169bd14a5cb6caed2e7d44277dec3d1de92e08f4d055523089a1"` |  |
 | createcerts.name | string | `"createcerts"` |  |
 | createcerts.replicaCount | int | `1` |  |
+| createcerts.resources | string | `""` |  |
 | createcerts.securityContext.runAsNonRoot | bool | `true` |  |
 | createcerts.securityContext.runAsUser | int | `65533` |  |
 | createcerts.serviceAccount.annotations | object | `{}` |  |
@@ -134,6 +135,7 @@ helm uninstall [RELEASE_NAME]
 | server.logging.production | bool | `false` |  |
 | server.name | string | `"server"` |  |
 | server.replicaCount | int | `1` |  |
+| server.resources | string | `""` |  |
 | server.secret | string | `"fulcio-server-secret"` |  |
 | server.securityContext.runAsNonRoot | bool | `true` |  |
 | server.securityContext.runAsUser | int | `65533` |  |

--- a/charts/fulcio/templates/createcerts-job.yaml
+++ b/charts/fulcio/templates/createcerts-job.yaml
@@ -29,6 +29,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+    {{- if .Values.createcerts.resources }}
+          resources:
+{{ toYaml .Values.createcerts.resources | indent 12 }}
+    {{- end }}
     {{- if .Values.createcerts.securityContext }}
       securityContext:
 {{ toYaml .Values.createcerts.securityContext | indent 8 }}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Adding ability to configure k8s resource requests and limits in all the components of fulcio.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

At present, we cannot configure resource requests and limits for some components like one time jobs, initContainers and some deployments via Sigstore helm charts. This becomes a problem when `ResourceQuota` is defined for namespaces and prevents pods to spin up. It is a best practice to define resource requests and limits for all k8s resources.

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.