### PR TITLE
Fixed tuf secrets path

### DIFF
--- a/charts/tuf/Chart.yaml
+++ b/charts/tuf/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tuf
 description: A framework for securing software update systems - the scaffolding implementation
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "0.6.10"
 
 home: https://sigstore.dev/

--- a/charts/tuf/README.md
+++ b/charts/tuf/README.md
@@ -1,6 +1,6 @@
 # tuf
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.10](https://img.shields.io/badge/AppVersion-0.6.10-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.10](https://img.shields.io/badge/AppVersion-0.6.10-informational?style=flat-square)
 
 A framework for securing software update systems - the scaffolding implementation
 
@@ -44,15 +44,15 @@ A framework for securing software update systems - the scaffolding implementatio
 | secrets.ctlog.create | bool | `false` |  |
 | secrets.ctlog.key | string | `"public"` |  |
 | secrets.ctlog.name | string | `"ctlog-public-key"` |  |
-| secrets.ctlog.path | string | `"ctlog-pubkey"` |  |
+| secrets.ctlog.path | string | `"ctfe.pub"` |  |
 | secrets.fulcio.create | bool | `false` |  |
 | secrets.fulcio.key | string | `"cert"` |  |
 | secrets.fulcio.name | string | `"fulcio-server-secret"` |  |
-| secrets.fulcio.path | string | `"fulcio-cert"` |  |
+| secrets.fulcio.path | string | `"fulcio_v1.crt.pem"` |  |
 | secrets.rekor.create | bool | `false` |  |
 | secrets.rekor.key | string | `"key"` |  |
 | secrets.rekor.name | string | `"rekor-public-key"` |  |
-| secrets.rekor.path | string | `"rekor-pubkey"` |  |
+| secrets.rekor.path | string | `"rekor.pub"` |  |
 | service.name | string | `"tuf-server"` |  |
 | service.port | int | `80` |  |
 | serviceAccountName | string | `"tuf"` |  |

--- a/charts/tuf/values.schema.json
+++ b/charts/tuf/values.schema.json
@@ -128,7 +128,7 @@
                         "path": {
                             "type": "string",
                             "examples": [
-                                "rekor-pubkey"
+                                "rekor.pub"
                             ]
                         }
                     },
@@ -136,7 +136,7 @@
                         "create": false,
                         "name": "rekor-public-key",
                         "key": "public",
-                        "path": "rekor-pubkey"
+                        "path": "rekor.pub"
                     }]
                 },
                 "fulcio": {
@@ -163,7 +163,7 @@
                         "path": {
                             "type": "string",
                             "examples": [
-                                "fulcio-cert"
+                                "fulcio_v1.crt.pem"
                             ]
                         }
                     },
@@ -171,7 +171,7 @@
                         "create": false,
                         "name": "fulcio-server-secret",
                         "key": "cert",
-                        "path": "fulcio-cert"
+                        "path": "fulcio_v1.crt.pem"
                     }]
                 },
                 "ctlog": {
@@ -198,7 +198,7 @@
                         "path": {
                             "type": "string",
                             "examples": [
-                                "ctlog-pubkey"
+                                "ctfe.pub"
                             ]
                         }
                     },
@@ -206,7 +206,7 @@
                         "create": false,
                         "name": "ctlog-public-key",
                         "key": "key",
-                        "path": "ctlog-pubkey"
+                        "path": "ctfe.pub"
                     }]
                 }
             },
@@ -215,19 +215,19 @@
                     "create": false,
                     "name": "rekor-public-key",
                     "key": "public",
-                    "path": "rekor-pubkey"
+                    "path": "rekor.pub"
                 },
                 "fulcio": {
                     "create": false,
                     "name": "fulcio-server-secret",
                     "key": "cert",
-                    "path": "fulcio-cert"
+                    "path": "fulcio_v1.crt.pem"
                 },
                 "ctlog": {
                     "create": false,
                     "name": "ctlog-public-key",
                     "key": "key",
-                    "path": "ctlog-pubkey"
+                    "path": "ctfe.pub"
                 }
             }]
         },
@@ -376,19 +376,19 @@
                 "create": false,
                 "name": "rekor-public-key",
                 "key": "public",
-                "path": "rekor-pubkey"
+                "path": "rekor.pub"
             },
             "fulcio": {
                 "create": false,
                 "name": "fulcio-server-secret",
                 "key": "cert",
-                "path": "fulcio-cert"
+                "path": "fulcio_v1.crt.pem"
             },
             "ctlog": {
                 "create": false,
                 "name": "ctlog-public-key",
                 "key": "key",
-                "path": "ctlog-pubkey"
+                "path": "ctfe.pub"
             }
         },
         "ingress": {

--- a/charts/tuf/values.yaml
+++ b/charts/tuf/values.yaml
@@ -21,17 +21,17 @@ secrets:
     create: false
     name: rekor-public-key
     key: key
-    path: rekor-pubkey
+    path: rekor.pub
   fulcio:
     create: false
     name: fulcio-server-secret
     key: cert
-    path: fulcio-cert
+    path: fulcio_v1.crt.pem
   ctlog:
     create: false
     name: ctlog-public-key
     key: public
-    path: ctlog-pubkey
+    path: ctfe.pub
 
 ingress:
   create: true


### PR DESCRIPTION
## Description of the change

Corrected secrets projected into tuf

## Existing or Associated Issue(s)

https://github.com/sigstore/scaffolding/issues/873

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
