### PR TITLE
Remove reclaimPolicy from Rekor PVC

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.1.0
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 
@@ -99,7 +99,6 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | server.attestation_storage.persistence.enabled | bool | `true` |  |
 | server.attestation_storage.persistence.existingClaim | string | `""` |  |
 | server.attestation_storage.persistence.mountPath | string | `"/var/lib/mysql"` |  |
-| server.attestation_storage.persistence.reclaimPolicy | string | `"Delete"` |  |
 | server.attestation_storage.persistence.size | string | `"5Gi"` |  |
 | server.attestation_storage.persistence.storageClass | string | `""` |  |
 | server.attestation_storage.persistence.subPath | string | `""` |  |

--- a/charts/rekor/templates/server/pvc.yaml
+++ b/charts/rekor/templates/server/pvc.yaml
@@ -24,6 +24,4 @@ spec:
 {{- if .Values.server.attestation_storage.persistence.storageClass }}
   storageClassName: {{ .Values.server.attestation_storage.persistence.storageClass }}
 {{- end }}
-  persistentVolumeReclaimPolicy: {{ .Values.server.attestation_storage.persistence.reclaimPolicy }}
-
 {{- end }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -1318,8 +1318,7 @@
                                 "mountPath",
                                 "subPath",
                                 "existingClaim",
-                                "accessModes",
-                                "reclaimPolicy"
+                                "accessModes"
                             ],
                             "properties": {
                                 "enabled": {
@@ -1396,16 +1395,6 @@
                                         [
                                             "ReadWriteOnce"
                                         ]
-                                    ]
-                                },
-                                "reclaimPolicy": {
-                                    "title": "Control whether the volume gets purged or retained",
-                                    "type": "string",
-                                    "default": "Delete",
-                                    "examples": [
-                                        "Delete",
-                                        "Retain",
-                                        "Recycle"
                                     ]
                                 }
                             },

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -129,7 +129,6 @@ server:
       existingClaim: ""
       accessModes:
         - ReadWriteOnce
-      reclaimPolicy: Delete
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/path: /metrics


### PR DESCRIPTION
## Description of the change

Removal of the field `persistentVolumeReclaimPolicy` from the Rekor server PVC as it is not a valid property on the resource

## Existing or Associated Issue(s)

None

## Additional Information

None

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
