### PR TITLE
fix(chart): dedup imagePullSecrets in trillian and rekor

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.3.6
 
 keywords:

--- a/charts/rekor/templates/mysql/deployment.yaml
+++ b/charts/rekor/templates/mysql/deployment.yaml
@@ -96,10 +96,6 @@ spec:
           securityContext:
 {{ toYaml (.Values.mysql).containerSecurityContext | indent 12 }}
     {{- end }}
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
     {{- if (.Values.mysql).nodeSelector }}
       nodeSelector:
 {{ toYaml (.Values.mysql).nodeSelector | indent 8 }}

--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.22
+version: 0.2.23
 appVersion: 1.6.0
 
 keywords:

--- a/charts/trillian/templates/mysql/deployment.yaml
+++ b/charts/trillian/templates/mysql/deployment.yaml
@@ -90,10 +90,6 @@ spec:
           securityContext:
 {{ toYaml .Values.mysql.containerSecurityContext | indent 12 }}
     {{- end }}
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
     {{- if .Values.mysql.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.mysql.nodeSelector | indent 8 }}

--- a/charts/trillian/templates/trillian-log-server/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-server/deployment.yaml
@@ -130,10 +130,6 @@ spec:
           securityContext:
 {{ toYaml .Values.logServer.containerSecurityContext | indent 12 }}
 {{- end }}
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
     {{- if .Values.logServer.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.logServer.nodeSelector | indent 8 }}

--- a/charts/trillian/templates/trillian-log-signer/deployment.yaml
+++ b/charts/trillian/templates/trillian-log-signer/deployment.yaml
@@ -130,10 +130,6 @@ spec:
           securityContext:
 {{ toYaml .Values.logSigner.containerSecurityContext | indent 12 }}
 {{- end }}
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-    {{- end }}
     {{- if .Values.logSigner.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.logSigner.nodeSelector | indent 8 }}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

imagePullSecrets is duplicated in the Trillian chart, which fails the rendering when trying to set an image pull secret.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

Closes #738

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

```
➜ ct lint --lint-conf ./ct.yaml
Linting charts...
------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 rekor => (version: "1.4.1", path: "charts/rekor")
 trillian => (version: "0.2.23", path: "charts/trillian")
------------------------------------------------------------------------------------------------------------------------
"sigstore" already exists with the same configuration, skipping                                                                                                                                                                       
Linting chart "rekor => (version: \"1.4.1\", path: \"charts/rekor\")"
Checking chart "rekor => (version: \"1.4.1\", path: \"charts/rekor\")" for a version bump...
Old chart version: 1.4.0
New chart version: 1.4.1
Chart version ok.
Validating /Users/nicolas.degory/Code/src/github.com/sigstore/helm-charts/charts/rekor/Chart.yaml...
Validation success! 👍

Linting chart with values file "charts/rekor/ci/ci-values.yaml"...

==> Linting charts/rekor
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
Linting chart "trillian => (version: \"0.2.23\", path: \"charts/trillian\")"
Checking chart "trillian => (version: \"0.2.23\", path: \"charts/trillian\")" for a version bump...
Old chart version: 0.2.22
New chart version: 0.2.23
Chart version ok.
Validating /Users/nicolas.degory/Code/src/github.com/sigstore/helm-charts/charts/trillian/Chart.yaml...
Validation success! 👍
==> Linting charts/trillian
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ rekor => (version: "1.4.1", path: "charts/rekor")
 ✔︎ trillian => (version: "0.2.23", path: "charts/trillian")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```

I haven't updated the dependencies in scaffold and rekor, I suppose this PR has to be merged first and the trillian chart published to be able to update the Chart.lock.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
