### PR TITLE
fix: scaffold tuf secret paths default values

### DIFF
--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.6.38
+version: 0.6.39
 keywords:
   - security
   - pki

--- a/charts/scaffold/README.md
+++ b/charts/scaffold/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.6.38](https://img.shields.io/badge/Version-0.6.38-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.39](https://img.shields.io/badge/Version-0.6.39-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Scaffolding the components of the sigstore architecture
 
@@ -102,11 +102,11 @@ helm uninstall [RELEASE_NAME]
 | tuf.namespace.create | bool | `true` |  |
 | tuf.namespace.name | string | `"tuf-system"` |  |
 | tuf.secrets.ctlog.name | string | `"ctlog-public-key"` |  |
-| tuf.secrets.ctlog.path | string | `"ctlog-pubkey"` |  |
+| tuf.secrets.ctlog.path | string | `"ctfe.pub"` |  |
 | tuf.secrets.fulcio.name | string | `"fulcio-server-secret"` |  |
-| tuf.secrets.fulcio.path | string | `"fulcio-cert"` |  |
+| tuf.secrets.fulcio.path | string | `"fulcio_v1.crt.pem"` |  |
 | tuf.secrets.rekor.name | string | `"rekor-public-key"` |  |
-| tuf.secrets.rekor.path | string | `"rekor-pubkey"` |  |
+| tuf.secrets.rekor.path | string | `"rekor.pub"` |  |
 
 ----------------------------------------------
 

--- a/charts/scaffold/values.schema.json
+++ b/charts/scaffold/values.schema.json
@@ -868,15 +868,15 @@
                 "secrets": {
                     "rekor": {
                         "name": "rekor-public-key",
-                        "path": "rekor-pubkey"
+                        "path": "rekor.pub"
                     },
                     "fulcio": {
                         "name": "fulcio-server-secret",
-                        "path": "fulcio-cert"
+                        "path": "fulcio_v1.crt.pem"
                     },
                     "ctlog": {
                         "name": "ctlog-public-key",
-                        "path": "ctlog-pubkey"
+                        "path": "ctfe.pub"
                     }
                 }
             }]

--- a/charts/scaffold/values.yaml
+++ b/charts/scaffold/values.yaml
@@ -73,13 +73,13 @@ tuf:
   secrets:
     rekor:
       name: rekor-public-key
-      path: rekor-pubkey
+      path: rekor.pub
     fulcio:
       name: fulcio-server-secret
-      path: fulcio-cert
+      path: fulcio_v1.crt.pem
     ctlog:
       name: ctlog-public-key
-      path: ctlog-pubkey
+      path: ctfe.pub
 
 copySecretJob:
   enabled: false


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

Tuf chart has been updated to version 0.1.9 to resolve a bug in the default path of sigstore PKI secrets (links below). Tuf new version has been updated in the scaffold chart, however the default values of the scaffold chart were not updated. This PR fixes the default value (which otherwise override the previous fix, unless one knows about it :)

## Existing or Associated Issue(s)

<!-- List any related issues. -->

* closes https://github.com/sigstore/helm-charts/issues/678
* also relates to:
  - https://github.com/sigstore/scaffolding/issues/873
  - https://github.com/sigstore/helm-charts/issues/670

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
