### PR TITLE
fix: fix issue with kubectl latest tag image

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.6.4
+version: 0.6.5
 appVersion: 0.8.2
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -1,6 +1,6 @@
 # policy-controller
 
-![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
+![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 The Helm chart for Policy Controller
 
@@ -68,7 +68,7 @@ The Helm chart for Policy Controller
 | webhook.volumes | list | `[]` |  |
 | leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |
 | leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
-| leasescleanup.image.version | string | `"latest"` |  |
+| leasescleanup.image.version | string | `"latest-dev"` | `"NOTE: use latest-dev tag because leases cleanup job needs /bin/sh, not present in latest tag"` |
 
 ### Deploy `policy-controller` Helm Chart
 

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -67,7 +67,7 @@ webhook:
 leasescleanup:
   image:
     repository: cgr.dev/chainguard/kubectl
-    version: latest
+    version: latest-dev
     pullPolicy: IfNotPresent
 
 ## common node selector for all the pods
@@ -84,6 +84,8 @@ commonTolerations: []
 
 ## This will set some annotations in config maps and secrets. Use case: Disable versioning to deploy helm chart using spinnaker
 commonAnnotations: {}
+#  strategy.spinnaker.io/versioned: "false"
+#  key2: value2
 
 ## serviceMonitor makes policy controller metrics discoverable to prometheus
 serviceMonitor:


### PR DESCRIPTION
## Description of the change

Change kubectl image tag to latest-dev, for cleanup-leases batch job.

## Existing or Associated Issue(s)

Issue when using latest tag:
`failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown. `

## Additional Information

## Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [X] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [X] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
