### PR TITLE
bump scaffold to get image updates from trillian chart

### DIFF
--- a/charts/scaffold/Chart.lock
+++ b/charts/scaffold/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.3.1
 - name: trillian
   repository: https://sigstore.github.io/helm-charts
-  version: 0.2.2
+  version: 0.2.4
 - name: ctlog
   repository: https://sigstore.github.io/helm-charts
   version: 0.2.40
@@ -17,5 +17,5 @@ dependencies:
 - name: tsa
   repository: https://sigstore.github.io/helm-charts
   version: 0.1.0
-digest: sha256:a9cdb378977792ed92f8efbc54a23050c9b40ba095543ac246dcbc0b88eacaa7
-generated: "2023-04-06T13:02:39.894747-04:00"
+digest: sha256:21b52969bb585d48daa359dc8f69345bdc5e0bf73cc08922a379052c4d0d55de
+generated: "2023-04-30T08:25:13.116546-07:00"

--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.6.2
+version: 0.6.3
 keywords:
   - security
   - pki
@@ -24,7 +24,7 @@ dependencies:
     repository: https://sigstore.github.io/helm-charts
     condition: rekor.enabled
   - name: trillian
-    version: 0.2.2
+    version: 0.2.4
     repository: https://sigstore.github.io/helm-charts
     condition: trillian.enabled
   - name: ctlog

--- a/charts/scaffold/README.md
+++ b/charts/scaffold/README.md
@@ -39,7 +39,7 @@ helm uninstall [RELEASE_NAME]
 | https://sigstore.github.io/helm-charts | ctlog | 0.2.40 |
 | https://sigstore.github.io/helm-charts | fulcio | 2.2.0 |
 | https://sigstore.github.io/helm-charts | rekor | 1.3.1 |
-| https://sigstore.github.io/helm-charts | trillian | 0.2.2 |
+| https://sigstore.github.io/helm-charts | trillian | 0.2.4 |
 | https://sigstore.github.io/helm-charts | tsa | 0.1.0 |
 | https://sigstore.github.io/helm-charts | tuf | 0.1.4 |
 


### PR DESCRIPTION

## Description of the change

- bump scaffold to get image updates from trillian chart

## Existing or Associated Issue(s)

Follow up of https://github.com/sigstore/helm-charts/pull/514

Part of https://github.com/sigstore/public-good-instance/issues/1268

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
