### PR TITLE
override fulcio server secret keys

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.2.0
+version: 2.2.1
 appVersion: 1.2.0
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -134,7 +134,10 @@ helm uninstall [RELEASE_NAME]
 | server.logging.production | bool | `false` |  |
 | server.name | string | `"server"` |  |
 | server.replicaCount | int | `1` |  |
-| server.secret | string | `"fulcio-server-secret"` |  |
+| server.secret.certificateKey | string | `"cert"` |  |
+| server.secret.name | string | `"fulcio-server-secret"` |  |
+| server.secret.passwordKey | string | `"password"` |  |
+| server.secret.privateKey | string | `"private"` |  |
 | server.securityContext.runAsNonRoot | bool | `true` |  |
 | server.securityContext.runAsUser | int | `65533` |  |
 | server.service.ports[0].name | string | `"http"` |  |

--- a/charts/fulcio/templates/createcerts-job.yaml
+++ b/charts/fulcio/templates/createcerts-job.yaml
@@ -23,7 +23,7 @@ spec:
         - name: {{ template "fulcio.createcerts.fullname" . }}
           image: "{{ template "fulcio.image" .Values.createcerts.image }}"
           imagePullPolicy: "{{ .Values.createcerts.image.pullPolicy }}"
-          args: ["--secret={{ .Values.server.secret }}"]
+          args: ["--secret={{ .Values.server.secret.name }}"]
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -64,8 +64,9 @@ spec:
             - name: PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.server.secret }}
-                  key: password
+                  name: {{ .Values.server.secret.name }}
+                  key: {{ .Values.server.secret.passwordKey }}
+                  optional: true
           {{- end }}
           volumeMounts:
             - name: fulcio-config
@@ -101,10 +102,10 @@ spec:
         {{- if eq .Values.server.args.certificateAuthority "fileca" }}
         - name: fulcio-cert
           secret:
-            secretName: {{ .Values.server.secret }}
+            secretName: {{ .Values.server.secret.name }}
             items:
-              - key: private
+              - key: {{ .Values.server.secret.privateKey }}
                 path: key.pem
-              - key: cert
+              - key: {{ .Values.server.secret.certificateKey }}
                 path: cert.pem
         {{- end }}

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -818,8 +818,42 @@
                     ]
                 },
                 "secret": {
-                    "type": "string",
-                    "title": "The name of the secret containing the fulcio keys, password and PEM"
+                    "type": "object",
+                    "default": {},
+                    "title": "The secret containing the fulcio sever keys, certificate",
+                    "required": [
+                        "name",
+                        "privateKey",
+                        "certificateKey"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "default": "fulcio-server-cert",
+                            "title": "The name of the fulcio secret containing the keys, password, pem",
+                            "examples": [
+                                "fulcio-server-cert"
+                            ]
+                        },
+                        "privateKey": {
+                            "type": "string",
+                            "default": "private",
+                            "title": "The key path for private key in secret",
+                            "examples": [
+                                "private",
+                                "tls.key"
+                            ]
+                        },
+                        "certificateKey": {
+                            "type": "string",
+                            "default": "cert",
+                            "title": "The key path for certificate PEM in secret",
+                            "examples": [
+                                "cert",
+                                "tls.cert"
+                            ]
+                        }
+                    }
                 }
             },
             "examples": [

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -10,7 +10,11 @@ server:
   name: server
   svcPort: 80
   grpcSvcPort: 5554
-  secret: fulcio-server-secret
+  secret:
+    name: fulcio-server-secret
+    privateKey: private
+    passwordKey: password
+    certificateKey: cert
   logging:
     production: false
   image:


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change
1. Override fulcio server secret keys to avoid duplicating the secrets generated in standard TLS format generated by tools like cert-manager
2. Make the Private Key password as optional since not all secrets are generated to support it.


<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)
Fix to partially overcome: https://github.com/sigstore/scaffolding/issues/546

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
