### PR TITLE
add ability to have multiple ingress objects for rekor, supporting GCE lb

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.3.3
+version: 1.3.4
 appVersion: 1.2.1
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
+![Version: 1.3.4](https://img.shields.io/badge/Version-1.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 
@@ -116,6 +116,18 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | server.ingress.hosts[0].host | string | `"root"` |  |
 | server.ingress.hosts[0].path | string | `"/"` |  |
 | server.ingress.tls | list | `[]` |  |
+| server.ingresses[0].annotations | object | `{}` |  |
+| server.ingresses[0].backendConfigSpec.logging.enable | bool | `true` |  |
+| server.ingresses[0].backendConfigSpec.securityPolicy.name | string | `"rekor-security-policy"` |  |
+| server.ingresses[0].className | string | `"gce"` |  |
+| server.ingresses[0].enabled | bool | `false` |  |
+| server.ingresses[0].frontendConfigSpec.redirectToHttps.enabled | bool | `true` |  |
+| server.ingresses[0].frontendConfigSpec.sslPolicy | string | `"rekor-ssl-policy"` |  |
+| server.ingresses[0].hosts[0].host | string | `"root"` |  |
+| server.ingresses[0].hosts[0].path | string | `"/"` |  |
+| server.ingresses[0].name | string | `"gce-ingress"` |  |
+| server.ingresses[0].staticGlobalIP | string | `"lb-ext-ip"` |  |
+| server.ingresses[0].tls | list | `[]` |  |
 | server.livenessProbe.failureThreshold | int | `3` |  |
 | server.livenessProbe.httpGet.path | string | `"/ping"` |  |
 | server.livenessProbe.httpGet.port | int | `3000` |  |

--- a/charts/rekor/ci/ci-values.yaml
+++ b/charts/rekor/ci/ci-values.yaml
@@ -4,3 +4,20 @@ server:
     hosts:
       - host: rekor.localhost
         path: /
+  ingresses:
+    - name: gce-ingress
+      enabled: false
+      className: gce
+      hosts:
+        - host: rekor.sigstoretest.dev
+          path: /
+          pathType: Prefix
+      tls: []
+      annotations: {}
+      staticGlobalIP: lb-ext-ip
+      frontendConfigSpec:
+        redirectToHttps:
+          enabled: false
+      backendConfigSpec:
+        logging:
+          enable: true

--- a/charts/rekor/templates/_helpers.tpl
+++ b/charts/rekor/templates/_helpers.tpl
@@ -339,13 +339,20 @@ Server Arguments
 {{- end -}}
 
 {{/*
+Return the port for the external service listener
+*/}}
+{{- define "rekor.server.port" -}}
+{{ (index .Values.server.service.ports 0).port | int }}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "rekor.server.ingress.backend" -}}
 service:
   name: {{ include "rekor.server.fullname" . }}
   port:
-    number: {{ (index .Values.server.service.ports 0).port | int }}
+    number: {{ include "rekor.server.port" . }}
 {{- end -}}
 
 {{/*

--- a/charts/rekor/templates/server/backendconfig.yaml
+++ b/charts/rekor/templates/server/backendconfig.yaml
@@ -1,0 +1,14 @@
+{{- range .Values.server.ingresses }}
+{{- if and (.enabled) (eq .className "gce") (.backendConfigSpec) }}
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ include "rekor.server.fullname" $ -}}-{{- .name }}
+  labels:
+    {{- include "rekor.server.labels" $ | nindent 4 }}
+{{ include "rekor.namespace" $ | indent 2 }}
+spec:
+{{ toYaml .backendConfigSpec | indent 2 }}
+---
+{{- end }}
+{{- end }}

--- a/charts/rekor/templates/server/frontendconfig.yaml
+++ b/charts/rekor/templates/server/frontendconfig.yaml
@@ -1,0 +1,14 @@
+{{- range .Values.server.ingresses }}
+{{- if and (.enabled) (eq .className "gce") (.frontendConfigSpec) }}
+apiVersion: "networking.gke.io/v1beta1"
+kind: FrontendConfig
+metadata:
+  name: {{ include "rekor.server.fullname" $ -}}-{{- .name }}
+  labels:
+    {{- include "rekor.server.labels" $ | nindent 4 }}
+{{ include "rekor.namespace" $ | indent 2 }}
+spec:
+{{ toYaml .frontendConfigSpec | indent 2 }}
+---
+{{- end }}
+{{- end }}

--- a/charts/rekor/templates/server/ingress.yaml
+++ b/charts/rekor/templates/server/ingress.yaml
@@ -30,5 +30,53 @@ spec:
       {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
+{{- end }}
 {{- end -}}
+{{- range .Values.server.ingresses }}
+{{- if .enabled }}
+---
+apiVersion: "networking.k8s.io/v1"
+kind: Ingress
+metadata:
+  labels:
+    {{- include "rekor.server.labels" $ | nindent 4 }}
+  name: {{ include "rekor.server.fullname" $ }}-{{ .name }}
+{{ include "rekor.namespace" $ | indent 2 }}
+  annotations:
+{{- if eq .className "gce"}}
+    kubernetes.io/ingress.class: "gce"
+    {{- if .frontendConfigSpec }}
+    networking.gke.io/v1beta1.FrontendConfig: "{{ include "rekor.server.fullname" $ }}-{{ .name }}"
+    {{- end }}
+    {{- if .staticGlobalIP }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .staticGlobalIP | quote }}
+    {{- end }}
+{{- end }}
+{{- with .annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if and (.className) (not (eq .className "gce")) }}
+  ingressClassName: {{ .className }}
+{{- end }}
+  rules:
+    {{- range .hosts }}
+    - host: {{ required "An Ingress hostname is required" .host | quote }}
+      http:
+        paths:
+          - path: {{ .path }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend: {{- include "rekor.server.ingress.backend" $  | nindent 14 }}
+    {{- end }}
+{{- if .tls }}
+  tls:
+    {{- range .tls }}
+    - hosts:
+      {{- range .hosts }}
+      - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/rekor/templates/server/service.yaml
+++ b/charts/rekor/templates/server/service.yaml
@@ -1,9 +1,20 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.server.service.annotations }}
   annotations:
+{{- $port := include "rekor.server.port" . -}}
+{{- $backendConfigName := include "rekor.server.fullname" . -}}
+{{ if .Values.server.service.annotations }}
 {{ toYaml .Values.server.service.annotations | indent 4 }}
+{{ end }}
+{{- range .Values.server.ingresses }}
+{{- if and (.enabled) (eq .className "gce") }}
+  {{- if .backendConfigSpec }}
+    cloud.google.com/backend-config: '{"ports": {"{{- printf "%v" $port -}}": "{{- printf "%v-%v" $backendConfigName .name -}}"}}'
+  {{- end }}
+    cloud.google.com/neg: '{"ingress": true}'
+{{- break -}}
+{{- end }}
 {{- end }}
   labels:
     {{- include "rekor.server.labels" . | nindent 4 }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -601,6 +601,7 @@
                 "image",
                 "logging",
                 "ingress",
+                "ingresses",
                 "service",
                 "signer",
                 "readinessProbe",
@@ -811,6 +812,141 @@
                         {
                             "enabled": true,
                             "className": "nginx",
+                            "hosts": [
+                                {
+                                    "path": "/"
+                                }
+                            ],
+                            "annotations": {},
+                            "tls": []
+                        }
+                    ]
+                },
+                "ingresses": {
+                    "title": "The ingresses Schema",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "title": "An ingress Schema",
+                        "default": {},
+                        "required": [
+                            "enabled",
+                            "name",
+                            "className",
+                            "hosts",
+                            "tls"
+                        ],
+                        "properties": {
+                            "enabled": {
+                                "title": "The enabled Schema",
+                                "type": "boolean",
+                                "default": false,
+                                "examples": [
+                                    true
+                                ]
+                            },
+                            "name": {
+                                "title": "The name for the ingress (and dependent objects)",
+                                "type": "string",
+                                "default": "",
+                                "examples": [
+                                    "gce-ingress"
+                                ]
+                            },
+                            "className": {
+                                "title": "The className Schema",
+                                "type": "string",
+                                "default": "",
+                                "examples": [
+                                    "gce"
+                                ]
+                            },
+                            "hosts": {
+                                "title": "The hosts Schema",
+                                "type": "array",
+                                "default": [],
+                                "items": {
+                                    "title": "A Schema",
+                                    "type": "object",
+                                    "default": {},
+                                    "required": [
+                                        "path"
+                                    ],
+                                    "properties": {
+                                        "path": {
+                                            "title": "The path Schema",
+                                            "type": "string",
+                                            "default": "",
+                                            "examples": [
+                                                "/"
+                                            ]
+                                        }
+                                    },
+                                    "examples": [
+                                        {
+                                            "path": "/"
+                                        }
+                                    ]
+                                },
+                                "examples": [
+                                    [
+                                        {
+                                            "path": "/"
+                                        }
+                                    ]
+                                ]
+                            },
+                            "annotations": {
+                                "title": "The annotations Schema",
+                                "type": "object",
+                                "default": {},
+                                "required": [],
+                                "properties": {},
+                                "examples": [
+                                    {}
+                                ]
+                            },
+                            "tls": {
+                                "title": "The tls Schema",
+                                "type": "array",
+                                "default": [],
+                                "items": {},
+                                "examples": [
+                                    []
+                                ]
+                            },
+                            "staticGlobalIP": {
+                                "title": "The name of a GCP static IP address object to be assigned to the ingress-created load balancer",
+                                "type": "string",
+                                "default": "",
+                                "examples": [
+                                    "lb-ext-ip"
+                                ]
+                            },
+                            "frontendConfigSpec": {
+                                "title": "The frontendConfigSpec Schema - refers to values for networking.gke.io/v1beta1 FrontendConfig",
+                                "type": "object",
+                                "default": {},
+                                "required": [],
+                                "examples": [
+                                    {}
+                                ]
+                            },
+                            "backendConfigSpec": {
+                                "title": "The backendConfigSpec Schema - refers to values for cloud.google.com/v1 BackendConfig",
+                                "type": "object",
+                                "default": {},
+                                "required": [],
+                                "examples": [
+                                    {}
+                                ]
+                            }
+                        }
+                    },
+                    "examples": [
+                        {
+                            "enabled": true,
+                            "className": "gce",
                             "hosts": [
                                 {
                                     "path": "/"
@@ -2229,6 +2365,21 @@
                     "annotations": {},
                     "tls": []
                 },
+                "ingresses": [
+                    {
+                        "enabled": false,
+                        "className": "gce",
+                        "hosts": [
+                            {
+                                "path": "/"
+                            }
+                        ],
+                        "annotations": {},
+                        "tls": [],
+                        "securityPolicy": "rekor",
+                        "sslPolicy": "rekor"
+                    }
+                ],
                 "service": {
                     "type": "ClusterIP",
                     "ports": [

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -74,6 +74,25 @@ server:
         host: root
     annotations: {}
     tls: []
+  ingresses:
+    - enabled: false
+      name: "gce-ingress"
+      className: "gce"
+      hosts:
+        - path: /
+          host: root
+      annotations: {}
+      tls: []
+      staticGlobalIP: lb-ext-ip
+      frontendConfigSpec:   # https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#configuring_ingress_features_through_frontendconfig_parameters
+        sslPolicy: rekor-ssl-policy
+        redirectToHttps:
+          enabled: true
+      backendConfigSpec:   # https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#configuring_ingress_features_through_backendconfig_parameters
+        securityPolicy:
+          name: rekor-security-policy
+        logging:
+          enable: true
   service:
     type: ClusterIP
     ports:


### PR DESCRIPTION
## Description of the change

Adds ability to define more than one Ingress object for rekor, so we can launch GCE load balancer-based Ingress in parallel with NGINX one for testing in preparation for eventual migration

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
