### PR TITLE
Add image pull secrets to fulcio

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.3.14
+version: 2.3.15
 appVersion: 1.4.3
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.3.14](https://img.shields.io/badge/Version-2.3.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.3](https://img.shields.io/badge/AppVersion-1.4.3-informational?style=flat-square)
+![Version: 2.3.15](https://img.shields.io/badge/Version-2.3.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.3](https://img.shields.io/badge/AppVersion-1.4.3-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -105,6 +105,7 @@ helm uninstall [RELEASE_NAME]
 | ctlog.namespace.create | bool | `true` |  |
 | ctlog.namespace.name | string | `"ctlog-system"` |  |
 | forceNamespace | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"fulcio-system"` |  |
 | server.args.aws_hsm_root_ca_path | string | `nil` |  |

--- a/charts/fulcio/templates/createcerts-job.yaml
+++ b/charts/fulcio/templates/createcerts-job.yaml
@@ -19,6 +19,10 @@ spec:
       serviceAccountName: {{ template "fulcio.serviceAccountName.createcerts" . }}
       restartPolicy: Never
       automountServiceAccountToken: {{ .Values.createcerts.serviceAccount.mountToken }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "fulcio.createcerts.fullname" . }}
           image: "{{ template "fulcio.image" .Values.createcerts.image }}"

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -23,6 +23,10 @@ spec:
       serviceAccountName: {{ template "fulcio.serviceAccountName" . }}
       # This doesn't actually use Kubernetes credentials, so don't mount them in.
       automountServiceAccountToken: {{ .Values.server.serviceAccount.mountToken }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "fulcio.fullname" . }}
           image: "{{ template "fulcio.image" .Values.server.image }}"

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -13,6 +13,9 @@
         "forceNamespace"
     ],
     "properties": {
+        "imagePullSecrets": {
+            "type": "array"
+        },
         "namespace": {
             "type": "object",
             "default": {},

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -2,6 +2,8 @@ namespace:
   create: false
   name: fulcio-system
 
+imagePullSecrets: []
+
 config:
   contents: {}
 


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Adding image pull secrets to additional charts

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

N/A

Similar to https://github.com/sigstore/helm-charts/pull/677
<!-- List any related issues. -->

## Additional Information

Following the existing pattern from other charts, add image pull secrets for private registries.


 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [X] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [X] JSON Schema generated.
- [X] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
