### PR TITLE
Fix security context not omitting "enabled" key in policy-controller chart

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.5.1
+version: 0.5.2
 appVersion: 0.7.0
 
 maintainers:

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -124,15 +124,15 @@ spec:
             name: custom-ca
             readOnly: true
           {{- end }}
-      {{- if .Values.webhook.securityContext.enabled }}
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.
       terminationGracePeriodSeconds: 300
 
+      {{- if .Values.webhook.securityContext.enabled }}
       securityContext:
         {{- with .Values.webhook.securityContext }}
-        {{- toYaml . | nindent 8}}
+        {{- omit . "enabled" | toYaml . | nindent 8}}
         {{- end }}
       {{- end }}
       volumes:


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

`webhook.securityContext.enabled` was not removed inside the security context of the deployment, which gave a warning. Omitting this key as with all other securityContexts.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

None
<!-- List any related issues. -->

## Additional Information

None

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
