### PR TITLE
Expose webhook loglevel to Helm chart

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.6.7
+version: 0.6.8
 appVersion: 0.8.2
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -40,7 +40,7 @@ The Helm chart for Policy  Controller
 | webhook.failurePolicy | string | `"Fail"` |  |
 | webhook.image.pullPolicy | string | `"IfNotPresent"` |  |
 | webhook.image.repository | string | `"ghcr.io/sigstore/policy-controller/policy-controller"` |  |
-| webhook.image.version | string | `"sha256:f291fce5b9c1a69ba54990eda7e0fe4114043b1afefb0f4ee3e6f84ec9ef1605"` |  |
+| webhook.image.version | string | `"sha256:f291fce5b9c1a69ba54990eda7e0fe4114043b1afefb0f4ee3e6f84ec9ef1605"` | `"v0.8.2"` |
 | webhook.name | string | `"webhook"` |  |
 | webhook.namespaceSelector.matchExpressions[0].key | string | `"policy.sigstore.dev/include"` |  |
 | webhook.namespaceSelector.matchExpressions[0].operator | string | `"In"` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -1,8 +1,8 @@
 # policy-controller
 
-![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
+![Version: 0.6.8](https://img.shields.io/badge/Version-0.6.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
-The Helm chart for Policy Controller
+The Helm chart for Policy  Controller
 
 **Homepage:** <https://github.com/sigstore/policy-controller>
 
@@ -21,27 +21,32 @@ The Helm chart for Policy Controller
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| commonAnnotations | object | `{}` |  |
 | commonNodeSelector | object | `{}` |  |
 | commonTolerations | list | `[]` |  |
-| commonAnnotations | object | `{}` |  |
 | cosign.cosignPub | string | `""` |  |
 | cosign.webhookName | string | `"policy.sigstore.dev"` |  |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` |  |
-| webhook.configData | object | `{}` | Set the data of the `policy-config-controller` configmap |
-| webhook.webhookNames.defaulting | string | `"defaulting.clusterimagepolicy.sigstore.dev"` |  |
-| webhook.webhookNames.validating | string | `"validating.clusterimagepolicy.sigstore.dev"` |  |
+| leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |
+| leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
+| leasescleanup.image.version | string | `"latest-dev"` |  |
+| loglevel | string | `"info"` |  |
 | serviceMonitor.enabled | bool | `false` |  |
+| webhook.configData | object | `{}` |  |
+| webhook.customLabels | object | `{}` |  |
 | webhook.env | object | `{}` |  |
 | webhook.extraArgs | object | `{}` |  |
+| webhook.failurePolicy | string | `"Fail"` |  |
 | webhook.image.pullPolicy | string | `"IfNotPresent"` |  |
 | webhook.image.repository | string | `"ghcr.io/sigstore/policy-controller/policy-controller"` |  |
-| webhook.image.version | string | `"sha256:e91bcd954394b414d3b80adfc2cefdae84dd7985fb938a895471eb34aac57744"` | `"v0.8.0"` |
+| webhook.image.version | string | `"sha256:f291fce5b9c1a69ba54990eda7e0fe4114043b1afefb0f4ee3e6f84ec9ef1605"` |  |
 | webhook.name | string | `"webhook"` |  |
-| webhook.failurePolicy | string | `"Fail"` |  |
 | webhook.namespaceSelector.matchExpressions[0].key | string | `"policy.sigstore.dev/include"` |  |
 | webhook.namespaceSelector.matchExpressions[0].operator | string | `"In"` |  |
 | webhook.namespaceSelector.matchExpressions[0].values[0] | string | `"true"` |  |
+| webhook.podDisruptionBudget.enabled | bool | `true` |  |
+| webhook.podDisruptionBudget.minAvailable | int | `1` |  |
 | webhook.podSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | webhook.podSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | webhook.podSecurityContext.enabled | bool | `true` |  |
@@ -49,15 +54,12 @@ The Helm chart for Policy Controller
 | webhook.podSecurityContext.runAsUser | int | `1000` |  |
 | webhook.registryCaBundle | object | `{}` |  |
 | webhook.replicaCount | int | `1` |  |
-| webhook.resources.limits.cpu | string | `"100m"` |  |
-| webhook.resources.limits.memory | string | `"256Mi"` |  |
+| webhook.resources.limits.cpu | string | `"200m"` |  |
+| webhook.resources.limits.memory | string | `"512Mi"` |  |
 | webhook.resources.requests.cpu | string | `"100m"` |  |
 | webhook.resources.requests.memory | string | `"128Mi"` |  |
 | webhook.securityContext.enabled | bool | `false` |  |
 | webhook.securityContext.runAsUser | int | `65532` |  |
-| webhook.podDisruptionBudget.enabled | bool | `true` |  |
-| webhook.podDisruptionBudget.minAvailable | int | `1` |  |
-| webhook.podDisruptionBudget.maxUnavailable | int | `null` |  |
 | webhook.service.annotations | object | `{}` |  |
 | webhook.service.port | int | `443` |  |
 | webhook.service.type | string | `"ClusterIP"` |  |
@@ -66,10 +68,9 @@ The Helm chart for Policy Controller
 | webhook.serviceAccount.name | string | `""` |  |
 | webhook.volumeMounts | list | `[]` |  |
 | webhook.volumes | list | `[]` |  |
-| webhook.customLabels | list | `{}` | |
-| leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |
-| leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
-| leasescleanup.image.version | string | `"latest-dev"` | `"NOTE: use latest-dev tag because leases cleanup job needs /bin/sh, not present in latest tag"` |
+| webhook.webhookNames.defaulting | string | `"defaulting.clusterimagepolicy.sigstore.dev"` |  |
+| webhook.webhookNames.validating | string | `"validating.clusterimagepolicy.sigstore.dev"` |  |
+
 
 ### Deploy `policy-controller` Helm Chart
 

--- a/charts/policy-controller/templates/webhook/configmap.yaml
+++ b/charts/policy-controller/templates/webhook/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
   zap-logger-config: |-
     {
-      "level": "info",
+      "level": "{{ .Values.loglevel }}",
       "development": false,
       "outputPaths": ["stdout"],
       "errorOutputPaths": ["stderr"],
@@ -34,8 +34,8 @@ data:
     }
   # Log level overrides
   # Changes are be picked up immediately.
-  loglevel.controller: "info"
-  loglevel.webhook: "info"
+  loglevel.controller: "{{ .Values.loglevel }}"
+  loglevel.webhook: "{{ .Values.loglevel }}"
 {{- if .Values.serviceMonitor.enabled }}
 ---
 apiVersion: v1

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -47,6 +47,9 @@
                 }
             }
         },
+        "loglevel": {
+            "type": "string"
+        },
         "serviceMonitor": {
             "type": "object",
             "properties": {

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -7,6 +7,8 @@ installCRDs: true
 
 imagePullSecrets: []
 
+loglevel: info
+
 webhook:
   customLabels: {}
   configData: {}


### PR DESCRIPTION
## Description of the change

Expose webhook loglevel to Helm chart


## Additional Information

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
```
❯ ct lint                                                          
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 policy-controller => (version: "0.6.8", path: "charts/policy-controller")
------------------------------------------------------------------------------------------------------------------------

"sigstore" already exists with the same configuration, skipping
Linting chart "policy-controller => (version: \"0.6.8\", path: \"charts/policy-controller\")"
Checking chart "policy-controller => (version: \"0.6.8\", path: \"charts/policy-controller\")" for a version bump...
Old chart version: 0.6.7
New chart version: 0.6.8
Chart version ok.
Validating /Users/tcnghia/code/src/github.com/sigstore/helm-charts/charts/policy-controller/Chart.yaml...
Validation success! 👍

Linting chart with values file "charts/policy-controller/ci/ci-values.yaml"...

==> Linting charts/policy-controller
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ policy-controller => (version: "0.6.8", path: "charts/policy-controller")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully

```