### PR TITLE
bump scaffold to get fulcio chart release v1.3.1

### DIFF
--- a/charts/scaffold/Chart.lock
+++ b/charts/scaffold/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: fulcio
   repository: https://sigstore.github.io/helm-charts
-  version: 2.3.1
+  version: 2.3.2
 - name: rekor
   repository: https://sigstore.github.io/helm-charts
   version: 1.3.2
@@ -17,5 +17,5 @@ dependencies:
 - name: tsa
   repository: https://sigstore.github.io/helm-charts
   version: 0.1.0
-digest: sha256:8df0184f012486c1c6d6897c537958c826a56fe80b8c261deaa730f5e6c5cd89
-generated: "2023-05-03T00:40:02.46029645Z"
+digest: sha256:50a711ceff37f9efe187824c95002b34189a399a1db3e4fc5641c02e2565f1e8
+generated: "2023-05-04T07:10:12.083391-07:00"

--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.6.6
+version: 0.6.7
 keywords:
   - security
   - pki
@@ -16,7 +16,7 @@ maintainers:
 
 dependencies:
   - name: fulcio
-    version: 2.3.1
+    version: 2.3.2
     repository: https://sigstore.github.io/helm-charts
     condition: fulcio.enabled
   - name: rekor

--- a/charts/scaffold/README.md
+++ b/charts/scaffold/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.6.6](https://img.shields.io/badge/Version-0.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.7](https://img.shields.io/badge/Version-0.6.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Scaffolding the components of the sigstore architecture
 
@@ -37,7 +37,7 @@ helm uninstall [RELEASE_NAME]
 | Repository | Name | Version |
 |------------|------|---------|
 | https://sigstore.github.io/helm-charts | ctlog | 0.2.40 |
-| https://sigstore.github.io/helm-charts | fulcio | 2.3.1 |
+| https://sigstore.github.io/helm-charts | fulcio | 2.3.2 |
 | https://sigstore.github.io/helm-charts | rekor | 1.3.2 |
 | https://sigstore.github.io/helm-charts | trillian | 0.2.4 |
 | https://sigstore.github.io/helm-charts | tsa | 0.1.0 |


### PR DESCRIPTION


## Description of the change

- bump scaffold to get fulcio chart release v1.3.1
follow up of https://github.com/sigstore/helm-charts/pull/525

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
