### PR TITLE
add securityContext to init and regular containers - trillian

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.14
+version: 0.2.15
 
 keywords:
   - security

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.2.14](https://img.shields.io/badge/Version-0.2.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 

--- a/charts/trillian/templates/createdb/createdb-job.yaml
+++ b/charts/trillian/templates/createdb/createdb-job.yaml
@@ -82,6 +82,10 @@ spec:
           resources:
 {{ toYaml .Values.createdb.resources | indent 12 }}
     {{- end }}
+    {{- if .Values.createdb.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.createdb.containerSecurityContext | indent 12 }}
+    {{- end }}
     {{- if .Values.createdb.securityContext }}
       securityContext:
 {{ toYaml .Values.createdb.securityContext | indent 8 }}

--- a/charts/trillian/templates/mysql/deployment.yaml
+++ b/charts/trillian/templates/mysql/deployment.yaml
@@ -82,6 +82,10 @@ spec:
             - name: storage
               mountPath: {{ .Values.mysql.persistence.mountPath }}
               subPath: {{ .Values.mysql.persistence.subPath }}
+    {{- if .Values.mysql.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.mysql.containerSecurityContext | indent 12 }}
+    {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/trillian/templates/trillian-log-server/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-server/deployment.yaml
@@ -45,6 +45,10 @@ spec:
           resources:
 {{ toYaml .Values.initContainerResources | indent 12 }}
       {{- end }}
+      {{- if .Values.initContainerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.initContainerSecurityContext | indent 12 }}
+      {{- end }}
       {{- if .Values.logServer.extraInitContainers }}
 {{ toYaml .Values.logServer.extraInitContainers | indent 8 }}
       {{- end }}
@@ -117,6 +121,10 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path }}
               name: cloud-sql-proxy-unix-domain-socket
+{{- end }}
+{{- if .Values.logServer.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.logServer.containerSecurityContext | indent 12 }}
 {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/trillian/templates/trillian-log-signer/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-signer/deployment.yaml
@@ -45,6 +45,10 @@ spec:
           resources:
 {{ toYaml .Values.initContainerResources | indent 12 }}
       {{- end }}
+      {{- if .Values.initContainerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.initContainerSecurityContext | indent 12 }}
+      {{- end }}
       {{- if .Values.logSigner.extraInitContainers }}
 {{ toYaml .Values.logSigner.extraInitContainers | indent 8 }}
       {{- end }}
@@ -117,6 +121,10 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path }}
               name: cloud-sql-proxy-unix-domain-socket
+{{- end }}
+{{- if .Values.logSigner.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.logSigner.containerSecurityContext | indent 12 }}
 {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
