### PR TITLE
Add support for search_index params in rekor chart

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.3.21
+version: 1.4.0
 appVersion: 1.3.6
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.3.21](https://img.shields.io/badge/Version-1.3.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.6](https://img.shields.io/badge/AppVersion-1.3.6-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.6](https://img.shields.io/badge/AppVersion-1.3.6-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 
@@ -59,6 +59,37 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | initContainerImage.curl.registry | string | `"docker.io"` |  |
 | initContainerImage.curl.repository | string | `"curlimages/curl"` |  |
 | initContainerImage.curl.version | string | `"sha256:4bfa3e2c0164fb103fb9bfd4dc956facce32b6c5d47cc09fcec883ce9535d5ac"` | 8.5.0 |
+| mysql.enabled | bool | `false` |  |
+| mysql.gcp.cloudsql.registry | string | `"gcr.io"` |  |
+| mysql.gcp.cloudsql.repository | string | `"cloud-sql-connectors/cloud-sql-proxy:2.9.0-alpine"` |  |
+| mysql.gcp.cloudsql.resources.requests.cpu | string | `"1"` |  |
+| mysql.gcp.cloudsql.resources.requests.memory | string | `"2Gi"` |  |
+| mysql.gcp.cloudsql.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| mysql.gcp.cloudsql.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| mysql.gcp.cloudsql.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| mysql.gcp.cloudsql.securityContext.runAsNonRoot | bool | `true` |  |
+| mysql.gcp.cloudsql.unixDomainSocket.enabled | bool | `false` |  |
+| mysql.gcp.cloudsql.unixDomainSocket.path | string | `"/cloudsql"` |  |
+| mysql.gcp.cloudsql.version | string | `"sha256:40a7b65ad15ce73666ddf8f79a7651b59477688c27e22fd47aa59bb9b39757d9"` | crane digest gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.9.0-alpine |
+| mysql.gcp.enabled | bool | `false` |  |
+| mysql.gcp.instance | string | `""` |  |
+| mysql.gcp.scaffoldSQLProxy.registry | string | `"ghcr.io"` |  |
+| mysql.gcp.scaffoldSQLProxy.repository | string | `"sigstore/scaffolding/cloudsqlproxy"` |  |
+| mysql.gcp.scaffoldSQLProxy.resources.requests.cpu | string | `"1"` |  |
+| mysql.gcp.scaffoldSQLProxy.resources.requests.memory | string | `"2Gi"` |  |
+| mysql.gcp.scaffoldSQLProxy.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| mysql.gcp.scaffoldSQLProxy.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| mysql.gcp.scaffoldSQLProxy.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| mysql.gcp.scaffoldSQLProxy.securityContext.runAsNonRoot | bool | `true` |  |
+| mysql.gcp.scaffoldSQLProxy.version | string | `"sha256:7cf71a5173283a5102e4765a829205007dd171511d6f8715f45b7179411ea2e2"` | v0.6.17 which is based on cloud-sql-proxy:2.9.0-alpine |
+| mysql.hostname | string | `""` |  |
+| mysql.image.pullPolicy | string | `"IfNotPresent"` |  |
+| mysql.image.registry | string | `"gcr.io"` |  |
+| mysql.image.repository | string | `"trillian-opensource-ci/db_server"` |  |
+| mysql.name | string | `"mysql"` |  |
+| mysql.port | int | `3306` |  |
+| mysql.replicaCount | int | `1` |  |
+| mysql.strategy.type | string | `"Recreate"` |  |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"rekor-system"` |  |
 | redis.args[0] | string | `"--bind"` |  |
@@ -151,6 +182,8 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | server.replicaCount | int | `1` |  |
 | server.resources | object | `{}` |  |
 | server.retrieve_api.enabled | bool | `true` |  |
+| server.searchIndex.mysql | object | `{}` |  |
+| server.searchIndex.storageProvider | string | `""` |  |
 | server.securityContext.runAsNonRoot | bool | `true` |  |
 | server.securityContext.runAsUser | int | `65533` |  |
 | server.service.ports[0].name | string | `"3000-tcp"` |  |

--- a/charts/rekor/templates/_helpers.tpl
+++ b/charts/rekor/templates/_helpers.tpl
@@ -100,22 +100,46 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Create a fully qualified Mysql name.
+Create a fully qualified mysql name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "rekor.mysql.fullname" -}}
-{{- if .Values.mysql.fullnameOverride -}}
+{{- if (.Values.mysql).fullnameOverride -}}
 {{- .Values.mysql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.mysql.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name (default "mysql" (.Values.mysql).name) | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.mysql.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name (default "mysql" (.Values.mysql).name) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return the hostname for mysql
+*/}}
+{{- define "mysql.hostname" -}}
+{{- default (include "rekor.mysql.fullname" .) (.Values.mysql).hostname }}
+{{- end -}}
+
+{{/*
+Return the database for mysql
+*/}}
+{{- define "mysql.database" -}}
+{{- default (include "rekor.fullname" .) (.Values.mysql).database }}
+{{- end -}}
+
+{{/*
+Return the secret with mysql credentials
+*/}}
+{{- define "mysql.secretName" -}}
+    {{- if ((.Values.mysql).auth).existingSecret -}}
+        {{- printf "%s" .Values.mysql.auth.existingSecret -}}
+    {{- else -}}
+        {{- printf "%s" (include "rekor.mysql.fullname" .) -}}
+    {{- end -}}
+{{- end -}}
 
 {{/*
 Define the rekor.namespace template if set with forceNamespace or .Release.Namespace is set
@@ -320,6 +344,28 @@ Server Arguments
 - {{ printf "--trillian_log_server.sharding_config=%s/%s" .Values.server.sharding.mountPath .Values.server.sharding.filename | quote }}
 - {{ printf "--redis_server.address=%s" (include "redis.hostname" .) | quote }}
 - {{ printf "--redis_server.port=%d" (.Values.redis.port | int) | quote }}
+{{- if (.Values.server.searchIndex).storageProvider }}
+- {{ printf "--search_index.storage_provider=%s" (.Values.server.searchIndex.storageProvider) | quote }}
+{{- end }}
+{{- if eq (.Values.server.searchIndex).storageProvider "mysql" }}
+{{- if and (.Values.mysql.gcp.enabled) (.Values.mysql.gcp.cloudsql.unixDomainSocket.enabled) }}
+- {{ printf "--search_index.mysql.dsn=$(MYSQL_USER):$(MYSQL_PASSWORD)@unix(%s/%s)/$(MYSQL_DATABASE)?parseTime=true" .Values.mysql.gcp.cloudsql.unixDomainSocket.path .Values.mysql.gcp.instance | quote }}
+{{- else }}
+- "--search_index.mysql.dsn=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOSTNAME):$(MYSQL_PORT))/$(MYSQL_DATABASE)"
+{{- end }}
+{{- end }}
+{{- if ((.Values.server.searchIndex).mysql).connMaxIdletime }}
+- {{ printf "--search_index.mysql.conn_max_idletime=%s" (.Values.server.searchIndex.mysql.connMaxIdletime) | quote }}
+{{- end }}
+{{- if ((.Values.server.searchIndex).mysql).connMaxLifetime }}
+- {{ printf "--search_index.mysql.conn_max_lifetime=%s" (.Values.server.searchIndex.mysql.connMaxLifetime) | quote }}
+{{- end }}
+{{- if ((.Values.server.searchIndex).mysql).maxOpenConnections }}
+- {{ printf "--search_index.mysql.max_open_connections=%d" (.Values.server.searchIndex.mysql.maxOpenConnections | int) | quote }}
+{{- end }}
+{{- if ((.Values.server.searchIndex).mysql).maxIdleConnections }}
+- {{ printf "--search_index.mysql.max_idle_connections=%d" (.Values.server.searchIndex.mysql.maxIdleConnections | int) | quote }}
+{{- end }}
 - "--rekor_server.address=0.0.0.0"
 - {{ printf "--rekor_server.signer=%s" (.Values.server.signer) | quote }}
 {{- if .Values.server.retrieve_api.enabled }}
@@ -406,4 +452,33 @@ Create the name of the sharding config
 */}}
 {{- define "rekor.sharding-config" -}}
 {{ printf "%s-sharding-config" (include "rekor.fullname" .) }}
+{{- end }}
+
+{{/*
+Place default environment credentials setup
+*/}}
+{{- define "searchIndex.mysql.envCredentials" -}}
+{{- if ((.Values.server.searchIndex).mysql).envCredentials }}
+{{ toYaml .Values.server.searchIndex.mysql.envCredentials }}
+{{- else }}
+- name: MYSQL_USER
+  valueFrom:
+    secretKeyRef:
+        name: {{ template "mysql.secretName" . }}
+        key: mysql-user
+- name: MYSQL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+        name: {{ template "mysql.secretName" . }}
+        key: mysql-password
+- name: MYSQL_DATABASE
+  valueFrom:
+    secretKeyRef:
+        name: {{ template "mysql.secretName" . }}
+        key: mysql-database
+- name: MYSQL_HOSTNAME
+  value: {{ template "mysql.hostname" . }}
+- name: MYSQL_PORT
+  value: {{ default "3306" (.Values.mysql).port | quote }}
+{{- end }}
 {{- end }}

--- a/charts/rekor/templates/mysql/deployment.yaml
+++ b/charts/rekor/templates/mysql/deployment.yaml
@@ -1,0 +1,136 @@
+{{- if (.Values.mysql).enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+{{- if (.Values.mysql).deploymentAnnotations }}
+  annotations:
+    {{ toYaml (.Values.mysql).deploymentAnnotations | nindent 4 }}
+{{- end }}
+  labels:
+    {{- include "rekor.mysql.labels" . | nindent 4 }}
+  name: {{ template "rekor.mysql.fullname" . }}
+{{ include "rekor.namespace" . | indent 2 }}
+spec:
+  selector:
+    {{- if .Values.schedulerName }}
+    schedulerName: "{{ .Values.schedulerName }}"
+    {{- end }}
+    matchLabels:
+      {{- include "rekor.mysql.matchLabels" . | nindent 6 }}
+  replicas: {{ (.Values.mysql).replicaCount }}
+  {{- if (.Values.mysql).strategy }}
+  strategy:
+{{ toYaml (.Values.mysql).strategy | trim | indent 4 }}
+    {{ if eq (.Values.mysql).strategy.type "Recreate" }}rollingUpdate: null{{ end }}
+{{- end }}
+  template:
+    metadata:
+    {{- if (.Values.mysql).podAnnotations }}
+      annotations:
+        {{ toYaml (.Values.mysql).podAnnotations | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "rekor.mysql.labels" . | nindent 8 }}
+        {{- if (.Values.mysql).podLabels}}
+        {{ toYaml (.Values.mysql).podLabels | nindent 8 }}
+        {{- end}}
+    spec:
+      serviceAccountName: {{ template "rekor.serviceAccountName.mysql" . }}
+      {{- if (.Values.mysql).extraInitContainers }}
+      initContainers:
+{{ toYaml (.Values.mysql).extraInitContainers | indent 8 }}
+      {{- end }}
+{{- if (.Values.mysql).priorityClassName }}
+      priorityClassName: "{{ (.Values.mysql).priorityClassName }}"
+{{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ template "rekor.name" . }}-{{ (.Values.mysql).name }}
+          image: "{{ template "rekor.image" (.Values.mysql).image }}"
+          imagePullPolicy: "{{ (.Values.mysql).image.pullPolicy }}"
+        {{- if (.Values.mysql).args }}
+          args:
+{{ toYaml (.Values.mysql).args | indent 12 }}
+        {{- end }}
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mysql.secretName" . }}
+                  key: mysql-root-password
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mysql.secretName" . }}
+                  key: mysql-user
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mysql.secretName" . }}
+                  key: mysql-password
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mysql.secretName" . }}
+                  key: mysql-database
+          ports:
+{{- include "rekor.containerPorts" (.Values.mysql).service.ports | indent 12 }}
+{{- if (.Values.mysql).livenessProbe }}
+          livenessProbe:
+{{ toYaml (.Values.mysql).livenessProbe | indent 12 }}
+{{- end }}
+{{- if (.Values.mysql).readinessProbe }}
+          readinessProbe:
+{{ toYaml (.Values.mysql).readinessProbe | indent 12 }}
+{{- end }}
+          resources:
+{{ toYaml (.Values.mysql).resources | indent 12 }}
+          volumeMounts:
+            - name: storage
+              mountPath: {{ (.Values.mysql).persistence.mountPath }}
+              subPath: {{ (.Values.mysql).persistence.subPath }}
+    {{- if (.Values.mysql).containerSecurityContext }}
+          securityContext:
+{{ toYaml (.Values.mysql).containerSecurityContext | indent 12 }}
+    {{- end }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+    {{- end }}
+    {{- if (.Values.mysql).nodeSelector }}
+      nodeSelector:
+{{ toYaml (.Values.mysql).nodeSelector | indent 8 }}
+    {{- end }}
+    {{- with (.Values.mysql).dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- if (.Values.mysql).securityContext }}
+      securityContext:
+{{ toYaml (.Values.mysql).securityContext | indent 8 }}
+    {{- end }}
+    {{- if (.Values.mysql).tolerations }}
+      tolerations:
+{{ toYaml (.Values.mysql).tolerations | indent 8 }}
+    {{- end }}
+    {{- if (.Values.mysql).affinity }}
+      affinity:
+{{ toYaml (.Values.mysql).affinity | indent 8 }}
+    {{- end }}
+      volumes:
+  {{- if not (.Values.mysql).persistence.enabled }}
+        - name: storage
+          emptyDir: {}
+  {{- else if (.Values.mysql).persistence.existingClaim }}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ (.Values.mysql).persistence.existingClaim }}
+  {{- else }}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ template "rekor.mysql.fullname" . }}
+  {{- end }}
+  {{- end }}

--- a/charts/rekor/templates/mysql/pvc.yaml
+++ b/charts/rekor/templates/mysql/pvc.yaml
@@ -1,0 +1,27 @@
+{{- if and (.Values.mysql).enabled (.Values.mysql.persistence).enabled (not (.Values.mysql.persistence).existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+{{- if (.Values.mysql.persistence).annotations }}
+  annotations:
+{{ toYaml (.Values.mysql.persistence).annotations | indent 4 }}
+{{- end }}
+  labels:
+    {{- include "rekor.mysql.labels" . | nindent 4 }}
+{{- if (.Values.mysql.persistence).labels }}
+{{ toYaml (.Values.mysql.persistence).labels | indent 4 }}
+{{- end }}
+  name: {{ template "rekor.mysql.fullname" . }}
+{{ include "rekor.namespace" . | indent 2 }}
+spec:
+  accessModes:
+  {{- range (.Values.mysql.persistence).accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ (.Values.mysql.persistence).size | quote }}
+{{- if (.Values.mysql.persistence).storageClass }}
+  storageClassName: {{ (.Values.mysql.persistence).storageClass }}
+{{- end }}
+{{- end }}

--- a/charts/rekor/templates/mysql/secret.yaml
+++ b/charts/rekor/templates/mysql/secret.yaml
@@ -1,0 +1,31 @@
+{{- if and (and .Values.mysql .Values.mysql.auth) (not .Values.mysql.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+{{- if and .Values.mysql.secret .Values.mysql.secret.annotations }}
+  annotations:
+{{ toYaml .Values.mysql.secret.annotations | indent 4 }}
+{{- end }}
+  labels:
+{{- if and .Values.mysql.secret .Values.mysql.secret.labels }}
+{{ toYaml .Values.mysql.secret.labels | indent 4 }}
+{{- end }}
+  name: {{ template "rekor.mysql.fullname" . }}
+{{ include "rekor.namespace" . | indent 2 }}
+type: Opaque
+data:
+  {{- if .Values.mysql.enabled -}}
+  {{- if not (empty .Values.mysql.auth.rootPassword) }}
+  mysql-root-password: {{ .Values.mysql.auth.rootPassword | b64enc | quote }}
+  {{- else }}
+  mysql-root-password: {{ (include "rekor.randomSecret" (dict "secretName" (include "rekor.mysql.fullname" .) "key" "mysql-root-password" "context" $)) | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if not (empty (.Values.mysql.auth).password) }}
+  mysql-password: {{ .Values.mysql.auth.password | b64enc | quote }}
+  {{- else }}
+  mysql-password: {{ (include "rekor.randomSecret" (dict "secretName" (include "rekor.mysql.fullname" .) "key" "mysql-password" "context" $)) | b64enc | quote }}
+  {{- end }}
+  mysql-user: {{ .Values.mysql.auth.username | b64enc | quote }}
+  mysql-database:  {{ (include "mysql.database" .) | b64enc | quote }}
+{{- end }}

--- a/charts/rekor/templates/mysql/service.yaml
+++ b/charts/rekor/templates/mysql/service.yaml
@@ -1,0 +1,22 @@
+{{- if (.Values.mysql).enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if (.Values.mysql.service).annotations }}
+  annotations:
+{{ toYaml (.Values.mysql.service).annotations | indent 4 }}
+{{- end }}
+  labels:
+    {{- include "rekor.mysql.labels" . | nindent 4 }}
+{{- if (.Values.mysql.service).labels }}
+{{ toYaml (.Values.mysql.service).labels | indent 4 }}
+{{- end }}
+  name: {{ template "rekor.mysql.fullname" . }}
+{{ include "rekor.namespace" . | indent 2 }}
+spec:
+  ports:
+    {{- tpl (toYaml (.Values.mysql.service).ports) . | nindent 4 }}
+  selector:
+    {{- include "rekor.mysql.matchLabels" . | nindent 4 }}
+  type: "{{ (.Values.mysql.service).type }}"
+{{- end -}}

--- a/charts/rekor/templates/mysql/serviceaccount.yaml
+++ b/charts/rekor/templates/mysql/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if (.Values.mysql).enabled -}}
+{{- if (.Values.mysql.serviceAccount).create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "rekor.mysql.labels" . | nindent 4 }}
+  name: {{ template "rekor.serviceAccountName.mysql" . }}
+{{ include "rekor.namespace" . | indent 2 }}
+  annotations:
+{{ toYaml (.Values.mysql.serviceAccount).annotations | indent 4 }}
+{{- end }}
+{{- end }}
+

--- a/charts/rekor/templates/server/deployment.yaml
+++ b/charts/rekor/templates/server/deployment.yaml
@@ -53,6 +53,43 @@ spec:
       priorityClassName: "{{ .Values.server.priorityClassName }}"
 {{- end }}
       containers:
+        {{- if ((.Values.mysql).gcp).enabled }}
+        - name: cloud-sql-proxy
+          image: "{{ template "rekor.image" .Values.mysql.gcp.cloudsql }}"
+          command:
+            - "/cloud-sql-proxy"
+            {{- if ((((.Values.mysql).gcp).cloudsql).unixDomainSocket).enabled }}
+            - "--unix-socket"
+            - {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path | quote }}
+            {{- end }}
+            {{- range (((.Values.mysql).gcp).cloudsql).extraArgs | default list }}
+            - {{ . | quote }}
+            {{- end }}
+            - "{{ .Values.mysql.gcp.instance }}"
+    {{- if (((.Values.mysql).gcp).cloudsql).securityContext }}
+          securityContext:
+{{ toYaml .Values.mysql.gcp.cloudsql.securityContext | indent 12 }}
+    {{- end }}
+          resources:
+{{ toYaml (((.Values.mysql).gcp).cloudsql).resources | indent 12 }}
+          {{- if ((((.Values.mysql).gcp).cloudsql).unixDomainSocket).enabled }}
+          volumeMounts:
+            - mountPath: {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path }}
+              name: cloud-sql-proxy-unix-domain-socket
+          {{- end }}
+{{- if (((.Values.mysql).gcp).cloudsql).startupProbe }}
+          startupProbe:
+{{ toYaml .Values.mysql.gcp.cloudsql.startupProbe | indent 12 }}
+{{- end }}
+{{- if (((.Values.mysql).gcp).cloudsql).livenessProbe }}
+          livenessProbe:
+{{ toYaml .Values.mysql.gcp.cloudsql.livenessProbe | indent 12 }}
+{{- end }}
+{{- if (((.Values.mysql).gcp).cloudsql).readinessProbe }}
+          readinessProbe:
+{{ toYaml .Values.mysql.gcp.cloudsql.readinessProbe | indent 12 }}
+{{- end }}
+        {{- end }}
         - name: {{ template "rekor.name" . }}-{{ .Values.server.name }}
           image: "{{ template "rekor.image" .Values.server.image }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
@@ -62,6 +99,9 @@ spec:
                 configMapKeyRef:
                   name: {{ template "rekor.config" . }}
                   key: {{ .Values.server.config.key }}
+{{- if eq (.Values.server.searchIndex).storageProvider "mysql" }}
+{{- include "searchIndex.mysql.envCredentials" . | indent 12 }}
+{{- end }}
           args:
 {{  include "rekor.server.args" . | indent 12 }}
           ports:
@@ -77,6 +117,10 @@ spec:
             - name: {{ .Values.server.signerFileSecretOptions.secretName }}-volume
               mountPath: {{ .Values.server.signerFileSecretOptions.secretMountPath }}
               readOnly: true
+{{- end }}
+{{- if and (((.Values.mysql).gcp).enabled) (((((.Values.mysql).gcp).cloudsql).unixDomainSocket).enabled) }}
+            - mountPath: {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path }}
+              name: cloud-sql-proxy-unix-domain-socket
 {{- end }}
 {{- if .Values.server.livenessProbe }}
           livenessProbe:
@@ -141,4 +185,8 @@ spec:
             items:
             - key: {{ .Values.server.signerFileSecretOptions.privateKeySecretKey }}
               path: {{ .Values.server.signerFileSecretOptions.secretMountSubPath }}
+{{- end }}
+{{- if and (((.Values.mysql).gcp).enabled) (((((.Values.mysql).gcp).cloudsql).unixDomainSocket).enabled) }}
+        - name: cloud-sql-proxy-unix-domain-socket
+          emptyDir: {}
 {{- end }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -589,6 +589,675 @@
                 }
             ]
         },
+        "mysql": {
+            "type": "object",
+            "default": {},
+            "title": "The mysql Schema",
+            "required": [
+                "gcp",
+                "enabled",
+                "replicaCount",
+                "name",
+                "hostname",
+                "port",
+                "strategy",
+                "image"
+            ],
+            "properties": {
+                "gcp": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The gcp Schema",
+                    "required": [
+                        "enabled",
+                        "instance",
+                        "scaffoldSQLProxy",
+                        "cloudsql"
+                    ],
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "The enabled Schema",
+                            "examples": [
+                                false
+                            ]
+                        },
+                        "instance": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The instance Schema",
+                            "examples": [
+                                ""
+                            ]
+                        },
+                        "scaffoldSQLProxy": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The scaffoldSQLProxy Schema",
+                            "required": [
+                                "registry",
+                                "repository",
+                                "version",
+                                "resources",
+                                "securityContext"
+                            ],
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The registry Schema",
+                                    "examples": [
+                                        "ghcr.io"
+                                    ]
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The repository Schema",
+                                    "examples": [
+                                        "sigstore/scaffolding/cloudsqlproxy"
+                                    ]
+                                },
+                                "version": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The version Schema",
+                                    "examples": [
+                                        "sha256:7cf71a5173283a5102e4765a829205007dd171511d6f8715f45b7179411ea2e2"
+                                    ]
+                                },
+                                "resources": {
+                                    "type": "object",
+                                    "default": {},
+                                    "title": "The resources Schema",
+                                    "required": [
+                                        "requests"
+                                    ],
+                                    "properties": {
+                                        "requests": {
+                                            "type": "object",
+                                            "default": {},
+                                            "title": "The requests Schema",
+                                            "required": [
+                                                "memory",
+                                                "cpu"
+                                            ],
+                                            "properties": {
+                                                "memory": {
+                                                    "type": "string",
+                                                    "default": "",
+                                                    "title": "The memory Schema",
+                                                    "examples": [
+                                                        "2Gi"
+                                                    ]
+                                                },
+                                                "cpu": {
+                                                    "type": "string",
+                                                    "default": "",
+                                                    "title": "The cpu Schema",
+                                                    "examples": [
+                                                        "1"
+                                                    ]
+                                                }
+                                            },
+                                            "examples": [{
+                                                "memory": "2Gi",
+                                                "cpu": "1"
+                                            }]
+                                        }
+                                    },
+                                    "examples": [{
+                                        "requests": {
+                                            "memory": "2Gi",
+                                            "cpu": "1"
+                                        }
+                                    }]
+                                },
+                                "securityContext": {
+                                    "type": "object",
+                                    "default": {},
+                                    "title": "The securityContext Schema",
+                                    "required": [
+                                        "allowPrivilegeEscalation",
+                                        "readOnlyRootFilesystem",
+                                        "runAsNonRoot",
+                                        "capabilities"
+                                    ],
+                                    "properties": {
+                                        "allowPrivilegeEscalation": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "title": "The allowPrivilegeEscalation Schema",
+                                            "examples": [
+                                                false
+                                            ]
+                                        },
+                                        "readOnlyRootFilesystem": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "title": "The readOnlyRootFilesystem Schema",
+                                            "examples": [
+                                                true
+                                            ]
+                                        },
+                                        "runAsNonRoot": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "title": "The runAsNonRoot Schema",
+                                            "examples": [
+                                                true
+                                            ]
+                                        },
+                                        "capabilities": {
+                                            "type": "object",
+                                            "default": {},
+                                            "title": "The capabilities Schema",
+                                            "required": [
+                                                "drop"
+                                            ],
+                                            "properties": {
+                                                "drop": {
+                                                    "type": "array",
+                                                    "default": [],
+                                                    "title": "The drop Schema",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "default": "",
+                                                        "title": "A Schema",
+                                                        "examples": [
+                                                            "ALL"
+                                                        ]
+                                                    },
+                                                    "examples": [
+                                                        [
+                                                            "ALL"]
+                                                    ]
+                                                }
+                                            },
+                                            "examples": [{
+                                                "drop": [
+                                                    "ALL"
+                                                ]
+                                            }]
+                                        }
+                                    },
+                                    "examples": [{
+                                        "allowPrivilegeEscalation": false,
+                                        "readOnlyRootFilesystem": true,
+                                        "runAsNonRoot": true,
+                                        "capabilities": {
+                                            "drop": [
+                                                "ALL"
+                                            ]
+                                        }
+                                    }]
+                                }
+                            },
+                            "examples": [{
+                                "registry": "ghcr.io",
+                                "repository": "sigstore/scaffolding/cloudsqlproxy",
+                                "version": "sha256:7cf71a5173283a5102e4765a829205007dd171511d6f8715f45b7179411ea2e2",
+                                "resources": {
+                                    "requests": {
+                                        "memory": "2Gi",
+                                        "cpu": "1"
+                                    }
+                                },
+                                "securityContext": {
+                                    "allowPrivilegeEscalation": false,
+                                    "readOnlyRootFilesystem": true,
+                                    "runAsNonRoot": true,
+                                    "capabilities": {
+                                        "drop": [
+                                            "ALL"
+                                        ]
+                                    }
+                                }
+                            }]
+                        },
+                        "cloudsql": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The cloudsql Schema",
+                            "required": [
+                                "registry",
+                                "repository",
+                                "version",
+                                "resources",
+                                "securityContext",
+                                "unixDomainSocket"
+                            ],
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The registry Schema",
+                                    "examples": [
+                                        "gcr.io"
+                                    ]
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The repository Schema",
+                                    "examples": [
+                                        "cloud-sql-connectors/cloud-sql-proxy:2.9.0-alpine"
+                                    ]
+                                },
+                                "version": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The version Schema",
+                                    "examples": [
+                                        "sha256:40a7b65ad15ce73666ddf8f79a7651b59477688c27e22fd47aa59bb9b39757d9"
+                                    ]
+                                },
+                                "resources": {
+                                    "type": "object",
+                                    "default": {},
+                                    "title": "The resources Schema",
+                                    "required": [
+                                        "requests"
+                                    ],
+                                    "properties": {
+                                        "requests": {
+                                            "type": "object",
+                                            "default": {},
+                                            "title": "The requests Schema",
+                                            "required": [
+                                                "memory",
+                                                "cpu"
+                                            ],
+                                            "properties": {
+                                                "memory": {
+                                                    "type": "string",
+                                                    "default": "",
+                                                    "title": "The memory Schema",
+                                                    "examples": [
+                                                        "2Gi"
+                                                    ]
+                                                },
+                                                "cpu": {
+                                                    "type": "string",
+                                                    "default": "",
+                                                    "title": "The cpu Schema",
+                                                    "examples": [
+                                                        "1"
+                                                    ]
+                                                }
+                                            },
+                                            "examples": [{
+                                                "memory": "2Gi",
+                                                "cpu": "1"
+                                            }]
+                                        }
+                                    },
+                                    "examples": [{
+                                        "requests": {
+                                            "memory": "2Gi",
+                                            "cpu": "1"
+                                        }
+                                    }]
+                                },
+                                "securityContext": {
+                                    "type": "object",
+                                    "default": {},
+                                    "title": "The securityContext Schema",
+                                    "required": [
+                                        "allowPrivilegeEscalation",
+                                        "readOnlyRootFilesystem",
+                                        "runAsNonRoot",
+                                        "capabilities"
+                                    ],
+                                    "properties": {
+                                        "allowPrivilegeEscalation": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "title": "The allowPrivilegeEscalation Schema",
+                                            "examples": [
+                                                false
+                                            ]
+                                        },
+                                        "readOnlyRootFilesystem": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "title": "The readOnlyRootFilesystem Schema",
+                                            "examples": [
+                                                true
+                                            ]
+                                        },
+                                        "runAsNonRoot": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "title": "The runAsNonRoot Schema",
+                                            "examples": [
+                                                true
+                                            ]
+                                        },
+                                        "capabilities": {
+                                            "type": "object",
+                                            "default": {},
+                                            "title": "The capabilities Schema",
+                                            "required": [
+                                                "drop"
+                                            ],
+                                            "properties": {
+                                                "drop": {
+                                                    "type": "array",
+                                                    "default": [],
+                                                    "title": "The drop Schema",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "default": "",
+                                                        "title": "A Schema",
+                                                        "examples": [
+                                                            "ALL"
+                                                        ]
+                                                    },
+                                                    "examples": [
+                                                        [
+                                                            "ALL"]
+                                                    ]
+                                                }
+                                            },
+                                            "examples": [{
+                                                "drop": [
+                                                    "ALL"
+                                                ]
+                                            }]
+                                        }
+                                    },
+                                    "examples": [{
+                                        "allowPrivilegeEscalation": false,
+                                        "readOnlyRootFilesystem": true,
+                                        "runAsNonRoot": true,
+                                        "capabilities": {
+                                            "drop": [
+                                                "ALL"
+                                            ]
+                                        }
+                                    }]
+                                },
+                                "unixDomainSocket": {
+                                    "type": "object",
+                                    "default": {},
+                                    "title": "The unixDomainSocket Schema",
+                                    "required": [
+                                        "enabled",
+                                        "path"
+                                    ],
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "title": "The enabled Schema",
+                                            "examples": [
+                                                false
+                                            ]
+                                        },
+                                        "path": {
+                                            "type": "string",
+                                            "default": "",
+                                            "title": "The path Schema",
+                                            "examples": [
+                                                "/cloudsql"
+                                            ]
+                                        }
+                                    },
+                                    "examples": [{
+                                        "enabled": false,
+                                        "path": "/cloudsql"
+                                    }]
+                                }
+                            },
+                            "examples": [{
+                                "registry": "gcr.io",
+                                "repository": "cloud-sql-connectors/cloud-sql-proxy:2.9.0-alpine",
+                                "version": "sha256:40a7b65ad15ce73666ddf8f79a7651b59477688c27e22fd47aa59bb9b39757d9",
+                                "resources": {
+                                    "requests": {
+                                        "memory": "2Gi",
+                                        "cpu": "1"
+                                    }
+                                },
+                                "securityContext": {
+                                    "allowPrivilegeEscalation": false,
+                                    "readOnlyRootFilesystem": true,
+                                    "runAsNonRoot": true,
+                                    "capabilities": {
+                                        "drop": [
+                                            "ALL"
+                                        ]
+                                    }
+                                },
+                                "unixDomainSocket": {
+                                    "enabled": false,
+                                    "path": "/cloudsql"
+                                }
+                            }]
+                        }
+                    },
+                    "examples": [{
+                        "enabled": false,
+                        "instance": "",
+                        "scaffoldSQLProxy": {
+                            "registry": "ghcr.io",
+                            "repository": "sigstore/scaffolding/cloudsqlproxy",
+                            "version": "sha256:7cf71a5173283a5102e4765a829205007dd171511d6f8715f45b7179411ea2e2",
+                            "resources": {
+                                "requests": {
+                                    "memory": "2Gi",
+                                    "cpu": "1"
+                                }
+                            },
+                            "securityContext": {
+                                "allowPrivilegeEscalation": false,
+                                "readOnlyRootFilesystem": true,
+                                "runAsNonRoot": true,
+                                "capabilities": {
+                                    "drop": [
+                                        "ALL"
+                                    ]
+                                }
+                            }
+                        },
+                        "cloudsql": {
+                            "registry": "gcr.io",
+                            "repository": "cloud-sql-connectors/cloud-sql-proxy:2.9.0-alpine",
+                            "version": "sha256:40a7b65ad15ce73666ddf8f79a7651b59477688c27e22fd47aa59bb9b39757d9",
+                            "resources": {
+                                "requests": {
+                                    "memory": "2Gi",
+                                    "cpu": "1"
+                                }
+                            },
+                            "securityContext": {
+                                "allowPrivilegeEscalation": false,
+                                "readOnlyRootFilesystem": true,
+                                "runAsNonRoot": true,
+                                "capabilities": {
+                                    "drop": [
+                                        "ALL"
+                                    ]
+                                }
+                            },
+                            "unixDomainSocket": {
+                                "enabled": false,
+                                "path": "/cloudsql"
+                            }
+                        }
+                    }]
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The enabled Schema",
+                    "examples": [
+                        false
+                    ]
+                },
+                "replicaCount": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The replicaCount Schema",
+                    "examples": [
+                        1
+                    ]
+                },
+                "name": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The name Schema",
+                    "examples": [
+                        "mysql"
+                    ]
+                },
+                "hostname": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The hostname Schema",
+                    "examples": [
+                        ""
+                    ]
+                },
+                "port": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The port Schema",
+                    "examples": [
+                        3306
+                    ]
+                },
+                "strategy": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The strategy Schema",
+                    "required": [
+                        "type"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The type Schema",
+                            "examples": [
+                                "Recreate"
+                            ]
+                        }
+                    },
+                    "examples": [{
+                        "type": "Recreate"
+                    }]
+                },
+                "image": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The image Schema",
+                    "required": [
+                        "registry",
+                        "repository",
+                        "pullPolicy"
+                    ],
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The registry Schema",
+                            "examples": [
+                                "gcr.io"
+                            ]
+                        },
+                        "repository": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The repository Schema",
+                            "examples": [
+                                "trillian-opensource-ci/db_server"
+                            ]
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The pullPolicy Schema",
+                            "examples": [
+                                "IfNotPresent"
+                            ]
+                        }
+                    },
+                    "examples": [{
+                        "registry": "gcr.io",
+                        "repository": "trillian-opensource-ci/db_server",
+                        "pullPolicy": "IfNotPresent"
+                    }]
+                }
+            },
+            "examples": [{
+                "gcp": {
+                    "enabled": false,
+                    "instance": "",
+                    "scaffoldSQLProxy": {
+                        "registry": "ghcr.io",
+                        "repository": "sigstore/scaffolding/cloudsqlproxy",
+                        "version": "sha256:7cf71a5173283a5102e4765a829205007dd171511d6f8715f45b7179411ea2e2",
+                        "resources": {
+                            "requests": {
+                                "memory": "2Gi",
+                                "cpu": "1"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "readOnlyRootFilesystem": true,
+                            "runAsNonRoot": true,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            }
+                        }
+                    },
+                    "cloudsql": {
+                        "registry": "gcr.io",
+                        "repository": "cloud-sql-connectors/cloud-sql-proxy:2.9.0-alpine",
+                        "version": "sha256:40a7b65ad15ce73666ddf8f79a7651b59477688c27e22fd47aa59bb9b39757d9",
+                        "resources": {
+                            "requests": {
+                                "memory": "2Gi",
+                                "cpu": "1"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "readOnlyRootFilesystem": true,
+                            "runAsNonRoot": true,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            }
+                        },
+                        "unixDomainSocket": {
+                            "enabled": false,
+                            "path": "/cloudsql"
+                        }
+                    }
+                },
+                "enabled": false,
+                "replicaCount": 1,
+                "name": "mysql",
+                "hostname": "",
+                "port": 3306,
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "image": {
+                    "registry": "gcr.io",
+                    "repository": "trillian-opensource-ci/db_server",
+                    "pullPolicy": "IfNotPresent"
+                }
+            }]
+        },
         "server": {
             "title": "The server Schema",
             "type": "object",
@@ -1676,6 +2345,37 @@
                         }
                     ]
                 },
+                "searchIndex": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The searchIndex Schema",
+                    "required": [
+                        "storageProvider",
+                        "mysql"
+                    ],
+                    "properties": {
+                        "storageProvider": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The storageProvider Schema",
+                            "examples": [
+                                ""
+                            ]
+                        },
+                        "mysql": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The mysql Schema",
+                            "required": [],
+                            "properties": {},
+                            "examples": [{}]
+                        }
+                    },
+                    "examples": [{
+                        "storageProvider": "",
+                        "mysql": {}
+                    }]
+                },
                 "signerFileSecretOptions": {
                     "title": "The signerFileSecretOptions Schema",
                     "type": "object",
@@ -1831,6 +2531,10 @@
                         "create": true,
                         "name": "",
                         "annotations": {}
+                    },
+                    "searchIndex": {
+                        "storageProvider": "",
+                        "mysql": {}
                     }
                 }
             ]
@@ -2340,6 +3044,71 @@
                     "annotations": {}
                 }
             },
+            "mysql": {
+                "gcp": {
+                    "enabled": false,
+                    "instance": "",
+                    "scaffoldSQLProxy": {
+                        "registry": "ghcr.io",
+                        "repository": "sigstore/scaffolding/cloudsqlproxy",
+                        "version": "sha256:7cf71a5173283a5102e4765a829205007dd171511d6f8715f45b7179411ea2e2",
+                        "resources": {
+                            "requests": {
+                                "memory": "2Gi",
+                                "cpu": "1"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "readOnlyRootFilesystem": true,
+                            "runAsNonRoot": true,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            }
+                        }
+                    },
+                    "cloudsql": {
+                        "registry": "gcr.io",
+                        "repository": "cloud-sql-connectors/cloud-sql-proxy:2.9.0-alpine",
+                        "version": "sha256:40a7b65ad15ce73666ddf8f79a7651b59477688c27e22fd47aa59bb9b39757d9",
+                        "resources": {
+                            "requests": {
+                                "memory": "2Gi",
+                                "cpu": "1"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "readOnlyRootFilesystem": true,
+                            "runAsNonRoot": true,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            }
+                        },
+                        "unixDomainSocket": {
+                            "enabled": false,
+                            "path": "/cloudsql"
+                        }
+                    }
+                },
+                "enabled": false,
+                "replicaCount": 1,
+                "name": "mysql",
+                "hostname": "",
+                "port": 3306,
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "image": {
+                    "registry": "gcr.io",
+                    "repository": "trillian-opensource-ci/db_server",
+                    "pullPolicy": "IfNotPresent"
+                }
+            },
             "server": {
                 "enabled": true,
                 "replicaCount": 1,
@@ -2463,6 +3232,12 @@
                     "create": true,
                     "name": "",
                     "annotations": {}
+                },
+                "server": {
+                    "searchIndex": {
+                        "storageProvider": "",
+                        "mysql": {}
+                    }
                 }
             },
             "createtree": {

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -53,6 +53,57 @@ redis:
     name: ""
     annotations: {}
 
+mysql:
+  gcp:
+    enabled: false
+    instance: ""
+    scaffoldSQLProxy:
+      registry: ghcr.io
+      repository: sigstore/scaffolding/cloudsqlproxy
+      # -- v0.6.17 which is based on cloud-sql-proxy:2.9.0-alpine
+      version: sha256:7cf71a5173283a5102e4765a829205007dd171511d6f8715f45b7179411ea2e2
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "1"
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop:
+            - ALL
+    cloudsql:
+      registry: gcr.io
+      repository: cloud-sql-connectors/cloud-sql-proxy:2.9.0-alpine
+      # -- crane digest gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.9.0-alpine
+      version: sha256:40a7b65ad15ce73666ddf8f79a7651b59477688c27e22fd47aa59bb9b39757d9
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "1"
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop:
+            - ALL
+      unixDomainSocket:
+        enabled: false
+        path: /cloudsql
+  enabled: false
+  replicaCount: 1
+  name: mysql
+  hostname: ""
+  port: 3306
+  strategy:
+    type: Recreate
+  image:
+    registry: gcr.io
+    repository: trillian-opensource-ci/db_server
+    pullPolicy: IfNotPresent
+
 server:
   enabled: true
   replicaCount: 1
@@ -158,6 +209,10 @@ server:
     create: true
     name: ""
     annotations: {}
+  searchIndex:
+    storageProvider: ""
+    mysql: {}
+
 createtree:
   name: createtree
   force: false


### PR DESCRIPTION
Follow the pattern used by trillian, which can either manage its own database container or connect to a GCP SQL instance. If a container is created, the trillian mysql image is reused for convenience.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
