### PR TITLE
Add Image Pull Secrets to Trillian

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.19
+version: 0.2.20
 appVersion: 1.5.3
 
 keywords:

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.3](https://img.shields.io/badge/AppVersion-1.5.3-informational?style=flat-square)
+![Version: 0.2.20](https://img.shields.io/badge/Version-0.2.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.3](https://img.shields.io/badge/AppVersion-1.5.3-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
@@ -52,6 +52,7 @@ helm uninstall [RELEASE_NAME]
 | createdb.serviceAccount.name | string | `""` |  |
 | createdb.ttlSecondsAfterFinished | int | `3600` |  |
 | forceNamespace | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
 | initContainerImage.curl.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initContainerImage.curl.registry | string | `"docker.io"` |  |
 | initContainerImage.curl.repository | string | `"curlimages/curl"` |  |

--- a/charts/trillian/templates/createdb/createdb-job.yaml
+++ b/charts/trillian/templates/createdb/createdb-job.yaml
@@ -19,6 +19,10 @@ spec:
       serviceAccountName: {{ template "trillian.serviceAccountName.logServer" . }}
       restartPolicy: Never
       automountServiceAccountToken: {{ .Values.createdb.serviceAccount.mountToken }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
         {{- if .Values.mysql.gcp.enabled }}
         - name: cloud-sql-proxy

--- a/charts/trillian/templates/mysql/deployment.yaml
+++ b/charts/trillian/templates/mysql/deployment.yaml
@@ -43,6 +43,10 @@ spec:
 {{- if .Values.mysql.priorityClassName }}
       priorityClassName: "{{ .Values.mysql.priorityClassName }}"
 {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "trillian.name" . }}-{{ .Values.mysql.name }}
           image: "{{ template "trillian.image" .Values.mysql.image }}"

--- a/charts/trillian/templates/trillian-log-server/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-server/deployment.yaml
@@ -56,6 +56,10 @@ spec:
 {{- if .Values.logServer.priorityClassName }}
       priorityClassName: "{{ .Values.logServer.priorityClassName }}"
 {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
         {{- if .Values.mysql.gcp.enabled }}
         - name: cloud-sql-proxy

--- a/charts/trillian/templates/trillian-log-signer/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-signer/deployment.yaml
@@ -56,6 +56,10 @@ spec:
 {{- if .Values.logSigner.priorityClassName }}
       priorityClassName: "{{ .Values.logSigner.priorityClassName }}"
 {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
         {{- if .Values.mysql.gcp.enabled }}
         - name: cloud-sql-proxy

--- a/charts/trillian/values.schema.json
+++ b/charts/trillian/values.schema.json
@@ -3,6 +3,9 @@
         "create": false,
         "name": "trillian-system"
     },
+    "imagePullSecrets": {
+        "type": "array"
+    },
     "initContainerImage": {
         "curl": {
             "registry": "docker.io",

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -1,6 +1,9 @@
 namespace:
   create: false
   name: trillian-system
+
+imagePullSecrets: []
+
 initContainerImage:
   curl:
     registry: docker.io


### PR DESCRIPTION
Signed-off-by: Karl Haworth <karl.haworth@aa.com>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Adding image pull secrets to additional charts


<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

N/A

Similar to https://github.com/sigstore/helm-charts/pull/677
<!-- List any related issues. -->

## Additional Information

Following the existing pattern from other charts, add image pull secrets for private registries.
 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [X] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [X] JSON Schema generated.
- [X] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
