### PR TITLE
bump scaffold chart to reflect new rekor chart version

### DIFF
--- a/charts/scaffold/Chart.lock
+++ b/charts/scaffold/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 2.3.2
 - name: rekor
   repository: https://sigstore.github.io/helm-charts
-  version: 1.3.3
+  version: 1.3.4
 - name: trillian
   repository: https://sigstore.github.io/helm-charts
   version: 0.2.6
@@ -17,5 +17,5 @@ dependencies:
 - name: tsa
   repository: https://sigstore.github.io/helm-charts
   version: 0.1.0
-digest: sha256:927b777cf07dd9006a5bb4629b02eee551a9a3915e7cb4bd1a252cdeda53592b
-generated: "2023-06-21T10:24:17.908567+02:00"
+digest: sha256:ccda506930417a2f29f333d0bff1d596ea0420561ee30548f6621ee846765581
+generated: "2023-06-26T06:41:16.068888313-04:00"

--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.6.10
+version: 0.6.11
 keywords:
   - security
   - pki
@@ -20,7 +20,7 @@ dependencies:
     repository: https://sigstore.github.io/helm-charts
     condition: fulcio.enabled
   - name: rekor
-    version: 1.3.3
+    version: 1.3.4
     repository: https://sigstore.github.io/helm-charts
     condition: rekor.enabled
   - name: trillian

--- a/charts/scaffold/README.md
+++ b/charts/scaffold/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.6.9](https://img.shields.io/badge/Version-0.6.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.11](https://img.shields.io/badge/Version-0.6.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Scaffolding the components of the sigstore architecture
 
@@ -38,8 +38,8 @@ helm uninstall [RELEASE_NAME]
 |------------|------|---------|
 | https://sigstore.github.io/helm-charts | ctlog | 0.2.40 |
 | https://sigstore.github.io/helm-charts | fulcio | 2.3.2 |
-| https://sigstore.github.io/helm-charts | rekor | 1.3.3 |
-| https://sigstore.github.io/helm-charts | trillian | 0.2.5 |
+| https://sigstore.github.io/helm-charts | rekor | 1.3.4 |
+| https://sigstore.github.io/helm-charts | trillian | 0.2.6 |
 | https://sigstore.github.io/helm-charts | tsa | 0.1.0 |
 | https://sigstore.github.io/helm-charts | tuf | 0.1.4 |
 


### PR DESCRIPTION
Needs https://github.com/sigstore/helm-charts/pull/555 to merge first

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
