### PR TITLE
Fix `ClusterRole` name to be based on SA name

### DIFF
--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.6.28
+version: 0.6.29
 keywords:
   - security
   - pki

--- a/charts/scaffold/templates/clusterrole.yaml
+++ b/charts/scaffold/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: tuf-secret-copy-job-role
+  name: {{ .Values.copySecretJob.serviceaccount }}-role
 rules:
   - apiGroups: [""]
     resources: ["secrets"]


### PR DESCRIPTION
## Description of the change

If you look in `rolebindings.yaml` alongside this file you will see that the way this role is consumed is via this templated name, but the name isn't actually templated!

## Existing or Associated Issue(s)

N/A

## Additional Information

N/A

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
