### PR TITLE
bump image gcr.io/cloudsql-docker/gce-proxy and gcr.io/trillian-opensource-ci/db_server

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -28,7 +28,7 @@ annotations:
     - name: netcat
       image: docker.io/toolbelt/netcat@sha256:7d921b6d368fb1736cb0832c6f57e426c161593c075847af3378eb3185801cea
     - name: db_server
-      image: gcr.io/trillian-opensource-ci/db_server@sha256:ae4043e9c5e4de522fb4958e92d592aa97c7fc294a12849b902fd1facd7122c6
+      image: gcr.io/trillian-opensource-ci/db_server@sha256:20a4b9b9532f466936ca2bb186251a0a21d34f89b78b12bb2bb1c2aae5e8e339
     - name: log_server
       image: gcr.io/projectsigstore/trillian_log_server@sha256:4599a3f037234423d13ff84755679a56da62363e7ed07c70bc556078fd73986d
     - name: log_signer

--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.3
+version: 0.2.4
 
 keywords:
   - security
@@ -34,7 +34,7 @@ annotations:
     - name: log_signer
       image: gcr.io/projectsigstore/trillian_log_signer@sha256:87699af429d79440f7e0a487d215c2129bf97b37698370d050a68822996f93f0
     - name: cloud_proxy
-      image: gcr.io/cloudsql-docker/gce-proxy@sha256:7f53fe219f6815e275301561e2f8819e59e38eca5a93de644a287452f841fab7
+      image: gcr.io/cloudsql-docker/gce-proxy@sha256:cbd474b0424a86df61834e60e8be5bbf19d771a387a0e5bb5c4686507b23ef7f
     - name: scaffold_cloud_proxy
       image: ghcr.io/sigstore/scaffolding/cloudsqlproxy:@sha256:2c818523a9060cdefca10af0804c8f60549bdc1744e71008f9849b23605c4ccf
     - name: createdb

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -125,7 +125,7 @@ helm uninstall [RELEASE_NAME]
 | mysql.gcp.cloudsql.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | mysql.gcp.cloudsql.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | mysql.gcp.cloudsql.securityContext.runAsNonRoot | bool | `true` |  |
-| mysql.gcp.cloudsql.version | string | `"sha256:7f53fe219f6815e275301561e2f8819e59e38eca5a93de644a287452f841fab7"` | v1.33.1 |
+| mysql.gcp.cloudsql.version | string | `"sha256:cbd474b0424a86df61834e60e8be5bbf19d771a387a0e5bb5c4686507b23ef7f"` | v1.33.6 |
 | mysql.gcp.enabled | bool | `false` |  |
 | mysql.gcp.instance | string | `""` |  |
 | mysql.gcp.scaffoldSQLProxy.registry | string | `"ghcr.io"` |  |

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -141,7 +141,7 @@ helm uninstall [RELEASE_NAME]
 | mysql.image.pullPolicy | string | `"IfNotPresent"` |  |
 | mysql.image.registry | string | `"gcr.io"` |  |
 | mysql.image.repository | string | `"trillian-opensource-ci/db_server"` |  |
-| mysql.image.version | string | `"sha256:22b7fddcb4bafc5692760d84dca5e86294363a94e8f0ecb8f5c39364d436e6d5"` | v1.5.0 |
+| mysql.image.version | string | `"sha256:20a4b9b9532f466936ca2bb186251a0a21d34f89b78b12bb2bb1c2aae5e8e339"` | v1.5.1 |
 | mysql.livenessProbe.exec.command[0] | string | `"/etc/init.d/mysql"` |  |
 | mysql.livenessProbe.exec.command[1] | string | `"status"` |  |
 | mysql.livenessProbe.failureThreshold | int | `3` |  |

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -68,8 +68,8 @@ mysql:
     registry: gcr.io
     repository: trillian-opensource-ci/db_server
     pullPolicy: IfNotPresent
-    # -- v1.5.0
-    version: sha256:22b7fddcb4bafc5692760d84dca5e86294363a94e8f0ecb8f5c39364d436e6d5
+    # -- v1.5.1
+    version: sha256:20a4b9b9532f466936ca2bb186251a0a21d34f89b78b12bb2bb1c2aae5e8e339
   resources: {}
   args:
     - "--ignore-db-dir=lost+found"

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -44,8 +44,8 @@ mysql:
     cloudsql:
       registry: gcr.io
       repository: cloudsql-docker/gce-proxy
-      # -- v1.33.1
-      version: sha256:7f53fe219f6815e275301561e2f8819e59e38eca5a93de644a287452f841fab7
+      # -- v1.33.6
+      version: sha256:cbd474b0424a86df61834e60e8be5bbf19d771a387a0e5bb5c4686507b23ef7f
       resources:
         requests:
           memory: "2Gi"
@@ -56,7 +56,7 @@ mysql:
         runAsNonRoot: true
         capabilities:
           drop:
-          - ALL
+            - ALL
   enabled: true
   replicaCount: 1
   name: mysql


### PR DESCRIPTION
## Description of the change

- bump `gcr.io/cloudsql-docker/gce-proxy` to use release `v1.33.6`
- bump `gcr.io/trillian-opensource-ci/db_server` to release `v1.5.1`

## Existing or Associated Issue(s)

Part of https://github.com/sigstore/public-good-instance/issues/1268

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
