### PR TITLE
WIP: Changes to ctlog to update to latest and incorporation of common chart

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.44
+version: 0.3.0
 appVersion: 0.3.0
 
 keywords:
@@ -16,14 +16,19 @@ home: https://sigstore.dev/
 maintainers:
   - name: The Sigstore Authors
 
+dependencies:
+  - name: common
+    version: 0.1.0
+    repository: https://sigstore.github.io/helm-charts
+
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: ct_server
-      image: ghcr.io/sigstore/scaffolding/ct_server@sha256:91d23363c34ca0a8ec1fb89129815fb32f851eb8986bfbf7b2aed85c98411f04
+      image: ghcr.io/sigstore/scaffolding/ct_server@sha256:2ea576af6b64e154b718b058cd03b74fac8399affcf93c4251ab2234704ca432
     - name: createctconfig
       image: ghcr.io/sigstore/scaffolding/createctconfig@sha256:b3dae896ddb7b01b3257c668bc1e87f15aafe97f30a767f99426f557fa33e44c
     - name: createtree
-      image: ghcr.io/sigstore/scaffolding/createtree@sha256:0c6a1a49f906da6e59e7cfbba08a473778fc0296abdf8b86115861d5f3556ed4
+      image: ghcr.io/sigstore/scaffolding/createtree@sha256:2da5284bb29e18d125e4565d47256d0ded82c3a7001b44a4d152e2475ca1166c
     - name: curlimages/curl
-      image: docker.io/curlimages/curl@sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498
+      image: docker.io/curlimages/curl@sha256:48318407b8d98e8c7d5bd4741c88e8e1a5442de660b47f63ba656e5c910bc3da

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -23,11 +23,11 @@ Certificate Log
 | createctconfig.image.pullPolicy | string | `"IfNotPresent"` |  |
 | createctconfig.image.registry | string | `"ghcr.io"` |  |
 | createctconfig.image.repository | string | `"sigstore/scaffolding/createctconfig"` |  |
-| createctconfig.image.version | string | `"sha256:b3dae896ddb7b01b3257c668bc1e87f15aafe97f30a767f99426f557fa33e44c"` | v0.6.3 |
+| createctconfig.image.version | string | `"sha256:2d8072d832370a8dbbe96536eaf479a5bf3a738c997394c888fed8ddcbe84a1b"` | v0.6.5 |
 | createctconfig.initContainerImage.curl.imagePullPolicy | string | `"IfNotPresent"` |  |
 | createctconfig.initContainerImage.curl.registry | string | `"docker.io"` |  |
 | createctconfig.initContainerImage.curl.repository | string | `"curlimages/curl"` |  |
-| createctconfig.initContainerImage.curl.version | string | `"sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498"` | 7.82.0 |
+| createctconfig.initContainerImage.curl.version | string | `"sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498"` | 7.88.1 |
 | createctconfig.logPrefix | string | `"sigstorescaffolding"` |  |
 | createctconfig.name | string | `"createctconfig"` |  |
 | createctconfig.privateKeyPasswordSecretName | string | `""` |  |
@@ -47,7 +47,7 @@ Certificate Log
 | createtree.image.pullPolicy | string | `"IfNotPresent"` |  |
 | createtree.image.registry | string | `"ghcr.io"` |  |
 | createtree.image.repository | string | `"sigstore/scaffolding/createtree"` |  |
-| createtree.image.version | string | `"sha256:d5776d8a43632291e1c5a22a9266608db0daa0a11663445d701e327f2205974c"` |  |
+| createtree.image.version | string | `"sha256:47206322c1d6002ffc737d94852924fae0f749aa3a64c1899eee11f502f609a6"` |  |
 | createtree.name | string | `"createtree"` |  |
 | createtree.securityContext.runAsNonRoot | bool | `true` |  |
 | createtree.securityContext.runAsUser | int | `65533` |  |
@@ -65,7 +65,7 @@ Certificate Log
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"ghcr.io"` |  |
 | server.image.repository | string | `"sigstore/scaffolding/ct_server"` |  |
-| server.image.version | string | `"sha256:7c791d3b7c15e817807f07d4cdb00406529a114702ad448ee857e1d0fc5fb5a9"` |  |
+| server.image.version | string | `"sha256:1ef2480cf8ddb1f99da0d931283f3c55babb84d79bf36f66d7bed29985bcca7e"` |  |
 | server.ingress.annotations | object | `{}` |  |
 | server.ingress.className | string | `"nginx"` |  |
 | server.ingress.enabled | bool | `false` |  |
@@ -77,9 +77,10 @@ Certificate Log
 | server.ingresses[0].frontendConfigSpec.redirectToHttps.enabled | bool | `true` |  |
 | server.ingresses[0].frontendConfigSpec.sslPolicy | string | `"ctlog-ssl-policy"` |  |
 | server.ingresses[0].hosts[0].host | string | `"fulcio.localhost"` |  |
-| server.ingresses[0].hosts[0].path | string | `"/test"` |  |
-| server.ingresses[0].hosts[1].host | string | `"fulcio.localhost"` |  |
-| server.ingresses[0].hosts[1].path | string | `"/other-shard"` |  |
+| server.ingresses[0].hosts[0].paths[0].path | string | `"/test"` |  |
+| server.ingresses[0].hosts[0].paths[0].pathType | string | `"Prefix"` |  |
+| server.ingresses[0].hosts[0].paths[1].path | string | `"/other-shard"` |  |
+| server.ingresses[0].hosts[0].paths[1].serviceName | string | `"other-shard"` |  |
 | server.ingresses[0].name | string | `"gce-ingress"` |  |
 | server.ingresses[0].staticGlobalIP | string | `"lb-ext-ip"` |  |
 | server.ingresses[0].tls | list | `[]` |  |
@@ -97,12 +98,6 @@ Certificate Log
 | server.replicaCount | int | `1` |  |
 | server.securityContext.runAsNonRoot | bool | `true` |  |
 | server.securityContext.runAsUser | int | `65533` |  |
-| server.service.backendConfig.name | string | `"ctlog-backend-config"` |  |
-| server.service.backendConfig.spec.healthCheck.port | int | `6962` |  |
-| server.service.backendConfig.spec.healthCheck.requestPath | string | `"/healthz"` |  |
-| server.service.backendConfig.spec.healthCheck.type | string | `"HTTP"` |  |
-| server.service.backendConfig.spec.logging.enable | bool | `true` |  |
-| server.service.backendConfig.spec.securityPolicy.name | string | `"ctlog-security-policy"` |  |
 | server.service.ports[0].name | string | `"6962-tcp"` |  |
 | server.service.ports[0].port | int | `80` |  |
 | server.service.ports[0].protocol | string | `"TCP"` |  |
@@ -120,3 +115,4 @@ Certificate Log
 | trillian.logServer.portRPC | int | `8091` |  |
 | trillian.namespace | string | `"trillian-system"` |  |
 
+----------------------------------------------

--- a/charts/ctlog/templates/_helpers.tpl
+++ b/charts/ctlog/templates/_helpers.tpl
@@ -1,47 +1,4 @@
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "ctlog.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "ctlog.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
-Define the raw ctlog.namespace template if set with forceNamespace or .Release.Namespace is set
-*/}}
-{{- define "ctlog.rawnamespace" -}}
-{{- if .Values.forceNamespace -}}
-{{ print .Values.forceNamespace }}
-{{- else -}}
-{{ print .Release.Namespace }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Define the ctlog.namespace template if set with forceNamespace or .Release.Namespace is set
-*/}}
-{{- define "ctlog.namespace" -}}
-{{ printf "namespace: %s" (include "ctlog.rawnamespace" .) }}
-{{- end -}}
-
-{{/*
 Create a fully qualified createctconfig name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -75,32 +32,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "ctlog.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
 
-{{/*
-Common labels
-*/}}
-{{- define "ctlog.labels" -}}
-helm.sh/chart: {{ include "ctlog.chart" . }}
-{{ include "ctlog.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "ctlog.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "ctlog.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
 
 {{/*
 Server Arguments
@@ -126,7 +58,7 @@ Create the name of the service account to use
 */}}
 {{- define "ctlog.serviceAccountName" -}}
 {{- if .Values.server.serviceAccount.create }}
-{{- default (include "ctlog.fullname" .) .Values.server.serviceAccount.name }}
+{{- default (include "common.names.fullname" .) .Values.server.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.server.serviceAccount.name }}
 {{- end }}
@@ -154,29 +86,33 @@ Create the name of the service account to use for the createtree component
 {{- end -}}
 {{- end -}}
 
-{{/*
-Create the image path for the passed in image field
-*/}}
-{{- define "ctlog.image" -}}
-{{- if eq (substr 0 7 .version) "sha256:" -}}
-{{- printf "%s/%s@%s" .registry .repository .version -}}
-{{- else -}}
-{{- printf "%s/%s:%s" .registry .repository .version -}}
-{{- end -}}
-{{- end -}}
 
 {{/*
 Create the name of the config
 */}}
 {{- define "ctlog.config" -}}
-{{ printf "%s-config" (include "ctlog.fullname" .) }}
+{{ include "common.names.fullnameSuffix" (dict "suffix" "config" "context" $) }}
 {{- end }}
 
 {{/*
 Create the name of the secret
 */}}
 {{- define "ctlog.secret" -}}
-{{ printf "%s-secret" (include "ctlog.fullname" .) }}
+{{ include "common.names.fullnameSuffix" (dict "suffix" "secret" "context" $) }}
+{{- end }}
+
+{{/*
+Create the name of the secret operator
+*/}}
+{{- define "ctlog.secret-operator" -}}
+{{ include "common.names.fullnameSuffix" (dict "suffix" "secret-operator" "context" $) }}
+{{- end }}
+
+{{/*
+Create the name of the cm operator
+*/}}
+{{- define "ctlog.cm-operator" -}}
+{{ include "common.names.fullnameSuffix" (dict "suffix" "cm-operator" "context" $) }}
 {{- end }}
 
 {{/*

--- a/charts/ctlog/templates/cm-operator-role.yaml
+++ b/charts/ctlog/templates/cm-operator-role.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "ctlog.fullname" . }}-cm-operator
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "ctlog.cm-operator" . }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["configmaps"]

--- a/charts/ctlog/templates/cm-operator-rolebinding.yaml
+++ b/charts/ctlog/templates/cm-operator-rolebinding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "ctlog.fullname" . }}-cm-operator
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "ctlog.cm-operator" . }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "ctlog.fullname" . }}-cm-operator
+  name: {{ template "ctlog.cm-operator" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "ctlog.serviceAccountName.createtree" . }}
-{{ include "ctlog.namespace" . | indent 4 }}
+{{ include "common.names.namespace" . | indent 4 }}

--- a/charts/ctlog/templates/createctconfig-job.yaml
+++ b/charts/ctlog/templates/createctconfig-job.yaml
@@ -3,9 +3,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "ctlog.createctconfig.fullname" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 {{- if .Values.createctconfig.annotations }}
   annotations:
 {{ toYaml .Values.createctconfig.annotations | indent 4 }}
@@ -22,7 +22,7 @@ spec:
       automountServiceAccountToken: {{ .Values.createctconfig.serviceAccount.mountToken }}
       initContainers:
         - name: "wait-for-createtree-configmap"
-          image: "{{ template "ctlog.image" .Values.createctconfig.initContainerImage.curl }}"
+          image: "{{ template "common.images.image" .Values.createctconfig.initContainerImage.curl }}"
           imagePullPolicy: {{ .Values.createctconfig.initContainerImage.curl.imagePullPolicy }}
           command: ["sh", "-c", "until curl --fail --header \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --max-time 10 https://kubernetes.default.svc/api/v1/namespaces/$(NAMESPACE)/configmaps/{{ template "ctlog.config" . }} | grep '\"treeID\":'; do echo waiting for Configmap {{ template "ctlog.config" . }}; sleep 5; done;"]
           env:
@@ -36,11 +36,11 @@ spec:
     {{- end }}
       containers:
         - name: {{ template "ctlog.createctconfig.fullname" . }}
-          image: "{{ template "ctlog.image" .Values.createctconfig.image }}"
+          image: "{{ template "common.images.image" .Values.createctconfig.image }}"
           imagePullPolicy: "{{ .Values.createctconfig.image.pullPolicy }}"
           args: [
             "--configmap={{ template "ctlog.config" . }}",
-            "--secret={{ .Values.createctconfig.secret | default (printf "%s-secret" (include "ctlog.fullname" .)) }}",
+            "--secret={{ .Values.createctconfig.secret | default (include "ctlog.secret" .) }}",
           {{- if .Values.createctconfig.privateSecret }}
             "--private-secret={{ .Values.createctconfig.privateSecret }}",
           {{- end }}
@@ -48,7 +48,7 @@ spec:
             "--pubkeysecret={{ .Values.createctconfig.pubkeysecret }}",
           {{- end }}
             "--fulcio-url={{ .Values.createctconfig.fulcioURL }}",
-            "--trillian-server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace }}:{{ .Values.trillian.logServer.portRPC}}",
+            "--trillian-server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace.name }}:{{ .Values.trillian.logServer.portRPC}}",
           {{- if .Values.createctconfig.privateKeyPasswordSecretName }}
             "--key-password=$(PRIVATE_KEY_PASSWORD)",
           {{- end }}

--- a/charts/ctlog/templates/createctconfig-serviceaccount.yaml
+++ b/charts/ctlog/templates/createctconfig-serviceaccount.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "ctlog.serviceAccountName.createctconfig" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
   annotations:
 {{ toYaml .Values.createctconfig.serviceAccount.annotations | indent 4 }}
 {{- end }}

--- a/charts/ctlog/templates/createtree-job.yaml
+++ b/charts/ctlog/templates/createtree-job.yaml
@@ -3,9 +3,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "ctlog.createtree.fullname" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 {{- if .Values.createtree.annotations }}
   annotations:
 {{ toYaml .Values.createtree.annotations | indent 4 }}
@@ -21,7 +21,7 @@ spec:
       automountServiceAccountToken: {{ .Values.createtree.serviceAccount.mountToken }}
       containers:
         - name: {{ template "ctlog.createtree.fullname" . }}
-          image: "{{ template "ctlog.image" .Values.createtree.image }}"
+          image: "{{ template "common.images.image" .Values.createtree.image }}"
           imagePullPolicy: "{{ .Values.createtree.image.pullPolicy }}"
           env:
           - name: NAMESPACE
@@ -32,7 +32,7 @@ spec:
             "--namespace=$(NAMESPACE)",
             "--configmap={{ template "ctlog.config" . }}",
             "--display_name={{ .Values.createtree.displayName }}",
-            "--admin_server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace }}:{{ .Values.trillian.logServer.portRPC}}"
+            "--admin_server={{ .Values.trillian.logServer.name }}.{{ .Values.trillian.namespace.name }}:{{ .Values.trillian.logServer.portRPC}}"
           ]
     {{- if .Values.createtree.resources }}
           resources:

--- a/charts/ctlog/templates/createtree-serviceaccount.yaml
+++ b/charts/ctlog/templates/createtree-serviceaccount.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "ctlog.serviceAccountName.createtree" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
   annotations:
 {{ toYaml .Values.createtree.serviceAccount.annotations | indent 4 }}
 {{- end }}

--- a/charts/ctlog/templates/ctlog-configmap.yaml
+++ b/charts/ctlog/templates/ctlog-configmap.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "ctlog.config" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 data:
   __placeholder: |
     ###################################################################

--- a/charts/ctlog/templates/ctlog-deployment.yaml
+++ b/charts/ctlog/templates/ctlog-deployment.yaml
@@ -1,15 +1,15 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "ctlog.fullname" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "common.names.fullname" . }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.server.replicaCount }}
   selector:
     matchLabels:
-      {{- include "ctlog.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -18,12 +18,12 @@ spec:
         {{- toYaml .Values.server.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "ctlog.labels" . | nindent 8 }}
+        {{- include "common.labels.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "ctlog.serviceAccountName" . }}
       containers:
-        - name: {{ template "ctlog.fullname" . }}
-          image: "{{ template "ctlog.image" .Values.server.image }}"
+        - name: {{ template "common.names.fullname" . }}
+          image: "{{ template "common.images.image" .Values.server.image }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           args:
 {{  include "ctlog.server.args" . | indent 12 }}
@@ -52,4 +52,4 @@ spec:
       volumes:
         - name: keys
           secret:
-            secretName: {{ .Values.createctconfig.secret | default (printf "%s-secret" (include "ctlog.fullname" .)) }}
+            secretName: {{ .Values.createctconfig.secret | default (include "ctlog.secret" .) }}

--- a/charts/ctlog/templates/ctlog-ingress.yaml
+++ b/charts/ctlog/templates/ctlog-ingress.yaml
@@ -3,9 +3,9 @@ apiVersion: "networking.k8s.io/v1"
 kind: Ingress
 metadata:
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
   name: {{ template "ctlog.fullname" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   annotations:
 {{ toYaml .Values.server.ingress.annotations | indent 4 }}
 spec:

--- a/charts/ctlog/templates/ctlog-service.yaml
+++ b/charts/ctlog/templates/ctlog-service.yaml
@@ -11,15 +11,15 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
   {{- end }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 {{- if .Values.server.service.labels }}
 {{ toYaml .Values.server.service.labels | indent 4 }}
 {{- end }}
-  name: {{ template "ctlog.fullname" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "common.names.fullname" . }}
+{{ include "common.names.namespace" . | indent 2 }}
 spec:
   ports:
     {{- tpl (toYaml .Values.server.service.ports) . | nindent 4 }}
   selector:
-    {{- include "ctlog.selectorLabels" . | nindent 4 }}
+    {{- include "common.labels.selectorLabels" . | nindent 4 }}
   type: "{{ .Values.server.service.type }}"

--- a/charts/ctlog/templates/ctlog-serviceaccount.yaml
+++ b/charts/ctlog/templates/ctlog-serviceaccount.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "ctlog.serviceAccountName" . }}
-{{ include "ctlog.namespace" . | indent 2 }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
   annotations:
 {{ toYaml .Values.server.serviceAccount.annotations | indent 4 }}

--- a/charts/ctlog/templates/secret-operator-role.yaml
+++ b/charts/ctlog/templates/secret-operator-role.yaml
@@ -1,10 +1,11 @@
+{{- $name := include "common.names.fullnameSuffix" (dict "suffix" "secret-operator" "context" $) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "ctlog.fullname" . }}-secret-operator
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ $name }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["configmaps"]

--- a/charts/ctlog/templates/secret-operator-rolebinding.yaml
+++ b/charts/ctlog/templates/secret-operator-rolebinding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "ctlog.fullname" . }}-secret-operator
-{{ include "ctlog.namespace" . | indent 2 }}
+  name: {{ template "ctlog.secret-operator" . }}
+{{ include "common.names.namespace" . | indent 2 }}
   labels:
-    {{- include "ctlog.labels" . | nindent 4 }}
+    {{- include "common.labels.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "ctlog.fullname" . }}-secret-operator
+  name: {{ template "ctlog.secret-operator" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "ctlog.serviceAccountName.createctconfig" . }}
-{{ include "ctlog.namespace" . | indent 4 }}
+{{ include "common.names.namespace" . | indent 4 }}

--- a/charts/ctlog/values.schema.json
+++ b/charts/ctlog/values.schema.json
@@ -39,12 +39,10 @@
                     ]
                 }
             },
-            "examples": [
-                {
-                    "create": false,
-                    "name": "ctlog-system"
-                }
-            ]
+            "examples": [{
+                "create": false,
+                "name": "ctlog-system"
+            }]
         },
         "server": {
             "type": "object",
@@ -54,12 +52,15 @@
                 "replicaCount",
                 "config",
                 "image",
+                "livenessProbe",
+                "readinessProbe",
                 "serviceAccount",
                 "podAnnotations",
                 "portHTTP",
                 "portHTTPMetrics",
                 "service",
                 "ingress",
+                "ingresses",
                 "extraArgs",
                 "securityContext"
             ],
@@ -98,12 +99,10 @@
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "key": "treeID",
-                            "treeID": ""
-                        }
-                    ]
+                    "examples": [{
+                        "key": "treeID",
+                        "treeID": ""
+                    }]
                 },
                 "image": {
                     "type": "object",
@@ -145,26 +144,130 @@
                             "default": "",
                             "title": "The version Schema",
                             "examples": [
-                                "sha256:7c791d3b7c15e817807f07d4cdb00406529a114702ad448ee857e1d0fc5fb5a9"
+                                "sha256:1ef2480cf8ddb1f99da0d931283f3c55babb84d79bf36f66d7bed29985bcca7e"
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "registry": "ghcr.io",
-                            "repository": "sigstore/scaffolding/ct_server",
-                            "pullPolicy": "IfNotPresent",
-                            "version": "sha256:7c791d3b7c15e817807f07d4cdb00406529a114702ad448ee857e1d0fc5fb5a9"
-                        }
-                    ]
+                    "examples": [{
+                        "registry": "ghcr.io",
+                        "repository": "sigstore/scaffolding/ct_server",
+                        "pullPolicy": "IfNotPresent",
+                        "version": "sha256:1ef2480cf8ddb1f99da0d931283f3c55babb84d79bf36f66d7bed29985bcca7e"
+                    }]
                 },
                 "livenessProbe": {
-                    "description": "Liveness probe configuration",
-                    "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
+                    "type": "object",
+                    "default": {},
+                    "title": "The livenessProbe Schema",
+                    "required": [
+                        "httpGet",
+                        "initialDelaySeconds"
+                    ],
+                    "properties": {
+                        "httpGet": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The httpGet Schema",
+                            "required": [
+                                "path",
+                                "port"
+                            ],
+                            "properties": {
+                                "path": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The path Schema",
+                                    "examples": [
+                                        "/healthz"
+                                    ]
+                                },
+                                "port": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The port Schema",
+                                    "examples": [
+                                        6962
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "path": "/healthz",
+                                "port": 6962
+                            }]
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer",
+                            "default": 0,
+                            "title": "The initialDelaySeconds Schema",
+                            "examples": [
+                                10
+                            ]
+                        }
+                    },
+                    "examples": [{
+                        "httpGet": {
+                            "path": "/healthz",
+                            "port": 6962
+                        },
+                        "initialDelaySeconds": 10
+                    }]
                 },
                 "readinessProbe": {
-                    "description": "Readiness probe configuration",
-                    "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
+                    "type": "object",
+                    "default": {},
+                    "title": "The readinessProbe Schema",
+                    "required": [
+                        "httpGet",
+                        "initialDelaySeconds"
+                    ],
+                    "properties": {
+                        "httpGet": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The httpGet Schema",
+                            "required": [
+                                "path",
+                                "port"
+                            ],
+                            "properties": {
+                                "path": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The path Schema",
+                                    "examples": [
+                                        "/healthz"
+                                    ]
+                                },
+                                "port": {
+                                    "type": "integer",
+                                    "default": 0,
+                                    "title": "The port Schema",
+                                    "examples": [
+                                        6962
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "path": "/healthz",
+                                "port": 6962
+                            }]
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer",
+                            "default": 0,
+                            "title": "The initialDelaySeconds Schema",
+                            "examples": [
+                                10
+                            ]
+                        }
+                    },
+                    "examples": [{
+                        "httpGet": {
+                            "path": "/healthz",
+                            "port": 6962
+                        },
+                        "initialDelaySeconds": 10
+                    }]
                 },
                 "serviceAccount": {
                     "type": "object",
@@ -199,9 +302,7 @@
                             "title": "The annotations Schema",
                             "required": [],
                             "properties": {},
-                            "examples": [
-                                {}
-                            ]
+                            "examples": [{}]
                         },
                         "mountToken": {
                             "type": "boolean",
@@ -212,14 +313,12 @@
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "create": true,
-                            "name": "",
-                            "annotations": {},
-                            "mountToken": false
-                        }
-                    ]
+                    "examples": [{
+                        "create": true,
+                        "name": "",
+                        "annotations": {},
+                        "mountToken": false
+                    }]
                 },
                 "podAnnotations": {
                     "type": "object",
@@ -256,13 +355,11 @@
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "prometheus.io/scrape": "true",
-                            "prometheus.io/path": "/metrics",
-                            "prometheus.io/port": "6963"
-                        }
-                    ]
+                    "examples": [{
+                        "prometheus.io/scrape": "true",
+                        "prometheus.io/path": "/metrics",
+                        "prometheus.io/port": "6963"
+                    }]
                 },
                 "portHTTP": {
                     "type": "integer",
@@ -343,76 +440,7 @@
                                         ]
                                     }
                                 },
-                                "examples": [
-                                    {
-                                        "name": "6962-tcp",
-                                        "port": 80,
-                                        "protocol": "TCP",
-                                        "targetPort": 6962
-                                    },
-                                    {
-                                        "name": "6963-tcp",
-                                        "port": 6963,
-                                        "protocol": "TCP",
-                                        "targetPort": 6963
-                                    }
-                                ]
-                            },
-                            "examples": [
-                                [
-                                    {
-                                        "name": "6962-tcp",
-                                        "port": 80,
-                                        "protocol": "TCP",
-                                        "targetPort": 6962
-                                    },
-                                    {
-                                        "name": "6963-tcp",
-                                        "port": 6963,
-                                        "protocol": "TCP",
-                                        "targetPort": 6963
-                                    }
-                                ]
-                            ]
-                        },
-                        "backendConfig": {
-                            "title": "The backendConfig Schema - refers to values for cloud.google.com/v1 BackendConfig",
-                            "type": "object",
-                            "default": {},
-                            "required": [
-                                "name",
-                                "spec"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "type": "string",
-                                    "title": "The name Schema",
-                                    "examples": [
-                                        "ctlog-backend-config"
-                                    ]
-                                },
-                                "spec": {
-                                    "type": "object",
-                                    "default": {},
-                                    "title": "The spec Schema",
-                                    "examples": []
-                                }
-                            },
-                            "examples": [
-                                {
-                                    "name": "ctlog-backend-config",
-                                    "spec": {
-                                        "foo": "bar"
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    "examples": [
-                        {
-                            "type": "ClusterIP",
-                            "ports": [
-                                {
+                                "examples": [{
                                     "name": "6962-tcp",
                                     "port": 80,
                                     "protocol": "TCP",
@@ -423,10 +451,39 @@
                                     "port": 6963,
                                     "protocol": "TCP",
                                     "targetPort": 6963
-                                }
+                                }]
+                            },
+                            "examples": [
+                                [{
+                                    "name": "6962-tcp",
+                                    "port": 80,
+                                    "protocol": "TCP",
+                                    "targetPort": 6962
+                                },
+                                {
+                                    "name": "6963-tcp",
+                                    "port": 6963,
+                                    "protocol": "TCP",
+                                    "targetPort": 6963
+                                }]
                             ]
                         }
-                    ]
+                    },
+                    "examples": [{
+                        "type": "ClusterIP",
+                        "ports": [{
+                            "name": "6962-tcp",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 6962
+                        },
+                        {
+                            "name": "6963-tcp",
+                            "port": 6963,
+                            "protocol": "TCP",
+                            "targetPort": 6963
+                        }]
+                    }]
                 },
                 "ingress": {
                     "type": "object",
@@ -477,18 +534,14 @@
                                         ]
                                     }
                                 },
-                                "examples": [
-                                    {
-                                        "path": "/"
-                                    }
-                                ]
+                                "examples": [{
+                                    "path": "/"
+                                }]
                             },
                             "examples": [
-                                [
-                                    {
-                                        "path": "/"
-                                    }
-                                ]
+                                [{
+                                    "path": "/"
+                                }]
                             ]
                         },
                         "annotations": {
@@ -497,9 +550,7 @@
                             "title": "The annotations Schema",
                             "required": [],
                             "properties": {},
-                            "examples": [
-                                {}
-                            ]
+                            "examples": [{}]
                         },
                         "tls": {
                             "type": "array",
@@ -511,191 +562,289 @@
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "enabled": false,
-                            "className": "nginx",
-                            "hosts": [
-                                {
-                                    "path": "/"
-                                }
-                            ],
-                            "annotations": {},
-                            "tls": []
-                        }
-                    ]
+                    "examples": [{
+                        "enabled": false,
+                        "className": "nginx",
+                        "hosts": [{
+                            "path": "/"
+                        }],
+                        "annotations": {},
+                        "tls": []
+                    }]
                 },
                 "ingresses": {
-                    "title": "The ingresses Schema",
                     "type": "array",
                     "default": [],
+                    "title": "The ingresses Schema",
                     "items": {
-                        "title": "An ingress Schema",
+                        "type": "object",
                         "default": {},
+                        "title": "A Schema",
                         "required": [
                             "enabled",
                             "name",
                             "className",
                             "hosts",
-                            "tls"
+                            "annotations",
+                            "tls",
+                            "staticGlobalIP",
+                            "frontendConfigSpec"
                         ],
                         "properties": {
                             "enabled": {
-                                "title": "The enabled Schema",
                                 "type": "boolean",
                                 "default": false,
+                                "title": "The enabled Schema",
                                 "examples": [
-                                    true
+                                    false
                                 ]
                             },
                             "name": {
-                                "title": "The name for the ingress (and dependent objects)",
                                 "type": "string",
                                 "default": "",
+                                "title": "The name Schema",
                                 "examples": [
                                     "gce-ingress"
                                 ]
                             },
                             "className": {
-                                "title": "The className Schema",
                                 "type": "string",
                                 "default": "",
+                                "title": "The className Schema",
                                 "examples": [
                                     "gce"
                                 ]
                             },
                             "hosts": {
-                                "title": "The hosts Schema",
                                 "type": "array",
                                 "default": [],
+                                "title": "The hosts Schema",
                                 "items": {
-                                    "title": "A Schema",
                                     "type": "object",
                                     "default": {},
+                                    "title": "A Schema",
                                     "required": [
+                                        "host",
                                         "paths"
                                     ],
                                     "properties": {
+                                        "host": {
+                                            "type": "string",
+                                            "default": "",
+                                            "title": "The host Schema",
+                                            "examples": [
+                                                "fulcio.localhost"
+                                            ]
+                                        },
                                         "paths": {
-                                            "title": "The path Schema",
                                             "type": "array",
                                             "default": [],
+                                            "title": "The paths Schema",
                                             "items": {
-                                                "title": "A Schema",
                                                 "type": "object",
-                                                "default": {},
+                                                "title": "A Schema",
                                                 "required": [
-                                                    "path"
+                                                    "path",
+                                                    "pathType",
+                                                    "serviceName"
                                                 ],
                                                 "properties": {
                                                     "path": {
-                                                        "title": "The path Schema",
                                                         "type": "string",
-                                                        "default": "",
+                                                        "title": "The path Schema",
                                                         "examples": [
-                                                            "/"
+                                                            "/test",
+                                                            "/other-shard"
                                                         ]
                                                     },
                                                     "pathType": {
-                                                        "title": "The pathType Schema",
                                                         "type": "string",
                                                         "default": "",
+                                                        "title": "The pathType Schema",
                                                         "examples": [
                                                             "Prefix"
                                                         ]
                                                     },
                                                     "serviceName": {
-                                                        "title": "The serviceName Schema",
                                                         "type": "string",
                                                         "default": "",
+                                                        "title": "The serviceName Schema",
                                                         "examples": [
-                                                            "ctlog-service"
+                                                            "other-shard"
                                                         ]
                                                     }
                                                 },
-                                                "examples": [
-                                                    {
-                                                        "path": "/",
-                                                        "pathType": "Prefix",
-                                                        "serviceName": "ctlog-service"
-                                                    }
-                                                ]
+                                                "examples": [{
+                                                    "path": "/test",
+                                                    "pathType": "Prefix"
+                                                },
+                                                {
+                                                    "path": "/other-shard",
+                                                    "serviceName": "other-shard"
+                                                }]
                                             },
                                             "examples": [
-                                                [
-                                                    {
-                                                        "path": "/",
-                                                        "pathType": "Prefix",
-                                                        "serviceName": "ctlog-service"
-                                                    }
-                                                ]
+                                                [{
+                                                    "path": "/test",
+                                                    "pathType": "Prefix"
+                                                },
+                                                {
+                                                    "path": "/other-shard",
+                                                    "serviceName": "other-shard"
+                                                }]
                                             ]
                                         }
                                     },
-                                    "examples": [
+                                    "examples": [{
+                                        "host": "fulcio.localhost",
+                                        "paths": [{
+                                            "path": "/test",
+                                            "pathType": "Prefix"
+                                        },
                                         {
-                                            "path": "/"
-                                        }
-                                    ]
+                                            "path": "/other-shard",
+                                            "serviceName": "other-shard"
+                                        }]
+                                    }]
                                 },
                                 "examples": [
-                                    [
+                                    [{
+                                        "host": "fulcio.localhost",
+                                        "paths": [{
+                                            "path": "/test",
+                                            "pathType": "Prefix"
+                                        },
                                         {
-                                            "path": "/"
-                                        }
-                                    ]
+                                            "path": "/other-shard",
+                                            "serviceName": "other-shard"
+                                        }]
+                                    }]
                                 ]
                             },
                             "annotations": {
-                                "title": "The annotations Schema",
                                 "type": "object",
                                 "default": {},
+                                "title": "The annotations Schema",
                                 "required": [],
                                 "properties": {},
-                                "examples": [
-                                    {}
-                                ]
+                                "examples": [{}]
                             },
                             "tls": {
-                                "title": "The tls Schema",
                                 "type": "array",
                                 "default": [],
+                                "title": "The tls Schema",
                                 "items": {},
                                 "examples": [
                                     []
                                 ]
                             },
                             "staticGlobalIP": {
-                                "title": "The name of a GCP static IP address object to be assigned to the ingress-created load balancer",
                                 "type": "string",
                                 "default": "",
+                                "title": "The staticGlobalIP Schema",
                                 "examples": [
                                     "lb-ext-ip"
                                 ]
                             },
                             "frontendConfigSpec": {
-                                "title": "The frontendConfigSpec Schema - refers to values for networking.gke.io/v1beta1 FrontendConfig",
                                 "type": "object",
                                 "default": {},
-                                "required": [],
-                                "examples": [
-                                    {}
-                                ]
+                                "title": "The frontendConfigSpec Schema",
+                                "required": [
+                                    "sslPolicy",
+                                    "redirectToHttps"
+                                ],
+                                "properties": {
+                                    "sslPolicy": {
+                                        "type": "string",
+                                        "default": "",
+                                        "title": "The sslPolicy Schema",
+                                        "examples": [
+                                            "ctlog-ssl-policy"
+                                        ]
+                                    },
+                                    "redirectToHttps": {
+                                        "type": "object",
+                                        "default": {},
+                                        "title": "The redirectToHttps Schema",
+                                        "required": [
+                                            "enabled"
+                                        ],
+                                        "properties": {
+                                            "enabled": {
+                                                "type": "boolean",
+                                                "default": false,
+                                                "title": "The enabled Schema",
+                                                "examples": [
+                                                    true
+                                                ]
+                                            }
+                                        },
+                                        "examples": [{
+                                            "enabled": true
+                                        }]
+                                    }
+                                },
+                                "examples": [{
+                                    "sslPolicy": "ctlog-ssl-policy",
+                                    "redirectToHttps": {
+                                        "enabled": true
+                                    }
+                                }]
                             }
-                        }
+                        },
+                        "examples": [{
+                            "enabled": false,
+                            "name": "gce-ingress",
+                            "className": "gce",
+                            "hosts": [{
+                                "host": "fulcio.localhost",
+                                "paths": [{
+                                    "path": "/test",
+                                    "pathType": "Prefix"
+                                },
+                                {
+                                    "path": "/other-shard",
+                                    "serviceName": "other-shard"
+                                }]
+                            }],
+                            "annotations": {},
+                            "tls": [],
+                            "staticGlobalIP": "lb-ext-ip",
+                            "frontendConfigSpec": {
+                                "sslPolicy": "ctlog-ssl-policy",
+                                "redirectToHttps": {
+                                    "enabled": true
+                                }
+                            }
+                        }]
                     },
                     "examples": [
-                        {
-                            "enabled": true,
+                        [{
+                            "enabled": false,
+                            "name": "gce-ingress",
                             "className": "gce",
-                            "hosts": [
+                            "hosts": [{
+                                "host": "fulcio.localhost",
+                                "paths": [{
+                                    "path": "/test",
+                                    "pathType": "Prefix"
+                                },
                                 {
-                                    "path": "/"
-                                }
-                            ],
+                                    "path": "/other-shard",
+                                    "serviceName": "other-shard"
+                                }]
+                            }],
                             "annotations": {},
-                            "tls": []
-                        }
+                            "tls": [],
+                            "staticGlobalIP": "lb-ext-ip",
+                            "frontendConfigSpec": {
+                                "sslPolicy": "ctlog-ssl-policy",
+                                "redirectToHttps": {
+                                    "enabled": true
+                                }
+                            }
+                        }]
                     ]
                 },
                 "extraArgs": {
@@ -733,75 +882,106 @@
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "runAsNonRoot": true,
-                            "runAsUser": 65533
-                        }
-                    ]
-                }
-            },
-            "examples": [
-                {
-                    "replicaCount": 1,
-                    "config": {
-                        "key": "treeID",
-                        "treeID": ""
-                    },
-                    "image": {
-                        "registry": "ghcr.io",
-                        "repository": "sigstore/scaffolding/ct_server",
-                        "pullPolicy": "IfNotPresent",
-                        "version": "sha256:7c791d3b7c15e817807f07d4cdb00406529a114702ad448ee857e1d0fc5fb5a9"
-                    },
-                    "serviceAccount": {
-                        "create": true,
-                        "name": "",
-                        "annotations": {},
-                        "mountToken": false
-                    },
-                    "podAnnotations": {
-                        "prometheus.io/scrape": "true",
-                        "prometheus.io/path": "/metrics",
-                        "prometheus.io/port": "6963"
-                    },
-                    "portHTTP": 6962,
-                    "portHTTPMetrics": 6963,
-                    "service": {
-                        "type": "ClusterIP",
-                        "ports": [
-                            {
-                                "name": "6962-tcp",
-                                "port": 80,
-                                "protocol": "TCP",
-                                "targetPort": 6962
-                            },
-                            {
-                                "name": "6963-tcp",
-                                "port": 6963,
-                                "protocol": "TCP",
-                                "targetPort": 6963
-                            }
-                        ]
-                    },
-                    "ingress": {
-                        "enabled": false,
-                        "className": "nginx",
-                        "hosts": [
-                            {
-                                "path": "/"
-                            }
-                        ],
-                        "annotations": {},
-                        "tls": []
-                    },
-                    "extraArgs": [],
-                    "securityContext": {
+                    "examples": [{
                         "runAsNonRoot": true,
                         "runAsUser": 65533
-                    }
+                    }]
                 }
-            ]
+            },
+            "examples": [{
+                "replicaCount": 1,
+                "config": {
+                    "key": "treeID",
+                    "treeID": ""
+                },
+                "image": {
+                    "registry": "ghcr.io",
+                    "repository": "sigstore/scaffolding/ct_server",
+                    "pullPolicy": "IfNotPresent",
+                    "version": "sha256:1ef2480cf8ddb1f99da0d931283f3c55babb84d79bf36f66d7bed29985bcca7e"
+                },
+                "livenessProbe": {
+                    "httpGet": {
+                        "path": "/healthz",
+                        "port": 6962
+                    },
+                    "initialDelaySeconds": 10
+                },
+                "readinessProbe": {
+                    "httpGet": {
+                        "path": "/healthz",
+                        "port": 6962
+                    },
+                    "initialDelaySeconds": 10
+                },
+                "serviceAccount": {
+                    "create": true,
+                    "name": "",
+                    "annotations": {},
+                    "mountToken": false
+                },
+                "podAnnotations": {
+                    "prometheus.io/scrape": "true",
+                    "prometheus.io/path": "/metrics",
+                    "prometheus.io/port": "6963"
+                },
+                "portHTTP": 6962,
+                "portHTTPMetrics": 6963,
+                "service": {
+                    "type": "ClusterIP",
+                    "ports": [{
+                        "name": "6962-tcp",
+                        "port": 80,
+                        "protocol": "TCP",
+                        "targetPort": 6962
+                    },
+                    {
+                        "name": "6963-tcp",
+                        "port": 6963,
+                        "protocol": "TCP",
+                        "targetPort": 6963
+                    }]
+                },
+                "ingress": {
+                    "enabled": false,
+                    "className": "nginx",
+                    "hosts": [{
+                        "path": "/"
+                    }],
+                    "annotations": {},
+                    "tls": []
+                },
+                "ingresses": [{
+                    "enabled": false,
+                    "name": "gce-ingress",
+                    "className": "gce",
+                    "hosts": [{
+                        "host": "fulcio.localhost",
+                        "paths": [{
+                            "path": "/test",
+                            "pathType": "Prefix"
+                        },
+                        {
+                            "path": "/other-shard",
+                            "serviceName": "other-shard"
+                        }]
+                    }],
+                    "annotations": {},
+                    "tls": [],
+                    "staticGlobalIP": "lb-ext-ip",
+                    "frontendConfigSpec": {
+                        "sslPolicy": "ctlog-ssl-policy",
+                        "redirectToHttps": {
+                            "enabled": true
+                        }
+                    }
+                }],
+                "extraArgs": [],
+                "securityContext": {
+                    "runAsNonRoot": true,
+                    "runAsUser": 65533
+                }
+            }]
         },
         "createtree": {
             "type": "object",
@@ -810,6 +990,7 @@
             "required": [
                 "enabled",
                 "name",
+                "displayName",
                 "image",
                 "ttlSecondsAfterFinished",
                 "serviceAccount",
@@ -831,6 +1012,14 @@
                     "title": "The name Schema",
                     "examples": [
                         "createtree"
+                    ]
+                },
+                "displayName": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The displayName Schema",
+                    "examples": [
+                        "ctlog-tree"
                     ]
                 },
                 "image": {
@@ -873,18 +1062,16 @@
                             "default": "",
                             "title": "The version Schema",
                             "examples": [
-                                "sha256:d5776d8a43632291e1c5a22a9266608db0daa0a11663445d701e327f2205974c"
+                                "sha256:47206322c1d6002ffc737d94852924fae0f749aa3a64c1899eee11f502f609a6"
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "registry": "ghcr.io",
-                            "repository": "sigstore/scaffolding/createtree",
-                            "pullPolicy": "IfNotPresent",
-                            "version": "sha256:d5776d8a43632291e1c5a22a9266608db0daa0a11663445d701e327f2205974c"
-                        }
-                    ]
+                    "examples": [{
+                        "registry": "ghcr.io",
+                        "repository": "sigstore/scaffolding/createtree",
+                        "pullPolicy": "IfNotPresent",
+                        "version": "sha256:47206322c1d6002ffc737d94852924fae0f749aa3a64c1899eee11f502f609a6"
+                    }]
                 },
                 "ttlSecondsAfterFinished": {
                     "type": "integer",
@@ -927,9 +1114,7 @@
                             "title": "The annotations Schema",
                             "required": [],
                             "properties": {},
-                            "examples": [
-                                {}
-                            ]
+                            "examples": [{}]
                         },
                         "mountToken": {
                             "type": "boolean",
@@ -940,14 +1125,12 @@
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "create": true,
-                            "name": "",
-                            "annotations": {},
-                            "mountToken": true
-                        }
-                    ]
+                    "examples": [{
+                        "create": true,
+                        "name": "",
+                        "annotations": {},
+                        "mountToken": true
+                    }]
                 },
                 "securityContext": {
                     "type": "object",
@@ -975,12 +1158,10 @@
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "runAsNonRoot": true,
-                            "runAsUser": 65533
-                        }
-                    ]
+                    "examples": [{
+                        "runAsNonRoot": true,
+                        "runAsUser": 65533
+                    }]
                 },
                 "annotations": {
                     "type": "object",
@@ -988,35 +1169,32 @@
                     "title": "The annotations Schema",
                     "required": [],
                     "properties": {},
-                    "examples": [
-                        {}
-                    ]
+                    "examples": [{}]
                 }
             },
-            "examples": [
-                {
-                    "enabled": true,
-                    "name": "createtree",
-                    "image": {
-                        "registry": "ghcr.io",
-                        "repository": "sigstore/scaffolding/createtree",
-                        "pullPolicy": "IfNotPresent",
-                        "version": "sha256:d5776d8a43632291e1c5a22a9266608db0daa0a11663445d701e327f2205974c"
-                    },
-                    "ttlSecondsAfterFinished": 3600,
-                    "serviceAccount": {
-                        "create": true,
-                        "name": "",
-                        "annotations": {},
-                        "mountToken": true
-                    },
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                        "runAsUser": 65533
-                    },
-                    "annotations": {}
-                }
-            ]
+            "examples": [{
+                "enabled": true,
+                "name": "createtree",
+                "displayName": "ctlog-tree",
+                "image": {
+                    "registry": "ghcr.io",
+                    "repository": "sigstore/scaffolding/createtree",
+                    "pullPolicy": "IfNotPresent",
+                    "version": "sha256:47206322c1d6002ffc737d94852924fae0f749aa3a64c1899eee11f502f609a6"
+                },
+                "ttlSecondsAfterFinished": 3600,
+                "serviceAccount": {
+                    "create": true,
+                    "name": "",
+                    "annotations": {},
+                    "mountToken": true
+                },
+                "securityContext": {
+                    "runAsNonRoot": true,
+                    "runAsUser": 65533
+                },
+                "annotations": {}
+            }]
         },
         "createctconfig": {
             "type": "object",
@@ -1033,6 +1211,8 @@
                 "logPrefix",
                 "privateKeyPasswordSecretName",
                 "ttlSecondsAfterFinished",
+                "pubkeysecret",
+                "privateSecret",
                 "serviceAccount",
                 "securityContext",
                 "annotations"
@@ -1045,11 +1225,6 @@
                     "examples": [
                         true
                     ]
-                },
-               "secret":  {
-                    "type": "string",
-                    "default": "ctlog-secret",
-                    "title": "The secret passed in to the createctconfig job via the --secret flag"
                 },
                 "replicaCount": {
                     "type": "integer",
@@ -1127,26 +1302,22 @@
                                     ]
                                 }
                             },
-                            "examples": [
-                                {
-                                    "registry": "docker.io",
-                                    "repository": "curlimages/curl",
-                                    "version": "sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498",
-                                    "imagePullPolicy": "IfNotPresent"
-                                }
-                            ]
-                        }
-                    },
-                    "examples": [
-                        {
-                            "curl": {
+                            "examples": [{
                                 "registry": "docker.io",
                                 "repository": "curlimages/curl",
                                 "version": "sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498",
                                 "imagePullPolicy": "IfNotPresent"
-                            }
+                            }]
                         }
-                    ]
+                    },
+                    "examples": [{
+                        "curl": {
+                            "registry": "docker.io",
+                            "repository": "curlimages/curl",
+                            "version": "sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498",
+                            "imagePullPolicy": "IfNotPresent"
+                        }
+                    }]
                 },
                 "image": {
                     "type": "object",
@@ -1188,18 +1359,16 @@
                             "default": "",
                             "title": "The version Schema",
                             "examples": [
-                                "sha256:2795b42d3b42cdb9eaf3825e0bca742963208a51e30d5a7173f8a68ac6d47732"
+                                "sha256:2d8072d832370a8dbbe96536eaf479a5bf3a738c997394c888fed8ddcbe84a1b"
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "registry": "ghcr.io",
-                            "repository": "sigstore/scaffolding/createctconfig",
-                            "pullPolicy": "IfNotPresent",
-                            "version": "sha256:2795b42d3b42cdb9eaf3825e0bca742963208a51e30d5a7173f8a68ac6d47732"
-                        }
-                    ]
+                    "examples": [{
+                        "registry": "ghcr.io",
+                        "repository": "sigstore/scaffolding/createctconfig",
+                        "pullPolicy": "IfNotPresent",
+                        "version": "sha256:2d8072d832370a8dbbe96536eaf479a5bf3a738c997394c888fed8ddcbe84a1b"
+                    }]
                 },
                 "fulcioURL": {
                     "type": "string",
@@ -1231,6 +1400,22 @@
                     "title": "The ttlSecondsAfterFinished Schema",
                     "examples": [
                         3600
+                    ]
+                },
+                "pubkeysecret": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The pubkeysecret Schema",
+                    "examples": [
+                        "ctlog-public-key"
+                    ]
+                },
+                "privateSecret": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The privateSecret Schema",
+                    "examples": [
+                        ""
                     ]
                 },
                 "serviceAccount": {
@@ -1266,9 +1451,7 @@
                             "title": "The annotations Schema",
                             "required": [],
                             "properties": {},
-                            "examples": [
-                                {}
-                            ]
+                            "examples": [{}]
                         },
                         "mountToken": {
                             "type": "boolean",
@@ -1279,14 +1462,12 @@
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "create": true,
-                            "name": "",
-                            "annotations": {},
-                            "mountToken": true
-                        }
-                    ]
+                    "examples": [{
+                        "create": true,
+                        "name": "",
+                        "annotations": {},
+                        "mountToken": true
+                    }]
                 },
                 "securityContext": {
                     "type": "object",
@@ -1314,12 +1495,10 @@
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "runAsNonRoot": true,
-                            "runAsUser": 65533
-                        }
-                    ]
+                    "examples": [{
+                        "runAsNonRoot": true,
+                        "runAsUser": 65533
+                    }]
                 },
                 "annotations": {
                     "type": "object",
@@ -1327,48 +1506,46 @@
                     "title": "The annotations Schema",
                     "required": [],
                     "properties": {},
-                    "examples": [
-                        {}
-                    ]
+                    "examples": [{}]
                 }
             },
-            "examples": [
-                {
-                    "enabled": true,
-                    "replicaCount": 1,
-                    "backoffLimit": 6,
-                    "name": "createctconfig",
-                    "initContainerImage": {
-                        "curl": {
-                            "registry": "docker.io",
-                            "repository": "curlimages/curl",
-                            "version": "sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498",
-                            "imagePullPolicy": "IfNotPresent"
-                        }
-                    },
-                    "image": {
-                        "registry": "ghcr.io",
-                        "repository": "sigstore/scaffolding/createctconfig",
-                        "pullPolicy": "IfNotPresent",
-                        "version": "sha256:2795b42d3b42cdb9eaf3825e0bca742963208a51e30d5a7173f8a68ac6d47732"
-                    },
-                    "fulcioURL": "http://fulcio-server.fulcio-system.svc",
-                    "logPrefix": "sigstorescaffolding",
-                    "privateKeyPasswordSecretName": "",
-                    "ttlSecondsAfterFinished": 3600,
-                    "serviceAccount": {
-                        "create": true,
-                        "name": "",
-                        "annotations": {},
-                        "mountToken": true
-                    },
-                    "securityContext": {
-                        "runAsNonRoot": true,
-                        "runAsUser": 65533
-                    },
-                    "annotations": {}
-                }
-            ]
+            "examples": [{
+                "enabled": true,
+                "replicaCount": 1,
+                "backoffLimit": 6,
+                "name": "createctconfig",
+                "initContainerImage": {
+                    "curl": {
+                        "registry": "docker.io",
+                        "repository": "curlimages/curl",
+                        "version": "sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                },
+                "image": {
+                    "registry": "ghcr.io",
+                    "repository": "sigstore/scaffolding/createctconfig",
+                    "pullPolicy": "IfNotPresent",
+                    "version": "sha256:2d8072d832370a8dbbe96536eaf479a5bf3a738c997394c888fed8ddcbe84a1b"
+                },
+                "fulcioURL": "http://fulcio-server.fulcio-system.svc",
+                "logPrefix": "sigstorescaffolding",
+                "privateKeyPasswordSecretName": "",
+                "ttlSecondsAfterFinished": 3600,
+                "pubkeysecret": "ctlog-public-key",
+                "privateSecret": "",
+                "serviceAccount": {
+                    "create": true,
+                    "name": "",
+                    "annotations": {},
+                    "mountToken": true
+                },
+                "securityContext": {
+                    "runAsNonRoot": true,
+                    "runAsUser": 65533
+                },
+                "annotations": {}
+            }]
         },
         "trillian": {
             "type": "object",
@@ -1380,12 +1557,25 @@
             ],
             "properties": {
                 "namespace": {
-                    "type": "string",
-                    "default": "",
+                    "type": "object",
+                    "default": {},
                     "title": "The namespace Schema",
-                    "examples": [
-                        "trillian-system"
-                    ]
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The name Schema",
+                            "examples": [
+                                "trillian-system"
+                            ]
+                        }
+                    },
+                    "examples": [{
+                        "name": "trillian-system"
+                    }]
                 },
                 "logServer": {
                     "type": "object",
@@ -1413,23 +1603,21 @@
                             ]
                         }
                     },
-                    "examples": [
-                        {
-                            "name": "trillian-logserver",
-                            "portRPC": 8091
-                        }
-                    ]
-                }
-            },
-            "examples": [
-                {
-                    "namespace": "trillian-system",
-                    "logServer": {
+                    "examples": [{
                         "name": "trillian-logserver",
                         "portRPC": 8091
-                    }
+                    }]
                 }
-            ]
+            },
+            "examples": [{
+                "namespace": {
+                    "name": "trillian-system"
+                },
+                "logServer": {
+                    "name": "trillian-logserver",
+                    "portRPC": 8091
+                }
+            }]
         },
         "forceNamespace": {
             "type": "string",
@@ -1440,136 +1628,174 @@
             ]
         }
     },
-    "examples": [
-        {
-            "namespace": {
-                "create": false,
-                "name": "ctlog-system"
+    "examples": [{
+        "namespace": {
+            "create": false,
+            "name": "ctlog-system"
+        },
+        "server": {
+            "replicaCount": 1,
+            "config": {
+                "key": "treeID",
+                "treeID": ""
             },
-            "server": {
-                "replicaCount": 1,
-                "config": {
-                    "key": "treeID",
-                    "treeID": ""
-                },
-                "image": {
-                    "registry": "ghcr.io",
-                    "repository": "sigstore/scaffolding/ct_server",
-                    "pullPolicy": "IfNotPresent",
-                    "version": "sha256:7c791d3b7c15e817807f07d4cdb00406529a114702ad448ee857e1d0fc5fb5a9"
-                },
-                "serviceAccount": {
-                    "create": true,
-                    "name": "",
-                    "annotations": {},
-                    "mountToken": false
-                },
-                "podAnnotations": {
-                    "prometheus.io/scrape": "true",
-                    "prometheus.io/path": "/metrics",
-                    "prometheus.io/port": "6963"
-                },
-                "portHTTP": 6962,
-                "portHTTPMetrics": 6963,
-                "service": {
-                    "type": "ClusterIP",
-                    "ports": [
-                        {
-                            "name": "6962-tcp",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 6962
-                        },
-                        {
-                            "name": "6963-tcp",
-                            "port": 6963,
-                            "protocol": "TCP",
-                            "targetPort": 6963
-                        }
-                    ]
-                },
-                "ingress": {
-                    "enabled": false,
-                    "className": "nginx",
-                    "hosts": [
-                        {
-                            "path": "/"
-                        }
-                    ],
-                    "annotations": {},
-                    "tls": []
-                },
-                "extraArgs": [],
-                "securityContext": {
-                    "runAsNonRoot": true,
-                    "runAsUser": 65533
-                }
+            "image": {
+                "registry": "ghcr.io",
+                "repository": "sigstore/scaffolding/ct_server",
+                "pullPolicy": "IfNotPresent",
+                "version": "sha256:1ef2480cf8ddb1f99da0d931283f3c55babb84d79bf36f66d7bed29985bcca7e"
             },
-            "createtree": {
-                "enabled": true,
-                "name": "createtree",
-                "image": {
-                    "registry": "ghcr.io",
-                    "repository": "sigstore/scaffolding/createtree",
-                    "pullPolicy": "IfNotPresent",
-                    "version": "sha256:d5776d8a43632291e1c5a22a9266608db0daa0a11663445d701e327f2205974c"
+            "livenessProbe": {
+                "httpGet": {
+                    "path": "/healthz",
+                    "port": 6962
                 },
-                "ttlSecondsAfterFinished": 3600,
-                "serviceAccount": {
-                    "create": true,
-                    "name": "",
-                    "annotations": {},
-                    "mountToken": true
-                },
-                "securityContext": {
-                    "runAsNonRoot": true,
-                    "runAsUser": 65533
-                },
-                "annotations": {}
+                "initialDelaySeconds": 10
             },
-            "createctconfig": {
-                "enabled": true,
-                "replicaCount": 1,
-                "backoffLimit": 6,
-                "name": "createctconfig",
-                "initContainerImage": {
-                    "curl": {
-                        "registry": "docker.io",
-                        "repository": "curlimages/curl",
-                        "version": "sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498",
-                        "imagePullPolicy": "IfNotPresent"
+            "readinessProbe": {
+                "httpGet": {
+                    "path": "/healthz",
+                    "port": 6962
+                },
+                "initialDelaySeconds": 10
+            },
+            "serviceAccount": {
+                "create": true,
+                "name": "",
+                "annotations": {},
+                "mountToken": false
+            },
+            "podAnnotations": {
+                "prometheus.io/scrape": "true",
+                "prometheus.io/path": "/metrics",
+                "prometheus.io/port": "6963"
+            },
+            "portHTTP": 6962,
+            "portHTTPMetrics": 6963,
+            "service": {
+                "type": "ClusterIP",
+                "ports": [{
+                    "name": "6962-tcp",
+                    "port": 80,
+                    "protocol": "TCP",
+                    "targetPort": 6962
+                },
+                {
+                    "name": "6963-tcp",
+                    "port": 6963,
+                    "protocol": "TCP",
+                    "targetPort": 6963
+                }]
+            },
+            "ingress": {
+                "enabled": false,
+                "className": "nginx",
+                "hosts": [{
+                    "path": "/"
+                }],
+                "annotations": {},
+                "tls": []
+            },
+            "ingresses": [{
+                "enabled": false,
+                "name": "gce-ingress",
+                "className": "gce",
+                "hosts": [{
+                    "host": "fulcio.localhost",
+                    "paths": [{
+                        "path": "/test",
+                        "pathType": "Prefix"
+                    },
+                    {
+                        "path": "/other-shard",
+                        "serviceName": "other-shard"
+                    }]
+                }],
+                "annotations": {},
+                "tls": [],
+                "staticGlobalIP": "lb-ext-ip",
+                "frontendConfigSpec": {
+                    "sslPolicy": "ctlog-ssl-policy",
+                    "redirectToHttps": {
+                        "enabled": true
                     }
-                },
-                "image": {
-                    "registry": "ghcr.io",
-                    "repository": "sigstore/scaffolding/createctconfig",
-                    "pullPolicy": "IfNotPresent",
-                    "version": "sha256:2795b42d3b42cdb9eaf3825e0bca742963208a51e30d5a7173f8a68ac6d47732"
-                },
-                "fulcioURL": "http://fulcio-server.fulcio-system.svc",
-                "logPrefix": "sigstorescaffolding",
-                "privateKeyPasswordSecretName": "",
-                "ttlSecondsAfterFinished": 3600,
-                "serviceAccount": {
-                    "create": true,
-                    "name": "",
-                    "annotations": {},
-                    "mountToken": true
-                },
-                "securityContext": {
-                    "runAsNonRoot": true,
-                    "runAsUser": 65533
-                },
-                "annotations": {}
+                }
+            }],
+            "extraArgs": [],
+            "securityContext": {
+                "runAsNonRoot": true,
+                "runAsUser": 65533
+            }
+        },
+        "createtree": {
+            "enabled": true,
+            "name": "createtree",
+            "displayName": "ctlog-tree",
+            "image": {
+                "registry": "ghcr.io",
+                "repository": "sigstore/scaffolding/createtree",
+                "pullPolicy": "IfNotPresent",
+                "version": "sha256:47206322c1d6002ffc737d94852924fae0f749aa3a64c1899eee11f502f609a6"
             },
-            "trillian": {
-                "namespace": "trillian-system",
-                "logServer": {
-                    "name": "trillian-logserver",
-                    "portRPC": 8091
+            "ttlSecondsAfterFinished": 3600,
+            "serviceAccount": {
+                "create": true,
+                "name": "",
+                "annotations": {},
+                "mountToken": true
+            },
+            "securityContext": {
+                "runAsNonRoot": true,
+                "runAsUser": 65533
+            },
+            "annotations": {}
+        },
+        "createctconfig": {
+            "enabled": true,
+            "replicaCount": 1,
+            "backoffLimit": 6,
+            "name": "createctconfig",
+            "initContainerImage": {
+                "curl": {
+                    "registry": "docker.io",
+                    "repository": "curlimages/curl",
+                    "version": "sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498",
+                    "imagePullPolicy": "IfNotPresent"
                 }
             },
-            "forceNamespace": ""
-        }
-    ]
+            "image": {
+                "registry": "ghcr.io",
+                "repository": "sigstore/scaffolding/createctconfig",
+                "pullPolicy": "IfNotPresent",
+                "version": "sha256:2d8072d832370a8dbbe96536eaf479a5bf3a738c997394c888fed8ddcbe84a1b"
+            },
+            "fulcioURL": "http://fulcio-server.fulcio-system.svc",
+            "logPrefix": "sigstorescaffolding",
+            "privateKeyPasswordSecretName": "",
+            "ttlSecondsAfterFinished": 3600,
+            "pubkeysecret": "ctlog-public-key",
+            "privateSecret": "",
+            "serviceAccount": {
+                "create": true,
+                "name": "",
+                "annotations": {},
+                "mountToken": true
+            },
+            "securityContext": {
+                "runAsNonRoot": true,
+                "runAsUser": 65533
+            },
+            "annotations": {}
+        },
+        "trillian": {
+            "namespace": {
+                "name": "trillian-system"
+            },
+            "logServer": {
+                "name": "trillian-logserver",
+                "portRPC": 8091
+            }
+        },
+        "forceNamespace": ""
+    }]
 }

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -11,8 +11,8 @@ server:
     registry: ghcr.io
     repository: sigstore/scaffolding/ct_server
     pullPolicy: IfNotPresent
-    # v0.3.0
-    version: "sha256:7c791d3b7c15e817807f07d4cdb00406529a114702ad448ee857e1d0fc5fb5a9"
+    # v0.6.5
+    version: "sha256:1ef2480cf8ddb1f99da0d931283f3c55babb84d79bf36f66d7bed29985bcca7e"
   livenessProbe:
     httpGet:
       path: /healthz
@@ -72,7 +72,9 @@ server:
           paths:
             - path: /test
               pathType: Prefix
+              serviceName: ""
             - path: /other-shard
+              pathType: Prefix
               serviceName: other-shard
       annotations: {}
       tls: []
@@ -95,8 +97,8 @@ createtree:
     registry: ghcr.io
     repository: sigstore/scaffolding/createtree
     pullPolicy: IfNotPresent
-    # v0.3.0
-    version: "sha256:d5776d8a43632291e1c5a22a9266608db0daa0a11663445d701e327f2205974c"
+    # v0.6.5
+    version: "sha256:47206322c1d6002ffc737d94852924fae0f749aa3a64c1899eee11f502f609a6"
   ttlSecondsAfterFinished: 3600
   serviceAccount:
     create: true
@@ -117,15 +119,15 @@ createctconfig:
     curl:
       registry: docker.io
       repository: curlimages/curl
-      # -- 7.82.0
+      # -- 7.88.1
       version: "sha256:dca6e1b1c8e7b8b8e7be4e79fc78a858d12fd56245cb31bfa281dbf7c73a6498"
       imagePullPolicy: IfNotPresent
   image:
     registry: ghcr.io
     repository: sigstore/scaffolding/createctconfig
     pullPolicy: IfNotPresent
-    # -- v0.6.3
-    version: "sha256:b3dae896ddb7b01b3257c668bc1e87f15aafe97f30a767f99426f557fa33e44c"
+    # -- v0.6.5
+    version: "sha256:2d8072d832370a8dbbe96536eaf479a5bf3a738c997394c888fed8ddcbe84a1b"
   fulcioURL: "http://fulcio-server.fulcio-system.svc"
   logPrefix: sigstorescaffolding
   privateKeyPasswordSecretName: ""
@@ -145,7 +147,8 @@ createctconfig:
   annotations: {}
 
 trillian:
-  namespace: trillian-system
+  namespace:
+    name: trillian-system
   logServer:
     name: trillian-logserver
     portRPC: 8091


### PR DESCRIPTION
## Description of the change

First integration of the v2 rework to refactor charts to using the [common](https://github.com/sigstore/helm-charts/tree/main/charts/common) Helm Charts. 

## Existing or Associated Issue(s)

#536 

## Additional Information


## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
