### PR TITLE
update fulcio image to use release v1.3.0

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,8 +5,8 @@ description: |
 
 type: application
 
-version: 2.2.1
-appVersion: 1.2.0
+version: 2.3.0
+appVersion: 1.3.0
 
 keywords:
   - security
@@ -27,6 +27,6 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: fulcio
-      image: gcr.io/projectsigstore/fulcio@sha256:17ae9911f54892224c85355a1f8559cfecf75343093f2eaeea1a5c4724283d12
+      image: gcr.io/projectsigstore/fulcio@sha256:29194a0b72f6e23e884ee4fef7aaa8d0dafefbf2e0f42bbb94f935da373e74be
     - name: createcerts
       image: ghcr.io/sigstore/scaffolding/createcerts@sha256:73e7ac35d0e5169bd14a5cb6caed2e7d44277dec3d1de92e08f4d055523089a1

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -118,7 +118,7 @@ helm uninstall [RELEASE_NAME]
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"gcr.io"` |  |
 | server.image.repository | string | `"projectsigstore/fulcio"` |  |
-| server.image.version | string | `"sha256:17ae9911f54892224c85355a1f8559cfecf75343093f2eaeea1a5c4724283d12"` | v1.2.0 |
+| server.image.version | string | `"sha256:29194a0b72f6e23e884ee4fef7aaa8d0dafefbf2e0f42bbb94f935da373e74be"` | v1.3.0 |
 | server.ingress.grpc.annotations."nginx.ingress.kubernetes.io/backend-protocol" | string | `"GRPC"` |  |
 | server.ingress.grpc.className | string | `""` |  |
 | server.ingress.grpc.enabled | bool | `false` |  |

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -17,9 +17,9 @@ server:
     registry: gcr.io
     repository: projectsigstore/fulcio
     pullPolicy: IfNotPresent
-    # crane digest gcr.io/projectsigstore/fulcio:v1.2.0
-    # -- v1.2.0
-    version: sha256:17ae9911f54892224c85355a1f8559cfecf75343093f2eaeea1a5c4724283d12
+    # crane digest gcr.io/projectsigstore/fulcio:v1.3.0
+    # -- v1.3.0
+    version: sha256:29194a0b72f6e23e884ee4fef7aaa8d0dafefbf2e0f42bbb94f935da373e74be
   args:
     port: 5555
     grpcPort: 5554


### PR DESCRIPTION
## Description of the change

- update fulcio image to use release v1.3.0


## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
