### PR TITLE
add ability to set TLS fields for GRPC via k8s secret

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.3.6
+version: 2.3.7
 appVersion: 1.3.4
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.3.6](https://img.shields.io/badge/Version-2.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.4](https://img.shields.io/badge/AppVersion-1.3.4-informational?style=flat-square)
+![Version: 2.3.7](https://img.shields.io/badge/Version-2.3.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.4](https://img.shields.io/badge/AppVersion-1.3.4-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -59,6 +59,10 @@ spec:
             - "--kms-cert-chain-path=/etc/fulcio-config/chain.pem"
             {{- end }}
             - "--ct-log-url={{ if .Values.server.args.disable_ct_log }}{{ else if .Values.server.args.ct_log_url }}{{ .Values.server.args.ct_log_url }}{{ else }}http://{{ .Values.ctlog.name }}.{{ .Values.ctlog.namespace.name }}.svc/{{ .Values.ctlog.createctconfig.logPrefix }}{{ end }}"
+            {{- if .Values.server.grpcSvcTLS }}
+            - "--grpc-tls-certificate=/var/run/grpc-tls/cert.pem"
+            - "--grpc-tls-key=/var/run/grpc-tls/key.pem"
+            {{- end }}
             {{- range .Values.server.extraArgs }}
             - {{ . | quote }}
             {{- end }}
@@ -98,6 +102,11 @@ spec:
               mountPath: "/var/run/fulcio-secrets"
               readOnly: true
            {{- end }}
+           {{- if .Values.server.grpcSvcTLS }}
+            - name: grpc-tls
+              mountPath: "/var/run/grpc-tls"
+              readOnly: true
+           {{- end }}
     {{- if .Values.server.resources }}
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}
@@ -128,4 +137,14 @@ spec:
                 path: key.pem
               - key: cert
                 path: cert.pem
+        {{- end }}
+        {{- if .Values.server.grpcSvcTLS }}
+        - name: grpc-tls
+          secret:
+            secretName: {{ .Values.server.grpcSvcTLS.secretName }}
+            items:
+              - key: {{ .Values.server.grpcSvcTLS.certField }}
+                path: cert.pem
+              - key: {{ .Values.server.grpcSvcTLS.keyField }}
+                path: key.pem
         {{- end }}

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -140,6 +140,49 @@
                         5554
                     ]
                 },
+                "grpcSvcTLS": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The grpcSvcTLS Schema",
+                    "required": [
+                        "secretName",
+                        "keyField",
+                        "certField"
+                    ],
+                    "properties": {
+                        "secretName": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The secretName Schema",
+                            "examples": [
+                                "fulcio-grpc-tls"
+                            ]
+                        },
+                        "keyField": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The keyField Schema",
+                            "examples": [
+                                "tls.key"
+                            ]
+                        },
+                        "certField": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The certField Schema",
+                            "examples": [
+                                "tls.crt"
+                            ]
+                        }
+                    },
+                    "examples": [
+                        {
+                            "secretName": "fulcio-grpc-tls",
+                            "keyField": "tls.key",
+                            "certField": "tls.crt"
+                        }
+                    ]
+                },
                 "image": {
                     "type": "object",
                     "default": {},


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
