### PR TITLE
Allow policy-controller to update sigstore keys configmap

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.5.7
+version: 0.5.8
 appVersion: 0.7.0
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -1,6 +1,6 @@
 # policy-controller
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.5.8](https://img.shields.io/badge/Version-0.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 The Helm chart for Policy  Controller
 

--- a/charts/policy-controller/templates/policy-webhook/role_policy_webhook.yaml
+++ b/charts/policy-controller/templates/policy-webhook/role_policy_webhook.yaml
@@ -39,6 +39,13 @@ rules:
     resourceNames: ["config-image-policies"]
     verbs: ["get", "list", "create", "update", "patch", "watch"]
 
+  # This is needed to create / patch ConfigMap that is created by the reconciler
+  # to consolidate various TrustRoot configuration into SigstoreKeys ConfigMap.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["config-sigstore-keys"]
+    verbs: ["get", "list", "create", "update", "patch", "watch"]
+
   - apiGroups: ["policy.sigstore.dev"]
     resources: ["trustroots"]
     verbs: ["get", "list"]


### PR DESCRIPTION
## Description of the change

If you use a custom `TrustRoot`, the policy-controller will persist the keys to a config map, `config-sigstore-keys`; however, installing the policy controller through the chart doesn't grant it the ability to manage this config map. As a result, trying to use the custom root will return an error from the validating webhook that the root doesn't exist:

> error: failed to create deployment: admission webhook "policy.sigstore.dev" denied the request: validation failed: failed policy: demo: spec.template.spec.containers[0].image
nginx creating CheckOpts: getting Fulcio certs: attestation: trustRootRef demo not found

The [sigstore/policy-controller example Kubernetes config](https://github.com/sigstore/policy-controller/blob/067e4fdb8c1f74d0f2a4faddf6723654a597faf2/config/200-role.yaml#L38-L43) permits this already, I only copied the role changes and comment over.

## Existing or Associated Issue(s)

N/A

## Additional Information

Policy webhook logs:

```json
{"level":"info","ts":"2023-05-16T20:24:34.195Z","logger":"clusterimagepolicy.event-broadcaster","caller":"record/event.go:285","msg":"Event(v1.ObjectReference{Kind:\"TrustRoot\", Namespace:\"\", Name:\"custom-root\", UID:\"6d1c5c66-757f-42b4-8460-830cda33f3e8\", APIVersion:\"policy.sigstore.dev/v1alpha1\", ResourceVersion:\"961\", FieldPath:\"\"}): type: 'Warning' reason: 'InternalError' configmaps \"config-sigstore-keys\" is forbidden: User \"system:serviceaccount:policy-controller:policy-controller-policy-webhook\" cannot patch resource \"configmaps\" in API group \"\" in the namespace \"policy-controller\"","commit":"89ef904-dirty"}
```

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content. (N/A)
- [ ] JSON Schema generated. (N/A)
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command. (N/A)
