### PR TITLE
feat: add pdb to policy-controller

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.8.2
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -54,6 +54,9 @@ The Helm chart for Policy  Controller
 | webhook.resources.requests.memory | string | `"128Mi"` |  |
 | webhook.securityContext.enabled | bool | `false` |  |
 | webhook.securityContext.runAsUser | int | `65532` |  |
+| webhook.podDisruptionBudget.enabled | bool | `true` |  |
+| webhook.podDisruptionBudget.minAvailable | int | `1` |  |
+| webhook.podDisruptionBudget.maxUnavailable | int | `null` |  |
 | webhook.service.annotations | object | `{}` |  |
 | webhook.service.port | int | `443` |  |
 | webhook.service.type | string | `"ClusterIP"` |  |

--- a/charts/policy-controller/templates/webhook/poddisruptionbudget.yaml
+++ b/charts/policy-controller/templates/webhook/poddisruptionbudget.yaml
@@ -1,0 +1,27 @@
+{{ if .Values.webhook.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "policy-controller.fullname" . }}-webhook
+  labels:
+    {{- include "policy-controller.labels" . | nindent 4 }}
+    control-plane: {{ template "policy-controller.fullname" . }}-webhook
+{{- if .Values.labels }}
+{{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}
+  annotations:
+{{- if .Values.annotations }}
+{{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}
+spec:
+  minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
+  maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "policy-controller.selectorLabels" . | nindent 6 }}
+      control-plane: {{ template "policy-controller.fullname" . }}-webhook
+{{- end }}

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -37,6 +37,10 @@ webhook:
     capabilities:
       drop:
         - ALL
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+    # maxUnavailable: 3
   serviceAccount:
     annotations: {}
     create: true


### PR DESCRIPTION
## Description of the change

Adds a PodDisruptionBudget for the webhook deployment

## Additional Information

Enhances availability, especially when using multiple replicas

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated. TODO need a hand with this
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
