### PR TITLE
Fix default key for tsa

### DIFF
--- a/charts/tuf/Chart.yaml
+++ b/charts/tuf/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tuf
 description: A framework for securing software update systems - the scaffolding implementation
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "0.6.16"
 
 home: https://sigstore.dev/

--- a/charts/tuf/values.yaml
+++ b/charts/tuf/values.yaml
@@ -35,7 +35,7 @@ secrets:
   tsa:
     create: false
     name: tsa-cert-chain
-    key: cert-chain
+    key: key
     path: tsa.certchain.pem
 
 ingress:


### PR DESCRIPTION
this should be the same as rekor [here](https://github.com/sigstore/helm-charts/blob/main/charts/scaffold/templates/copy-secrets-job.yaml#L46), i'll add it in for the tsa in that job as well in a follow up