### PR TITLE
Make cleanup-leases security context configurable

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.8.2
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -1,6 +1,6 @@
 # policy-controller
 
-![Version: 0.5.8](https://img.shields.io/badge/Version-0.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 The Helm chart for Policy  Controller
 
@@ -27,17 +27,19 @@ The Helm chart for Policy  Controller
 | cosign.webhookName | string | `"policy.sigstore.dev"` |  |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` |  |
-| webhook.configData | object | `{}` | Set the data of the `policy-config-controller` configmap |
-| webhook.webhookNames.defaulting | string | `"defaulting.clusterimagepolicy.sigstore.dev"` |  |
-| webhook.webhookNames.validating | string | `"validating.clusterimagepolicy.sigstore.dev"` |  |
+| leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |
+| leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
+| leasescleanup.image.version | string | `"1.26.0"` |  |
+| leasescleanup.securityContext.enabled | bool | `false` |  |
 | serviceMonitor.enabled | bool | `false` |  |
+| webhook.configData | object | `{}` |  |
 | webhook.env | object | `{}` |  |
 | webhook.extraArgs | object | `{}` |  |
+| webhook.failurePolicy | string | `"Fail"` |  |
 | webhook.image.pullPolicy | string | `"IfNotPresent"` |  |
 | webhook.image.repository | string | `"ghcr.io/sigstore/policy-controller/policy-controller"` |  |
-| webhook.image.version | string | `"sha256:e91bcd954394b414d3b80adfc2cefdae84dd7985fb938a895471eb34aac57744"` | `"v0.8.0"` |
+| webhook.image.version | string | `"sha256:e91bcd954394b414d3b80adfc2cefdae84dd7985fb938a895471eb34aac57744"` | `"v0.8.2"` |
 | webhook.name | string | `"webhook"` |  |
-| webhook.failurePolicy | string | `"Fail"` |  |
 | webhook.namespaceSelector.matchExpressions[0].key | string | `"policy.sigstore.dev/include"` |  |
 | webhook.namespaceSelector.matchExpressions[0].operator | string | `"In"` |  |
 | webhook.namespaceSelector.matchExpressions[0].values[0] | string | `"true"` |  |
@@ -48,8 +50,8 @@ The Helm chart for Policy  Controller
 | webhook.podSecurityContext.runAsUser | int | `1000` |  |
 | webhook.registryCaBundle | object | `{}` |  |
 | webhook.replicaCount | int | `1` |  |
-| webhook.resources.limits.cpu | string | `"100m"` |  |
-| webhook.resources.limits.memory | string | `"256Mi"` |  |
+| webhook.resources.limits.cpu | string | `"200m"` |  |
+| webhook.resources.limits.memory | string | `"512Mi"` |  |
 | webhook.resources.requests.cpu | string | `"100m"` |  |
 | webhook.resources.requests.memory | string | `"128Mi"` |  |
 | webhook.securityContext.enabled | bool | `false` |  |
@@ -62,9 +64,8 @@ The Helm chart for Policy  Controller
 | webhook.serviceAccount.name | string | `""` |  |
 | webhook.volumeMounts | list | `[]` |  |
 | webhook.volumes | list | `[]` |  |
-| leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |
-| leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
-| leasescleanup.image.version | string | `"1.26.0"` |  |
+| webhook.webhookNames.defaulting | string | `"defaulting.clusterimagepolicy.sigstore.dev"` |  |
+| webhook.webhookNames.validating | string | `"validating.clusterimagepolicy.sigstore.dev"` |  |
 
 ### Deploy `policy-controller` Helm Chart
 

--- a/charts/policy-controller/templates/webhook/cleanup-leases.yaml
+++ b/charts/policy-controller/templates/webhook/cleanup-leases.yaml
@@ -25,6 +25,12 @@ spec:
             - -c
             - kubectl delete leases --all --ignore-not-found -n {{ .Release.Namespace }}
       restartPolicy: OnFailure
+      {{- if .Values.leasescleanup.securityContext.enabled }}
+      securityContext:
+        {{- with .Values.leasescleanup.securityContext }}
+        {{- omit . "enabled" | toYaml | nindent 8}}
+        {{- end }}
+      {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -42,6 +42,14 @@
                         }
                     }
                 }
+            },
+            "securityContext": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "type": "boolean"
+                    }
+                }
             }
         },
         "serviceMonitor": {

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -65,6 +65,15 @@ leasescleanup:
     repository: cgr.dev/chainguard/kubectl
     version: 1.26.0
     pullPolicy: IfNotPresent
+  ## set pod security context options to harden the pod or allow exceptions
+  securityContext:
+    enabled: false
+    # allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem: true
+    # runAsUser: 1000
+    # capabilities:
+    #   drop:
+    #     - ALL
 
 ## common node selector for all the pods
 commonNodeSelector: {}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

The SecurityContext field for this job is currently static, however when deploying policy-controller into a namespace that uses Pod Security Admission controllers this job will not be able to run.

This adds a new field to the values file that operates in a manner similar to the `securityContext` option for the webhook deployment.
<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
