### PR TITLE
bump scaffold to get new v0.2.2 trillian chart update

### DIFF
--- a/charts/scaffold/Chart.lock
+++ b/charts/scaffold/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 1.1.1
 - name: trillian
   repository: https://sigstore.github.io/helm-charts
-  version: 0.2.1
+  version: 0.2.2
 - name: ctlog
   repository: https://sigstore.github.io/helm-charts
   version: 0.2.38
 - name: tuf
   repository: https://sigstore.github.io/helm-charts
   version: 0.1.4
-digest: sha256:9903a03a61fcd359cd86a6aa3ca5446a25b54c4a1671b65778aabcfa934a3eb5
-generated: "2023-01-18T09:14:14.370153+02:00"
+digest: sha256:b69f1df50fe188818a52763e3344f074571e26368186322f8f0635de6c92366e
+generated: "2023-01-18T11:53:43.993991+02:00"

--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.5.1
+version: 0.5.2
 keywords:
   - security
   - pki
@@ -24,7 +24,7 @@ dependencies:
     repository: https://sigstore.github.io/helm-charts
     condition: rekor.enabled
   - name: trillian
-    version: 0.2.1
+    version: 0.2.2
     repository: https://sigstore.github.io/helm-charts
     condition: trillian.enabled
   - name: ctlog

--- a/charts/scaffold/README.md
+++ b/charts/scaffold/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Scaffolding the components of the sigstore architecture
 
@@ -39,7 +39,7 @@ helm uninstall [RELEASE_NAME]
 | https://sigstore.github.io/helm-charts | ctlog | 0.2.38 |
 | https://sigstore.github.io/helm-charts | fulcio | 2.0.0 |
 | https://sigstore.github.io/helm-charts | rekor | 1.1.1 |
-| https://sigstore.github.io/helm-charts | trillian | 0.2.1 |
+| https://sigstore.github.io/helm-charts | trillian | 0.2.2 |
 | https://sigstore.github.io/helm-charts | tuf | 0.1.4 |
 
 ## Values


### PR DESCRIPTION
## Description of the change

- bump scaffold to get new v0.2.2 trillian chart update

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
