### PR TITLE
fix: Add common annotations to cms/secrets. Avoid spinnaker issue with versioning

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.6.3
+version: 0.6.4
 appVersion: 0.8.2
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -1,8 +1,8 @@
 # policy-controller
 
-![Version: 0.5.8](https://img.shields.io/badge/Version-0.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
-The Helm chart for Policy  Controller
+The Helm chart for Policy Controller
 
 **Homepage:** <https://github.com/sigstore/policy-controller>
 
@@ -23,6 +23,7 @@ The Helm chart for Policy  Controller
 |-----|------|---------|-------------|
 | commonNodeSelector | object | `{}` |  |
 | commonTolerations | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
 | cosign.cosignPub | string | `""` |  |
 | cosign.webhookName | string | `"policy.sigstore.dev"` |  |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/policy-controller/templates/webhook/config-sigstore-keys.yaml
+++ b/charts/policy-controller/templates/webhook/config-sigstore-keys.yaml
@@ -17,7 +17,10 @@ kind: ConfigMap
 metadata:
   name: config-sigstore-keys
   namespace: {{ .Release.Namespace }}
-
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
 data:
   _example: |
     ##################################

--- a/charts/policy-controller/templates/webhook/configmap-clusterimagepolicy.yaml
+++ b/charts/policy-controller/templates/webhook/configmap-clusterimagepolicy.yaml
@@ -18,6 +18,10 @@ kind: ConfigMap
 metadata:
   name: config-image-policies
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
 data:
   _example: |
     #######################################

--- a/charts/policy-controller/templates/webhook/configmap-policy-controller.yaml
+++ b/charts/policy-controller/templates/webhook/configmap-policy-controller.yaml
@@ -17,6 +17,10 @@ kind: ConfigMap
 metadata:
   name: config-policy-controller
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
 data:
   {{- if not .Values.webhook.configData }}
   _example: |

--- a/charts/policy-controller/templates/webhook/configmap.yaml
+++ b/charts/policy-controller/templates/webhook/configmap.yaml
@@ -6,6 +6,10 @@ metadata:
     control-plane: {{ template "policy-controller.fullname" . }}-webhook
   name: {{ template "policy-controller.fullname" . }}-webhook-logging
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
 data:
   zap-logger-config: |-
     {
@@ -42,6 +46,10 @@ metadata:
     control-plane: {{ template "policy-controller.fullname" . }}-webhook
   name: {{ template "policy-controller.fullname" . }}-webhook-observability
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+{{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
 data:
   metrics.backend-destination: prometheus
   metrics.request-metrics-backend-destination: prometheus

--- a/charts/policy-controller/templates/webhook/cosign_secret.yaml
+++ b/charts/policy-controller/templates/webhook/cosign_secret.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "policy-controller.labels" . | nindent 4 }}
   name: {{ template "policy-controller.fullname" . }}-cosign-key
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   cosign.pub: {{ .Values.cosign.cosignPub}}

--- a/charts/policy-controller/templates/webhook/secret_certs_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/secret_certs_webhook.yaml
@@ -5,6 +5,9 @@ metadata:
     {{- if .Values.webhook.service.annotations }}
     {{ toYaml .Values.webhook.service.annotations | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "policy-controller.labels" . | nindent 4 }}
     control-plane: {{ template "policy-controller.fullname" . }}-webhook

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -8,6 +8,9 @@
         "commonTolerations": {
             "type": "array"
         },
+        "commonAnnotations": {
+            "type": "object"
+        },
         "cosign": {
             "type": "object",
             "properties": {

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -82,6 +82,9 @@ commonTolerations: []
 #   value: "value"
 #   effect: "NoSchedule"
 
+## This will set some annotations in config maps and secrets. Use case: Disable versioning to deploy helm chart using spinnaker
+commonAnnotations: {}
+
 ## serviceMonitor makes policy controller metrics discoverable to prometheus
 serviceMonitor:
   enabled: false


### PR DESCRIPTION

## Description of the change

Add common annotations variable inside values.yaml. If enabled, this will add those annotations to configmaps and secrets. Use case. Disable versioning in configmaps and secrets to avoid issues when policy controller helm chart is deployed using spinnaker.

## Existing or Associated Issue(s)

## Additional Information

## Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [X] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [X] JSON Schema generated.
- [X] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
