### PR TITLE
Bugfix: Do not use ctlog.enabled to control ct-log-url flag

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.3.0
+version: 2.3.1
 appVersion: 1.3.0
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 
@@ -110,6 +110,7 @@ helm uninstall [RELEASE_NAME]
 | server.args.aws_hsm_root_ca_path | string | `nil` |  |
 | server.args.certificateAuthority | string | `"fileca"` |  |
 | server.args.ct_log_url | string | `""` |  |
+| server.args.disable_ct_log | bool | `false` |  |
 | server.args.gcp_private_ca_parent | string | `"projects/test/locations/us-east1/caPools/test"` |  |
 | server.args.grpcPort | int | `5554` |  |
 | server.args.hsm_caroot_id | string | `nil` |  |

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - "--kms-resource={{ .Values.server.args.kms_resource }}"
             - "--kms-cert-chain-path=/etc/fulcio-config/chain.pem"
             {{- end }}
-            - "--ct-log-url={{ if .Values.ctlog.enabled }}http://{{ .Values.ctlog.name }}.{{ .Values.ctlog.namespace.name }}.svc/{{ .Values.ctlog.createctconfig.logPrefix }}{{ else }}{{ .Values.server.args.ct_log_url }}{{ end }}"
+            - "--ct-log-url={{ if .Values.server.args.disable_ct_log }}{{ else if .Values.server.args.ct_log_url }}{{ .Values.server.args.ct_log_url }}{{ else }}http://{{ .Values.ctlog.name }}.{{ .Values.ctlog.namespace.name }}.svc/{{ .Values.ctlog.createctconfig.logPrefix }}{{ end }}"
           {{- if eq .Values.server.args.certificateAuthority "fileca" }}
           env:
             - name: PASSWORD

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -241,11 +241,21 @@
                                 "projects/test/locations/us-east1/caPools/test"
                             ]
                         },
+                        "disable_ct_log": {
+                            "type": "bool",
+                            "default": false,
+                            "title": "Disable CT log submission",
+                            "description": "If set, Fulcio will not submit issued certificates to a CT log.",
+                            "examples": [
+                                true,
+                                false
+                            ]
+                        },
                         "ct_log_url": {
                             "type": "string",
                             "default": "",
                             "title": "URL of the CT log to submit to",
-                            "description": "If set, Fulcio will submit issued certificates to the specified CT log. If ctlog.enabled is set to true, this value will be ignored and the Helm-generated CT log will be used.",
+                            "description": "If set, Fulcio will submit issued certificates to the specified CT log instead of the default in-cluster CT Log.",
                             "examples": [
                                 "https://ct.example.com/"
                             ]

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -242,7 +242,7 @@
                             ]
                         },
                         "disable_ct_log": {
-                            "type": "bool",
+                            "type": "boolean",
                             "default": false,
                             "title": "Disable CT log submission",
                             "description": "If set, Fulcio will not submit issued certificates to a CT log.",

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -32,6 +32,7 @@ server:
     aws_hsm_root_ca_path:
     gcp_private_ca_parent: projects/test/locations/us-east1/caPools/test
     ct_log_url: ""
+    disable_ct_log: false
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Context: I added the Helm value `ct_log_url` in https://github.com/sigstore/helm-charts/pull/509. It relied on `ctlog.enabled` to control the output of the flag. This unfortunately doesn't work with the scaffold Helm chart, which sets `fulcio.ctlog.enabled=false`, which causes the ct_log_url to be set to an empty string, which is not the intent with that chart. This PR changes the behavior so that:

- If `disable_ct_log` is set to true, the flag is output as a blank string
- If `ct_log_url` is set, the output is the value
- Otherwise, the old behavior is preserved (assume CT Log running in cluster)

The `disable_ct_log` setting is added here because `ct_log_url` may not be set to an empty string as it would fail the boolean test, and that's a feature I would like personally.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
