### PR TITLE
update gce-proxy image to 1.33.8

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.5
+version: 0.2.6
 
 keywords:
   - security
@@ -34,7 +34,7 @@ annotations:
     - name: log_signer
       image: gcr.io/projectsigstore/trillian_log_signer@sha256:87699af429d79440f7e0a487d215c2129bf97b37698370d050a68822996f93f0
     - name: cloud_proxy
-      image: gcr.io/cloudsql-docker/gce-proxy@sha256:c378a623353ee9c592795c0ad9e448bdc7e26c7635ba982968a60d0e3bb4d575
+      image: gcr.io/cloudsql-docker/gce-proxy@sha256:ec2858d78ac2b4d7945020589f6f86d151704a4617322f6c4196bafd952bf827
     - name: scaffold_cloud_proxy
       image: ghcr.io/sigstore/scaffolding/cloudsqlproxy:@sha256:2c818523a9060cdefca10af0804c8f60549bdc1744e71008f9849b23605c4ccf
     - name: createdb

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -125,7 +125,7 @@ helm uninstall [RELEASE_NAME]
 | mysql.gcp.cloudsql.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | mysql.gcp.cloudsql.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | mysql.gcp.cloudsql.securityContext.runAsNonRoot | bool | `true` |  |
-| mysql.gcp.cloudsql.version | string | `"sha256:c378a623353ee9c592795c0ad9e448bdc7e26c7635ba982968a60d0e3bb4d575"` | v1.33.7 |
+| mysql.gcp.cloudsql.version | string | `"sha256:ec2858d78ac2b4d7945020589f6f86d151704a4617322f6c4196bafd952bf827"` | v1.33.8 |
 | mysql.gcp.enabled | bool | `false` |  |
 | mysql.gcp.instance | string | `""` |  |
 | mysql.gcp.scaffoldSQLProxy.registry | string | `"ghcr.io"` |  |

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -44,8 +44,8 @@ mysql:
     cloudsql:
       registry: gcr.io
       repository: cloudsql-docker/gce-proxy
-      # -- crane digest gcr.io/cloudsql-docker/gce-proxy:1.33.7
-      version: sha256:c378a623353ee9c592795c0ad9e448bdc7e26c7635ba982968a60d0e3bb4d575
+      # -- crane digest gcr.io/cloudsql-docker/gce-proxy:1.33.8
+      version: sha256:ec2858d78ac2b4d7945020589f6f86d151704a4617322f6c4196bafd952bf827
       resources:
         requests:
           memory: "2Gi"


### PR DESCRIPTION
## Description of the change

- update gce-proxy image to 1.33.8

Related to https://github.com/sigstore/public-good-instance/issues/1430
