### PR TITLE
feat: Add option for setting attestation storage PVC reclaim policy

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.1.1
+version: 1.2.0
 appVersion: 1.0.2
 
 keywords:

--- a/charts/rekor/templates/server/pvc.yaml
+++ b/charts/rekor/templates/server/pvc.yaml
@@ -24,4 +24,6 @@ spec:
 {{- if .Values.server.attestation_storage.persistence.storageClass }}
   storageClassName: {{ .Values.server.attestation_storage.persistence.storageClass }}
 {{- end }}
+  persistentVolumeReclaimPolicy: {{ .Values.server.attestation_storage.persistence.reclaimPolicy }}
+
 {{- end }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -1318,7 +1318,8 @@
                                 "mountPath",
                                 "subPath",
                                 "existingClaim",
-                                "accessModes"
+                                "accessModes",
+                                "reclaimPolicy"
                             ],
                             "properties": {
                                 "enabled": {
@@ -1395,6 +1396,16 @@
                                         [
                                             "ReadWriteOnce"
                                         ]
+                                    ]
+                                },
+                                "reclaimPolicy": {
+                                    "title": "Control whether the volume gets purged or retained",
+                                    "type": "string",
+                                    "default": "Delete",
+                                    "examples": [
+                                        "Delete",
+                                        "Retain",
+                                        "Recycle"
                                     ]
                                 }
                             },

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -129,6 +129,7 @@ server:
       existingClaim: ""
       accessModes:
         - ReadWriteOnce
+      reclaimPolicy: Delete
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/path: /metrics


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

This change adds an option for setting the reclaim policy on the PVC used for storing the attestations for Rekor.
The default setting is 'Delete', which is also reflected in the configuration.
Hence, it's a non-breaking change.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
