### PR TITLE
Add probes for ctlog chart

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.41
+version: 0.2.42
 appVersion: 0.3.0
 
 keywords:

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -1,6 +1,6 @@
 # ctlog
 
-![Version: 0.2.41](https://img.shields.io/badge/Version-0.2.41-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 0.2.42](https://img.shields.io/badge/Version-0.2.42-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 Certificate Log
 
@@ -71,11 +71,17 @@ Certificate Log
 | server.ingress.enabled | bool | `false` |  |
 | server.ingress.hosts[0].path | string | `"/"` |  |
 | server.ingress.tls | list | `[]` |  |
+| server.livenessProbe.httpGet.path | string | `"/healthz"` |  |
+| server.livenessProbe.httpGet.port | int | `6962` |  |
+| server.livenessProbe.initialDelaySeconds | int | `10` |  |
 | server.podAnnotations."prometheus.io/path" | string | `"/metrics"` |  |
 | server.podAnnotations."prometheus.io/port" | string | `"6963"` |  |
 | server.podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
 | server.portHTTP | int | `6962` |  |
 | server.portHTTPMetrics | int | `6963` |  |
+| server.readinessProbe.httpGet.path | string | `"/healthz"` |  |
+| server.readinessProbe.httpGet.port | int | `6962` |  |
+| server.readinessProbe.initialDelaySeconds | int | `10` |  |
 | server.replicaCount | int | `1` |  |
 | server.securityContext.runAsNonRoot | bool | `true` |  |
 | server.securityContext.runAsUser | int | `65533` |  |

--- a/charts/ctlog/templates/ctlog-deployment.yaml
+++ b/charts/ctlog/templates/ctlog-deployment.yaml
@@ -27,6 +27,14 @@ spec:
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           args:
 {{  include "ctlog.server.args" . | indent 12 }}
+          {{- if .Values.server.livenessProbe }}
+          livenessProbe:
+{{ toYaml .Values.server.livenessProbe | indent 12 }}
+          {{- end }}
+          {{- if .Values.server.readinessProbe }}
+          readinessProbe:
+{{ toYaml .Values.server.readinessProbe | indent 12 }}
+          {{- end }}
           volumeMounts:
             - name: keys
               mountPath: "/ctfe-keys"

--- a/charts/ctlog/values.schema.json
+++ b/charts/ctlog/values.schema.json
@@ -158,6 +158,14 @@
                         }
                     ]
                 },
+                "livenessProbe": {
+                    "description": "Liveness probe configuration",
+                    "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
+                },
+                "readinessProbe": {
+                    "description": "Readiness probe configuration",
+                    "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
+                },
                 "serviceAccount": {
                     "type": "object",
                     "default": {},

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -13,6 +13,16 @@ server:
     pullPolicy: IfNotPresent
     # v0.3.0
     version: "sha256:7c791d3b7c15e817807f07d4cdb00406529a114702ad448ee857e1d0fc5fb5a9"
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: 6962
+    initialDelaySeconds: 10
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: 6962
+    initialDelaySeconds: 10
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

This adds `livenessProbe`/`readinessProbe` for the ctlog service.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
