### PR TITLE
adds tolerations, nodeSelector, and affinity to sigstore-prober.

### DIFF
--- a/charts/sigstore-prober/Chart.yaml
+++ b/charts/sigstore-prober/Chart.yaml
@@ -4,7 +4,7 @@ description: Sigstore API Endpoint Prober
 
 type: application
 
-version: 0.0.22
+version: 0.0.23
 appVersion: 0.6.17
 
 

--- a/charts/sigstore-prober/templates/deployment.yaml
+++ b/charts/sigstore-prober/templates/deployment.yaml
@@ -68,3 +68,15 @@ spec:
         - name: sigstore
           emptyDir: {}
       {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}

--- a/charts/sigstore-prober/values.schema.json
+++ b/charts/sigstore-prober/values.schema.json
@@ -1,9 +1,11 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "affinity": {
+            "properties": {},
+            "type": "object"
+        },
         "namespace": {
-            "type": "object",
             "properties": {
                 "create": {
                     "type": "boolean"
@@ -11,18 +13,22 @@
                 "name": {
                     "type": "string"
                 }
-            }
+            },
+            "type": "object"
+        },
+        "nodeSelector": {
+            "properties": {},
+            "type": "object"
         },
         "prometheus": {
-            "type": "object",
             "properties": {
                 "port": {
                     "type": "integer"
                 }
-            }
+            },
+            "type": "object"
         },
         "serviceAccount": {
-            "type": "object",
             "properties": {
                 "create": {
                     "type": "boolean"
@@ -30,13 +36,12 @@
                 "name": {
                     "type": "string"
                 }
-            }
+            },
+            "type": "object"
         },
         "spec": {
-            "type": "object",
             "properties": {
                 "args": {
-                    "type": "object",
                     "properties": {
                         "frequency": {
                             "type": "integer"
@@ -59,7 +64,8 @@
                         "writeProber": {
                             "type": "boolean"
                         }
-                    }
+                    },
+                    "type": "object"
                 },
                 "image": {
                     "type": "string"
@@ -68,21 +74,19 @@
                     "type": "string"
                 },
                 "matchLabels": {
-                    "type": "object",
                     "properties": {
                         "app": {
                             "type": "string"
                         }
-                    }
+                    },
+                    "type": "object"
                 },
                 "replicaCount": {
                     "type": "integer"
                 },
                 "resources": {
-                    "type": "object",
                     "properties": {
                         "limits": {
-                            "type": "object",
                             "properties": {
                                 "cpu": {
                                     "type": "string"
@@ -90,10 +94,10 @@
                                 "memory": {
                                     "type": "string"
                                 }
-                            }
+                            },
+                            "type": "object"
                         },
                         "requests": {
-                            "type": "object",
                             "properties": {
                                 "cpu": {
                                     "type": "string"
@@ -101,11 +105,18 @@
                                 "memory": {
                                     "type": "string"
                                 }
-                            }
+                            },
+                            "type": "object"
                         }
-                    }
+                    },
+                    "type": "object"
                 }
-            }
+            },
+            "type": "object"
+        },
+        "tolerations": {
+            "type": "array"
         }
-    }
+    },
+    "type": "object"
 }

--- a/charts/sigstore-prober/values.yaml
+++ b/charts/sigstore-prober/values.yaml
@@ -27,3 +27,6 @@ spec:
     trustRekorAPIPublicKey: false
 prometheus:
   port: 8080
+tolerations: []
+nodeSelector: {}
+affinity: {}


### PR DESCRIPTION
Partly resolves https://github.com/sigstore/helm-charts/issues/696

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change
Adds tolerations, nodeSelector and affinity to charts.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->
[Request for tolerations, nodeSelector and affinity to be allowed to configure for all charts](https://github.com/sigstore/helm-charts/issues/696)

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

[initial PR w/ all changes in one.](https://github.com/sigstore/helm-charts/pull/754)

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
```
❯ ct lint --config ct.yaml
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 sigstore-prober => (version: "0.0.23", path: "charts/sigstore-prober")
------------------------------------------------------------------------------------------------------------------------

"sigstore" already exists with the same configuration, skipping
Linting chart "sigstore-prober => (version: \"0.0.23\", path: \"charts/sigstore-prober\")"
Checking chart "sigstore-prober => (version: \"0.0.23\", path: \"charts/sigstore-prober\")" for a version bump...
Old chart version: 0.0.22
New chart version: 0.0.23
Chart version ok.
Validating /Users/x308080/Projects/helmcharts-2/charts/sigstore-prober/Chart.yaml...
Validation success! 👍
==> Linting charts/sigstore-prober
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ sigstore-prober => (version: "0.0.23", path: "charts/sigstore-prober")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```
