### PR TITLE
parametrize leases-cleanup repository

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.5.8
+version: 0.5.9
 appVersion: 0.7.0
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -87,6 +87,9 @@ The Helm chart for Policy  Controller
 | webhook.serviceAccount.name | string | `""` |  |
 | webhook.volumeMounts | list | `[]` |  |
 | webhook.volumes | list | `[]` |  |
+| leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |
+| leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
+| leasescleanup.image.version | string | `"1.26.0"` |  |
 
 ### Deploy `policy-controller` Helm Chart
 

--- a/charts/policy-controller/templates/_helpers.tpl
+++ b/charts/policy-controller/templates/_helpers.tpl
@@ -139,6 +139,13 @@ Create the image path for the passed in policy-webhook image field
 {{- end -}}
 
 {{/*
+Create the image path for the passed in leases-cleanup image field
+*/}}
+{{- define "leases-cleanup.image" -}}
+{{- printf "%s:%s" .repository .version -}}
+{{- end -}}
+
+{{/*
 */}}
 {{- define "policy-controller.webhook.namespaceSelector" -}}
 {{- if .Values.webhook.namespaceSelector }}

--- a/charts/policy-controller/templates/webhook/cleanup-leases.yaml
+++ b/charts/policy-controller/templates/webhook/cleanup-leases.yaml
@@ -18,8 +18,8 @@ spec:
       serviceAccountName: {{ template "webhook.serviceAccountName" . }}-cleanup
       containers:
         - name: kubectl
-          image: cgr.dev/chainguard/kubectl:1.26.0
-          imagePullPolicy: IfNotPresent
+          image: "{{ template "leases-cleanup.image" .Values.leasescleanup.image }}"
+          imagePullPolicy: "{{ .Values.leasescleanup.image.pullPolicy }}"
           command:
             - /bin/sh
             - -c
@@ -37,7 +37,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": hook-succeeded    
+    "helm.sh/hook-delete-policy": hook-succeeded
 subjects:
 - kind: ServiceAccount
   name: {{ include "webhook.serviceAccountName" . }}-cleanup

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -336,6 +336,25 @@
                     "type": "array"
                 }
             }
+        },
+        "leasescleanup": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -98,6 +98,12 @@ webhook:
         values: ["true"]
   registryCaBundle: {}
 
+leasescleanup:
+  image:
+    repository: cgr.dev/chainguard/kubectl
+    version: 1.26.0
+    pullPolicy: IfNotPresent
+
 ## common node selector for all the pods
 commonNodeSelector: {}
 #  key1: value1


### PR DESCRIPTION
## Description of the change

Parametrize repository kubectl for policy-controller to possibility to choose private repository.

## Existing or Associated Issue(s)

## Additional Information


## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
