### PR TITLE
bump ctlog chart for v0.6.17 scaffolding release

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,8 +4,8 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.51
-appVersion: 0.6.16
+version: 0.2.52
+appVersion: 0.6.17
 
 keywords:
   - security
@@ -20,10 +20,10 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: ct_server
-      image: ghcr.io/sigstore/scaffolding/ct_server:v0.6.16@sha256:8687309238b35ed7869019c98d27c26ca5429cf23ecd397931917bd1398cde7e
+      image: ghcr.io/sigstore/scaffolding/ct_server:v0.6.17@sha256:e16f0a2be43a317a4c392cca24eec8c8fef06b0e836bc3545979ac0335fcf6f5
     - name: createctconfig
-      image: ghcr.io/sigstore/scaffolding/createctconfig:v0.6.16@sha256:d8d4652b93147a9d4d780844a8f0008f044e14b2594da98f0bc7a300c06765d9
+      image: ghcr.io/sigstore/scaffolding/createctconfig:v0.6.17@sha256:a891233c7f54a11025a4cac6119ba4aeea4f643c2012ff30e921aeca8a32d6db
     - name: createtree
-      image: ghcr.io/sigstore/scaffolding/createtree:v0.6.16@sha256:bdffe48121354c475f29be316bd31d7149c215b23c4cd2b36093832193adad09
+      image: ghcr.io/sigstore/scaffolding/createtree:v0.6.17@sha256:eb1a94738f34964c7456d18d30b8a45a654af89bb5371f69b2403df373be0826
     - name: curlimages/curl
       image: docker.io/curlimages/curl:8.5.0@sha256:4bfa3e2c0164fb103fb9bfd4dc956facce32b6c5d47cc09fcec883ce9535d5ac

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -1,6 +1,6 @@
 # ctlog
 
-![Version: 0.2.51](https://img.shields.io/badge/Version-0.2.51-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.16](https://img.shields.io/badge/AppVersion-0.6.16-informational?style=flat-square)
+![Version: 0.2.52](https://img.shields.io/badge/Version-0.2.52-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.17](https://img.shields.io/badge/AppVersion-0.6.17-informational?style=flat-square)
 
 Certificate Log
 
@@ -23,7 +23,7 @@ Certificate Log
 | createctconfig.image.pullPolicy | string | `"IfNotPresent"` |  |
 | createctconfig.image.registry | string | `"ghcr.io"` |  |
 | createctconfig.image.repository | string | `"sigstore/scaffolding/createctconfig"` |  |
-| createctconfig.image.version | string | `"sha256:d8d4652b93147a9d4d780844a8f0008f044e14b2594da98f0bc7a300c06765d9"` | v0.6.16 |
+| createctconfig.image.version | string | `"sha256:a891233c7f54a11025a4cac6119ba4aeea4f643c2012ff30e921aeca8a32d6db"` | v0.6.17 |
 | createctconfig.initContainerImage.curl.imagePullPolicy | string | `"IfNotPresent"` |  |
 | createctconfig.initContainerImage.curl.registry | string | `"docker.io"` |  |
 | createctconfig.initContainerImage.curl.repository | string | `"curlimages/curl"` |  |
@@ -47,7 +47,7 @@ Certificate Log
 | createtree.image.pullPolicy | string | `"IfNotPresent"` |  |
 | createtree.image.registry | string | `"ghcr.io"` |  |
 | createtree.image.repository | string | `"sigstore/scaffolding/createtree"` |  |
-| createtree.image.version | string | `"sha256:bdffe48121354c475f29be316bd31d7149c215b23c4cd2b36093832193adad09"` |  |
+| createtree.image.version | string | `"sha256:eb1a94738f34964c7456d18d30b8a45a654af89bb5371f69b2403df373be0826"` |  |
 | createtree.name | string | `"createtree"` |  |
 | createtree.securityContext.runAsNonRoot | bool | `true` |  |
 | createtree.securityContext.runAsUser | int | `65533` |  |
@@ -66,7 +66,7 @@ Certificate Log
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"ghcr.io"` |  |
 | server.image.repository | string | `"sigstore/scaffolding/ct_server"` |  |
-| server.image.version | string | `"sha256:8687309238b35ed7869019c98d27c26ca5429cf23ecd397931917bd1398cde7e"` |  |
+| server.image.version | string | `"sha256:e16f0a2be43a317a4c392cca24eec8c8fef06b0e836bc3545979ac0335fcf6f5"` |  |
 | server.ingress.annotations | object | `{}` |  |
 | server.ingress.className | string | `"nginx"` |  |
 | server.ingress.enabled | bool | `false` |  |

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -13,8 +13,8 @@ server:
     registry: ghcr.io
     repository: sigstore/scaffolding/ct_server
     pullPolicy: IfNotPresent
-    # v0.6.16
-    version: sha256:8687309238b35ed7869019c98d27c26ca5429cf23ecd397931917bd1398cde7e
+    # v0.6.17
+    version: sha256:e16f0a2be43a317a4c392cca24eec8c8fef06b0e836bc3545979ac0335fcf6f5
   livenessProbe:
     httpGet:
       path: /healthz
@@ -97,8 +97,8 @@ createtree:
     registry: ghcr.io
     repository: sigstore/scaffolding/createtree
     pullPolicy: IfNotPresent
-    # v0.6.16
-    version: sha256:bdffe48121354c475f29be316bd31d7149c215b23c4cd2b36093832193adad09
+    # v0.6.17
+    version: sha256:eb1a94738f34964c7456d18d30b8a45a654af89bb5371f69b2403df373be0826
   ttlSecondsAfterFinished: 3600
   serviceAccount:
     create: true
@@ -126,8 +126,8 @@ createctconfig:
     registry: ghcr.io
     repository: sigstore/scaffolding/createctconfig
     pullPolicy: IfNotPresent
-    # -- v0.6.16
-    version: sha256:d8d4652b93147a9d4d780844a8f0008f044e14b2594da98f0bc7a300c06765d9
+    # -- v0.6.17
+    version: sha256:a891233c7f54a11025a4cac6119ba4aeea4f643c2012ff30e921aeca8a32d6db
   fulcioURL: "http://fulcio-server.fulcio-system.svc"
   logPrefix: sigstorescaffolding
   privateKeyPasswordSecretName: ""


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
