### PR TITLE
adds tsa

### DIFF
--- a/charts/tuf/Chart.yaml
+++ b/charts/tuf/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tuf
 description: A framework for securing software update systems - the scaffolding implementation
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "0.6.10"
 
 home: https://sigstore.dev/

--- a/charts/tuf/README.md
+++ b/charts/tuf/README.md
@@ -1,6 +1,6 @@
 # tuf
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.10](https://img.shields.io/badge/AppVersion-0.6.10-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.10](https://img.shields.io/badge/AppVersion-0.6.10-informational?style=flat-square)
 
 A framework for securing software update systems - the scaffolding implementation
 
@@ -53,6 +53,10 @@ A framework for securing software update systems - the scaffolding implementatio
 | secrets.rekor.key | string | `"key"` |  |
 | secrets.rekor.name | string | `"rekor-public-key"` |  |
 | secrets.rekor.path | string | `"rekor.pub"` |  |
+| secrets.tsa.create | bool | `false` |  |
+| secrets.tsa.key | string | `"cert-chain"` |  |
+| secrets.tsa.name | string | `"tsa-cert-chain"` |  |
+| secrets.tsa.path | string | `"tsa.certchain.pem"` |  |
 | service.name | string | `"tuf-server"` |  |
 | service.port | int | `80` |  |
 | serviceAccountName | string | `"tuf"` |  |

--- a/charts/tuf/ci/ci-values.yaml
+++ b/charts/tuf/ci/ci-values.yaml
@@ -9,3 +9,6 @@ secrets:
   ctlog:
     create: true
     value: baz
+  tsa:
+    create: true
+    value: qux

--- a/charts/tuf/templates/deployment.yaml
+++ b/charts/tuf/templates/deployment.yaml
@@ -63,6 +63,11 @@ spec:
               items:
               - key: {{ .Values.secrets.rekor.key }}
                 path: {{ .Values.secrets.rekor.path }}
+          - secret:
+              name: {{ .Values.secrets.tsa.name }}
+              items:
+              - key: {{ .Values.secrets.tsa.key }}
+                path: {{ .Values.secrets.tsa.path }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/tuf/templates/secrets.yaml
+++ b/charts/tuf/templates/secrets.yaml
@@ -29,4 +29,15 @@ metadata:
 type: Opaque
 data:
   {{ .Values.secrets.ctlog.key }}: {{ b64enc .Values.secrets.ctlog.value }}
+---
+{{ end }}
+{{ if .Values.secrets.tsa.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.tsa.name }}
+{{ include "tuf.namespace" . | indent 2 }}
+type: Opaque
+data:
+  {{ .Values.secrets.tsa.key }}: {{ b64enc .Values.secrets.tsa.value }}
 {{ end }}

--- a/charts/tuf/values.schema.json
+++ b/charts/tuf/values.schema.json
@@ -208,6 +208,41 @@
                         "key": "key",
                         "path": "ctfe.pub"
                     }]
+                },
+                "tsa": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "examples": [
+                                false
+                            ]
+                        },
+                        "name": {
+                            "type": "string",
+                            "examples": [
+                                "tsa-cert-chain"
+                            ]
+                        },
+                        "key": {
+                            "type": "string",
+                            "examples": [
+                                "cert-chain"
+                            ]
+                        },
+                        "path": {
+                            "type": "string",
+                            "examples": [
+                                "tsa.certchain.pem"
+                            ]
+                        }
+                    },
+                    "examples": [{
+                        "create": false,
+                        "name": "tsa-cert-chain",
+                        "key": "cert-chain",
+                        "path": "tsa.certchain.pem"
+                    }]
                 }
             },
             "examples": [{
@@ -228,6 +263,12 @@
                     "name": "ctlog-public-key",
                     "key": "key",
                     "path": "ctfe.pub"
+                },
+                "tsa": {
+                    "create": false,
+                    "name": "tsa-cert-chain",
+                    "key": "cert-chain",
+                    "path": "tsa.certchain.pem"
                 }
             }]
         },
@@ -389,6 +430,12 @@
                 "name": "ctlog-public-key",
                 "key": "key",
                 "path": "ctfe.pub"
+            },
+            "tsa": {
+                "create": false,
+                "name": "tsa-cert-chain",
+                "key": "key",
+                "path": "tsa.certchain.pem"
             }
         },
         "ingress": {

--- a/charts/tuf/values.yaml
+++ b/charts/tuf/values.yaml
@@ -32,6 +32,11 @@ secrets:
     name: ctlog-public-key
     key: public
     path: ctfe.pub
+  tsa:
+    create: false
+    name: tsa-cert-chain
+    key: cert-chain
+    path: tsa.certchain.pem
 
 ingress:
   create: true


### PR DESCRIPTION
## Description of the change

Adds the ability to pass the TSA cert-chain since the TUF pkg/cmd being used supports this.

## Existing or Associated Issue(s)

https://github.com/sigstore/helm-charts/issues/640

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
```
❯ ct lint --target-branch adds_tsa
Linting charts...

------------------------------------------------------------------------------------------------------------------------
No chart changes detected.
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```