### PR TITLE
update image gcr.io/cloudsql-docker/gce-proxy to 1.33.9

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.7
+version: 0.2.8
 
 keywords:
   - security
@@ -34,7 +34,7 @@ annotations:
     - name: log_signer
       image: gcr.io/projectsigstore/trillian_log_signer@sha256:87699af429d79440f7e0a487d215c2129bf97b37698370d050a68822996f93f0
     - name: cloud_proxy
-      image: gcr.io/cloudsql-docker/gce-proxy@sha256:ec2858d78ac2b4d7945020589f6f86d151704a4617322f6c4196bafd952bf827
+      image: gcr.io/cloudsql-docker/gce-proxy@sha256:2c7789354d9063e5a910c1c40c8d5c91736d564e9f41d69f7ac4d785fd3333d7
     - name: scaffold_cloud_proxy
       image: ghcr.io/sigstore/scaffolding/cloudsqlproxy:@sha256:2c818523a9060cdefca10af0804c8f60549bdc1744e71008f9849b23605c4ccf
     - name: createdb

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -123,7 +123,7 @@ helm uninstall [RELEASE_NAME]
 | mysql.gcp.cloudsql.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | mysql.gcp.cloudsql.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | mysql.gcp.cloudsql.securityContext.runAsNonRoot | bool | `true` |  |
-| mysql.gcp.cloudsql.version | string | `"sha256:ec2858d78ac2b4d7945020589f6f86d151704a4617322f6c4196bafd952bf827"` | crane digest gcr.io/cloudsql-docker/gce-proxy:1.33.8 |
+| mysql.gcp.cloudsql.version | string | `"sha256:2c7789354d9063e5a910c1c40c8d5c91736d564e9f41d69f7ac4d785fd3333d7"` | crane digest gcr.io/cloudsql-docker/gce-proxy:1.33.9 |
 | mysql.gcp.enabled | bool | `false` |  |
 | mysql.gcp.instance | string | `""` |  |
 | mysql.gcp.scaffoldSQLProxy.registry | string | `"ghcr.io"` |  |

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -44,8 +44,8 @@ mysql:
     cloudsql:
       registry: gcr.io
       repository: cloudsql-docker/gce-proxy
-      # -- crane digest gcr.io/cloudsql-docker/gce-proxy:1.33.8
-      version: sha256:ec2858d78ac2b4d7945020589f6f86d151704a4617322f6c4196bafd952bf827
+      # -- crane digest gcr.io/cloudsql-docker/gce-proxy:1.33.9
+      version: sha256:2c7789354d9063e5a910c1c40c8d5c91736d564e9f41d69f7ac4d785fd3333d7
       resources:
         requests:
           memory: "2Gi"


### PR DESCRIPTION
## Description of the change

- update image gcr.io/cloudsql-docker/gce-proxy to 1.33.9

## Existing or Associated Issue(s)

Related to: https://github.com/sigstore/public-good-instance/issues/1534

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
