### PR TITLE
Add lifecycle hooks for Trillian

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.3
+version: 0.2.4
 
 keywords:
   - security

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
@@ -68,6 +68,7 @@ helm uninstall [RELEASE_NAME]
 | logServer.image.registry | string | `"gcr.io"` |  |
 | logServer.image.repository | string | `"projectsigstore/trillian_log_server"` |  |
 | logServer.image.version | string | `"sha256:75dbbfc4c0b64334b985c4971fe58c30b9dd73d7aa54b15cee61223ff92aebf3"` | v0.9.1 |
+| logServer.lifecycle | object | `{}` |  |
 | logServer.livenessProbe | object | `{}` |  |
 | logServer.name | string | `"log-server"` |  |
 | logServer.nodeSelector | object | `{"kubernetes.io/arch":"amd64"}` | Trillian images currently only support amd64 due to the toolbelt/netcat container |
@@ -95,6 +96,7 @@ helm uninstall [RELEASE_NAME]
 | logSigner.image.registry | string | `"gcr.io"` |  |
 | logSigner.image.repository | string | `"projectsigstore/trillian_log_signer"` |  |
 | logSigner.image.version | string | `"sha256:b56ed0b7b5e9813c91b208ba6041c9342f9a53162d96943374e59b5289090f1f"` | v0.9.1 |
+| logSigner.lifecycle | object | `{}` |  |
 | logSigner.livenessProbe | object | `{}` |  |
 | logSigner.name | string | `"log-signer"` |  |
 | logSigner.nodeSelector | object | `{"kubernetes.io/arch":"amd64"}` | Trillian images currently only support amd64 due to the toolbelt/netcat container |

--- a/charts/trillian/templates/trillian-log-server/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-server/deployment.yaml
@@ -78,7 +78,7 @@ spec:
 {{- if .Values.logServer.lifecycle }}
           lifecycle:
 {{ toYaml .Values.logServer.lifecycle | indent 12 }}
-{{- end }
+{{- end }}
 {{- if .Values.logServer.livenessProbe }}
           livenessProbe:
 {{ toYaml .Values.logServer.livenessProbe | indent 12 }}

--- a/charts/trillian/templates/trillian-log-server/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-server/deployment.yaml
@@ -75,6 +75,10 @@ spec:
 {{- include "trillian.storageSystem.envCredentials" . | indent 12}}
           ports:
 {{- include "trillian.containerPorts" .Values.logServer.service.ports | indent 12 }}
+{{- if .Values.logServer.lifecycle }}
+          lifecycle:
+{{ toYaml .Values.logServer.lifecycle | indent 12 }}
+{{- end }
 {{- if .Values.logServer.livenessProbe }}
           livenessProbe:
 {{ toYaml .Values.logServer.livenessProbe | indent 12 }}

--- a/charts/trillian/templates/trillian-log-signer/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-signer/deployment.yaml
@@ -78,7 +78,7 @@ spec:
 {{- if .Values.logSigner.lifecycle }}
           lifecycle:
 {{ toYaml .Values.logSigner.lifecycle | indent 12 }}
-{{- end }
+{{- end }}
 {{- if .Values.logSigner.livenessProbe }}
           livenessProbe:
 {{ toYaml .Values.logSigner.livenessProbe | indent 12 }}

--- a/charts/trillian/templates/trillian-log-signer/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-signer/deployment.yaml
@@ -75,6 +75,10 @@ spec:
 {{- include "trillian.storageSystem.envCredentials" . | indent 12}}
           ports:
 {{- include "trillian.containerPorts" .Values.logSigner.service.ports | indent 12 }}
+{{- if .Values.logSigner.lifecycle }}
+          lifecycle:
+{{ toYaml .Values.logSigner.lifecycle | indent 12 }}
+{{- end }
 {{- if .Values.logSigner.livenessProbe }}
           livenessProbe:
 {{ toYaml .Values.logSigner.livenessProbe | indent 12 }}

--- a/charts/trillian/values.schema.json
+++ b/charts/trillian/values.schema.json
@@ -143,6 +143,7 @@
                 }
             ]
         },
+        "lifecycle": {},
         "livenessProbe": {},
         "readinessProbe": {},
         "resources": {},
@@ -176,6 +177,7 @@
                 }
             ]
         },
+        "lifecycle": {},
         "livenessProbe": {},
         "readinessProbe": {},
         "resources": {},

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -150,6 +150,7 @@ logServer:
         port: 8090
         protocol: TCP
         targetPort: 8090
+  lifecycle: {}
   livenessProbe: {}
   readinessProbe: {}
   resources: {}
@@ -184,6 +185,7 @@ logSigner:
         port: 8091
         protocol: TCP
         targetPort: 8091
+  lifecycle: {}
   livenessProbe: {}
   readinessProbe: {}
   resources: {}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

This adds the ability to configure lifecycle hooks to the Trillian Helm Chart.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
