### PR TITLE
Use multi-arch image for Trillian's netcat initContainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ charts/*/Chart.lock
 
 # Vim swap files
 *.swp
+
+# OS-generated files
+.DS_Store

--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -25,8 +25,8 @@ annotations:
   artifacthub.io/images: |
     - name: curl
       image: docker.io/curlimages/curl@sha256:e83fef2d5a036d40df4ded829141e8c0ec41871490d252fb8c81cb4580ebb35b
-    - name: netcat
-      image: docker.io/toolbelt/netcat@sha256:7d921b6d368fb1736cb0832c6f57e426c161593c075847af3378eb3185801cea
+    - name: alpine
+      image: docker.io/alpine@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a
     - name: db_server
       image: gcr.io/trillian-opensource-ci/db_server@sha256:ae4043e9c5e4de522fb4958e92d592aa97c7fc294a12849b902fd1facd7122c6
     - name: log_server

--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.3
+version: 0.2.4
 
 keywords:
   - security

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -47,6 +47,7 @@ helm uninstall [RELEASE_NAME]
 | createdb.image.repository | string | `"sigstore/scaffolding/createdb"` |  |
 | createdb.image.version | string | `"sha256:9aa98492115c465b0cecfd6dbb04411a40c0d2d7e5d7c510f5646bd1d825e3c7"` | v0.6.2 |
 | createdb.name | string | `"createdb"` |  |
+| createdb.resources | object | `{}` |  |
 | createdb.serviceAccount.annotations | object | `{}` |  |
 | createdb.serviceAccount.create | bool | `false` |  |
 | createdb.serviceAccount.name | string | `""` |  |

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
@@ -47,21 +47,19 @@ helm uninstall [RELEASE_NAME]
 | createdb.image.repository | string | `"sigstore/scaffolding/createdb"` |  |
 | createdb.image.version | string | `"sha256:9aa98492115c465b0cecfd6dbb04411a40c0d2d7e5d7c510f5646bd1d825e3c7"` | v0.6.2 |
 | createdb.name | string | `"createdb"` |  |
-| createdb.resources | string | `""` |  |
 | createdb.serviceAccount.annotations | object | `{}` |  |
 | createdb.serviceAccount.create | bool | `false` |  |
 | createdb.serviceAccount.name | string | `""` |  |
 | createdb.ttlSecondsAfterFinished | int | `3600` |  |
 | forceNamespace | string | `""` |  |
-| initContainerResources | string | `""` |  |
 | initContainerImage.curl.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainerImage.curl.registry | string | `"docker.io"` |  |
 | initContainerImage.curl.repository | string | `"curlimages/curl"` |  |
 | initContainerImage.curl.version | string | `"sha256:9fab1b73f45e06df9506d947616062d7e8319009257d3a05d970b0de80a41ec5"` | 7.85.0 |
 | initContainerImage.netcat.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainerImage.netcat.registry | string | `"docker.io"` |  |
-| initContainerImage.netcat.repository | string | `"toolbelt/netcat"` |  |
-| initContainerImage.netcat.version | string | `"sha256:7d921b6d368fb1736cb0832c6f57e426c161593c075847af3378eb3185801cea"` | 2022-05-23 |
+| initContainerImage.netcat.repository | string | `"alpine"` |  |
+| initContainerImage.netcat.version | string | `"sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a"` | 3.17.2 |
 | logServer.enabled | bool | `true` |  |
 | logServer.extraArgs | list | `[]` |  |
 | logServer.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -70,7 +68,6 @@ helm uninstall [RELEASE_NAME]
 | logServer.image.version | string | `"sha256:75dbbfc4c0b64334b985c4971fe58c30b9dd73d7aa54b15cee61223ff92aebf3"` | v0.9.1 |
 | logServer.livenessProbe | object | `{}` |  |
 | logServer.name | string | `"log-server"` |  |
-| logServer.nodeSelector | object | `{"kubernetes.io/arch":"amd64"}` | Trillian images currently only support amd64 due to the toolbelt/netcat container |
 | logServer.portHTTP | int | `8090` |  |
 | logServer.portRPC | int | `8091` |  |
 | logServer.readinessProbe | object | `{}` |  |
@@ -97,7 +94,6 @@ helm uninstall [RELEASE_NAME]
 | logSigner.image.version | string | `"sha256:b56ed0b7b5e9813c91b208ba6041c9342f9a53162d96943374e59b5289090f1f"` | v0.9.1 |
 | logSigner.livenessProbe | object | `{}` |  |
 | logSigner.name | string | `"log-signer"` |  |
-| logSigner.nodeSelector | object | `{"kubernetes.io/arch":"amd64"}` | Trillian images currently only support amd64 due to the toolbelt/netcat container |
 | logSigner.portHTTP | int | `8090` |  |
 | logSigner.portRPC | int | `8091` |  |
 | logSigner.readinessProbe | object | `{}` |  |

--- a/charts/trillian/values.schema.json
+++ b/charts/trillian/values.schema.json
@@ -12,8 +12,8 @@
         },
         "netcat": {
             "registry": "docker.io",
-            "repository": "toolbelt/netcat",
-            "version": "sha256:99a582fa45fe1b50c97c652c9ada24b96c80d7071283227bd9a9f8eaa1c7a12b",
+            "repository": "alpine",
+            "version": "sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a",
             "imagePullPolicy": "IfNotPresent"
         }
     },

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -200,5 +200,6 @@ createdb:
     create: false
     name: ""
     annotations: {}
+  resources: {}
 # Force namespace of namespaced resources
 forceNamespace: ""

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -10,9 +10,9 @@ initContainerImage:
     imagePullPolicy: IfNotPresent
   netcat:
     registry: docker.io
-    repository: toolbelt/netcat
-    # -- 2022-05-23
-    version: "sha256:7d921b6d368fb1736cb0832c6f57e426c161593c075847af3378eb3185801cea"
+    repository: alpine
+    # -- 3.17.2
+    version: "sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a"
     imagePullPolicy: IfNotPresent
 
 storageSystem:
@@ -135,10 +135,6 @@ logServer:
     # -- v0.9.1
     version: sha256:75dbbfc4c0b64334b985c4971fe58c30b9dd73d7aa54b15cee61223ff92aebf3
 
-  # -- Trillian images currently only support amd64 due to the toolbelt/netcat container
-  nodeSelector:
-    kubernetes.io/arch: amd64
-
   service:
     type: ClusterIP
     ports:
@@ -172,10 +168,6 @@ logSigner:
     pullPolicy: IfNotPresent
     # -- v0.9.1
     version: sha256:b56ed0b7b5e9813c91b208ba6041c9342f9a53162d96943374e59b5289090f1f
-
-  # -- Trillian images currently only support amd64 due to the toolbelt/netcat container
-  nodeSelector:
-    kubernetes.io/arch: amd64
 
   service:
     type: ClusterIP


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

This replaces `toolbelt/netcat` with the standard `alpine` multi-arch image, which makes this chart compatible with non-amd64 architectures. The alpine image includes the `nc` command.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
