### PR TITLE
move to v2 of cloud-sql-proxy for trillian chart

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.8
+version: 0.2.9
 
 keywords:
   - security
@@ -34,7 +34,7 @@ annotations:
     - name: log_signer
       image: gcr.io/projectsigstore/trillian_log_signer@sha256:87699af429d79440f7e0a487d215c2129bf97b37698370d050a68822996f93f0
     - name: cloud_proxy
-      image: gcr.io/cloudsql-docker/gce-proxy@sha256:2c7789354d9063e5a910c1c40c8d5c91736d564e9f41d69f7ac4d785fd3333d7
+      image: gcr.io/cloud-sql-connectors/cloud-sql-proxy@sha256:b0aee6522475a236254394e573bae95693c02f8a07bceccb110f4e90336a1722
     - name: scaffold_cloud_proxy
       image: ghcr.io/sigstore/scaffolding/cloudsqlproxy:@sha256:2c818523a9060cdefca10af0804c8f60549bdc1744e71008f9849b23605c4ccf
     - name: createdb

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
@@ -116,14 +116,16 @@ helm uninstall [RELEASE_NAME]
 | mysql.auth.username | string | `"mysql"` |  |
 | mysql.enabled | bool | `true` |  |
 | mysql.gcp.cloudsql.registry | string | `"gcr.io"` |  |
-| mysql.gcp.cloudsql.repository | string | `"cloudsql-docker/gce-proxy"` |  |
+| mysql.gcp.cloudsql.repository | string | `"cloud-sql-connectors/cloud-sql-proxy:2.6.1-alpine"` |  |
 | mysql.gcp.cloudsql.resources.requests.cpu | string | `"1"` |  |
 | mysql.gcp.cloudsql.resources.requests.memory | string | `"2Gi"` |  |
 | mysql.gcp.cloudsql.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | mysql.gcp.cloudsql.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | mysql.gcp.cloudsql.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | mysql.gcp.cloudsql.securityContext.runAsNonRoot | bool | `true` |  |
-| mysql.gcp.cloudsql.version | string | `"sha256:2c7789354d9063e5a910c1c40c8d5c91736d564e9f41d69f7ac4d785fd3333d7"` | crane digest gcr.io/cloudsql-docker/gce-proxy:1.33.9 |
+| mysql.gcp.cloudsql.unixDomainSocket.enabled | bool | `false` |  |
+| mysql.gcp.cloudsql.unixDomainSocket.path | string | `"/cloudsql"` |  |
+| mysql.gcp.cloudsql.version | string | `"sha256:b0aee6522475a236254394e573bae95693c02f8a07bceccb110f4e90336a1722"` | crane digest cloud-sql-connectors/cloud-sql-proxy:2.6.1-alpine |
 | mysql.gcp.enabled | bool | `false` |  |
 | mysql.gcp.instance | string | `""` |  |
 | mysql.gcp.scaffoldSQLProxy.registry | string | `"ghcr.io"` |  |
@@ -134,7 +136,7 @@ helm uninstall [RELEASE_NAME]
 | mysql.gcp.scaffoldSQLProxy.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | mysql.gcp.scaffoldSQLProxy.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | mysql.gcp.scaffoldSQLProxy.securityContext.runAsNonRoot | bool | `true` |  |
-| mysql.gcp.scaffoldSQLProxy.version | string | `"sha256:2c818523a9060cdefca10af0804c8f60549bdc1744e71008f9849b23605c4ccf"` | v0.6.2 |
+| mysql.gcp.scaffoldSQLProxy.version | string | `"sha256:e29cb16f09223880f3c40758d6efb227bd0318d0bba2ce7cc9cc6bd799ca2f76"` | v0.6.6 which is based on cloud-sql-proxy:2.6.0-alpine |
 | mysql.hostname | string | `""` |  |
 | mysql.image.pullPolicy | string | `"IfNotPresent"` |  |
 | mysql.image.registry | string | `"gcr.io"` |  |

--- a/charts/trillian/templates/_helpers.tpl
+++ b/charts/trillian/templates/_helpers.tpl
@@ -190,7 +190,11 @@ Log Server Arguments
 - {{ printf "--storage_system=%s" (include "trillian.storageSystem" .) | quote }}
 - {{ printf "--quota_system=%s" (include "trillian.quotaSystem" .) | quote }}
 {{- if eq (include "trillian.storageSystem" .) "mysql" }}
+{{- if and (.Values.mysql.gcp.enabled) (.Values.mysql.gcp.cloudsql.unixDomainSocket.enabled) }}
+- {{ printf "--mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@unix(%s/%s)/$(MYSQL_DATABASE)?parseTime=true" .Values.mysql.gcp.cloudsql.unixDomainSocket.path .Values.mysql.gcp.instance | quote }}
+{{- else }}
 - "--mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOSTNAME):$(MYSQL_PORT))/$(MYSQL_DATABASE)"
+{{- end }}
 {{- end }}
 - {{ printf "--rpc_endpoint=0.0.0.0:%d" (.Values.logServer.portRPC | int) | quote }}
 - {{ printf "--http_endpoint=0.0.0.0:%d" (.Values.logServer.portHTTP | int) | quote }}
@@ -207,7 +211,11 @@ Log Signer Arguments
 - {{ printf "--storage_system=%s" (include "trillian.storageSystem" .) | quote }}
 - {{ printf "--quota_system=%s" (include "trillian.quotaSystem" .) | quote }}
 {{- if eq (include "trillian.storageSystem" .) "mysql" }}
+{{- if and (.Values.mysql.gcp.enabled) (.Values.mysql.gcp.cloudsql.unixDomainSocket.enabled) }}
+- {{ printf "--mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@unix(%s/%s)/$(MYSQL_DATABASE)?parseTime=true" .Values.mysql.gcp.cloudsql.unixDomainSocket.path .Values.mysql.gcp.instance | quote }}
+{{- else }}
 - "--mysql_uri=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOSTNAME):$(MYSQL_PORT))/$(MYSQL_DATABASE)"
+{{- end }}
 {{- end }}
 - {{ printf "--rpc_endpoint=0.0.0.0:%d" (.Values.logSigner.portRPC | int) | quote }}
 - {{ printf "--http_endpoint=0.0.0.0:%d" (.Values.logSigner.portHTTP | int) | quote }}

--- a/charts/trillian/templates/trillian-log-server/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-server/deployment.yaml
@@ -57,14 +57,26 @@ spec:
         - name: cloud-sql-proxy
           image: "{{ template "trillian.image" .Values.mysql.gcp.cloudsql }}"
           command:
-            - "/cloud_sql_proxy"
-            - "-instances={{ .Values.mysql.gcp.instance }}=tcp:{{ .Values.mysql.port }}"
+            - "/cloud-sql-proxy"
+            {{- if .Values.mysql.gcp.cloudsql.unixDomainSocket.enabled }}
+            - "--unix-socket"
+            - {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path | quote }}
+            {{- end }}
+            {{- range .Values.mysql.gcp.cloudsql.extraArgs | default list }}
+            - {{ . | quote }}
+            {{- end }}
+            - "{{ .Values.mysql.gcp.instance }}"
     {{- if .Values.mysql.gcp.cloudsql.securityContext }}
           securityContext:
 {{ toYaml .Values.mysql.gcp.cloudsql.securityContext | indent 12 }}
     {{- end }}
           resources:
 {{ toYaml .Values.mysql.gcp.cloudsql.resources | indent 12 }}
+          {{- if .Values.mysql.gcp.cloudsql.unixDomainSocket.enabled }}
+          volumeMounts:
+            - mountPath: {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path }}
+              name: cloud-sql-proxy-unix-domain-socket
+          {{- end }}
         {{- end }}
         - name: {{ template "trillian.name" . }}-{{ .Values.logServer.name }}
           image: "{{ template "trillian.image" .Values.logServer.image }}"
@@ -85,6 +97,11 @@ spec:
 {{- end }}
           resources:
 {{ toYaml .Values.logServer.resources | indent 12 }}
+{{- if and (.Values.mysql.gcp.enabled) (.Values.mysql.gcp.cloudsql.unixDomainSocket.enabled) }}
+          volumeMounts:
+            - mountPath: {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path }}
+              name: cloud-sql-proxy-unix-domain-socket
+{{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -108,4 +125,9 @@ spec:
     {{- if .Values.logServer.affinity }}
       affinity:
 {{ toYaml .Values.logServer.affinity | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.mysql.gcp.enabled) (.Values.mysql.gcp.cloudsql.unixDomainSocket.enabled) }}
+      volumes:
+      - name: cloud-sql-proxy-unix-domain-socket
+        emptyDir: {}
     {{- end }}

--- a/charts/trillian/templates/trillian-log-signer/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-signer/deployment.yaml
@@ -57,8 +57,15 @@ spec:
         - name: cloud-sql-proxy
           image: "{{ template "trillian.image" .Values.mysql.gcp.cloudsql }}"
           command:
-            - "/cloud_sql_proxy"
-            - "-instances={{ .Values.mysql.gcp.instance }}=tcp:{{ .Values.mysql.port }}"
+            - "/cloud-sql-proxy"
+            {{- if .Values.mysql.gcp.cloudsql.unixDomainSocket.enabled }}
+            - "--unix-socket"
+            - {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path | quote }}
+            {{- end }}
+            {{- range .Values.mysql.gcp.cloudsql.extraArgs | default list }}
+            - {{ . | quote }}
+            {{- end }}
+            - "{{ .Values.mysql.gcp.instance }}"
     {{- if .Values.mysql.gcp.cloudsql.securityContext }}
           securityContext:
 {{ toYaml .Values.mysql.gcp.cloudsql.securityContext | indent 12 }}
@@ -66,6 +73,11 @@ spec:
           resources:
 {{ toYaml .Values.mysql.gcp.cloudsql.resources | indent 12 }}
         {{- end }}
+          {{- if .Values.mysql.gcp.cloudsql.unixDomainSocket.enabled }}
+          volumeMounts:
+            - mountPath: {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path }}
+              name: cloud-sql-proxy-unix-domain-socket
+          {{- end }}
         - name: {{ template "trillian.name" . }}-{{ .Values.logSigner.name }}
           image: "{{ template "trillian.image" .Values.logSigner.image }}"
           imagePullPolicy: "{{ .Values.logSigner.image.pullPolicy }}"
@@ -85,6 +97,11 @@ spec:
 {{- end }}
           resources:
 {{ toYaml .Values.logSigner.resources | indent 12 }}
+{{- if and (.Values.mysql.gcp.enabled) (.Values.mysql.gcp.cloudsql.unixDomainSocket.enabled) }}
+          volumeMounts:
+            - mountPath: {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path }}
+              name: cloud-sql-proxy-unix-domain-socket
+{{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -108,4 +125,9 @@ spec:
     {{- if .Values.logSigner.affinity }}
       affinity:
 {{ toYaml .Values.logSigner.affinity | indent 8 }}
+    {{- end }}
+    {{- if and (.Values.mysql.gcp.enabled) (.Values.mysql.gcp.cloudsql.unixDomainSocket.enabled) }}
+      volumes:
+      - name: cloud-sql-proxy-unix-domain-socket
+        emptyDir: {}
     {{- end }}

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -28,8 +28,8 @@ mysql:
     scaffoldSQLProxy:
       registry: ghcr.io
       repository: sigstore/scaffolding/cloudsqlproxy
-      # -- v0.6.2
-      version: sha256:2c818523a9060cdefca10af0804c8f60549bdc1744e71008f9849b23605c4ccf
+      # -- v0.6.6 which is based on cloud-sql-proxy:2.6.0-alpine
+      version: sha256:e29cb16f09223880f3c40758d6efb227bd0318d0bba2ce7cc9cc6bd799ca2f76
       resources:
         requests:
           memory: "2Gi"
@@ -43,9 +43,9 @@ mysql:
             - ALL
     cloudsql:
       registry: gcr.io
-      repository: cloudsql-docker/gce-proxy
-      # -- crane digest gcr.io/cloudsql-docker/gce-proxy:1.33.9
-      version: sha256:2c7789354d9063e5a910c1c40c8d5c91736d564e9f41d69f7ac4d785fd3333d7
+      repository: cloud-sql-connectors/cloud-sql-proxy:2.6.1-alpine
+      # -- crane digest cloud-sql-connectors/cloud-sql-proxy:2.6.1-alpine
+      version: sha256:b0aee6522475a236254394e573bae95693c02f8a07bceccb110f4e90336a1722
       resources:
         requests:
           memory: "2Gi"
@@ -57,6 +57,9 @@ mysql:
         capabilities:
           drop:
             - ALL
+      unixDomainSocket:
+        enabled: false
+        path: /cloudsql
   enabled: true
   replicaCount: 1
   name: mysql


### PR DESCRIPTION
moves to v2 version of https://github.com/GoogleCloudPlatform/cloud-sql-proxy for the trillian chart

adds support for using unix domain sockets to provide connectivity between containers instead of TCP

also adds support for other command line arguments, which enables environment specific features like structured logging, health checks, etc