### PR TITLE
adds tolerations, nodeSelector, and affinity to tuf.

### DIFF
--- a/charts/tuf/Chart.yaml
+++ b/charts/tuf/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tuf
 description: A framework for securing software update systems - the scaffolding implementation
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "0.6.17"
 
 home: https://sigstore.dev/

--- a/charts/tuf/templates/deployment.yaml
+++ b/charts/tuf/templates/deployment.yaml
@@ -72,3 +72,15 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
     {{- end }}
+    {{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.deployment.tolerations }}
+      tolerations:
+{{ toYaml .Values.deployment.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.deployment.affinity }}
+      affinity:
+{{ toYaml .Values.deployment.affinity | indent 8 }}
+    {{- end }}

--- a/charts/tuf/values.schema.json
+++ b/charts/tuf/values.schema.json
@@ -1,462 +1,196 @@
 {
-    "$schema": "https://json-schema.org/draft-07/schema",
-    "type": "object",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
-        "forceNamespace": {
-            "type": "string",
-            "examples": [
-                ""
-            ]
-        },
-        "imagePullSecrets": {
-            "type": "array",
-            "items": {},
-            "examples": [
-                []
-            ]
-        },
-        "serviceAccountName": {
-            "type": "string",
-            "examples": [
-                "tuf"
-            ]
-        },
-        "roleName": {
-            "type": "string",
-            "examples": [
-                "tuf"
-            ]
-        },
-        "roleBindingName": {
-            "type": "string",
-            "examples": [
-                "tuf"
-            ]
-        },
-        "fullnameOverride": {
-            "type": "string",
-            "examples": [
-                "tuf"
-            ]
-        },
-        "enabled": {
-            "type": "boolean",
-            "examples": [
-                true
-            ]
-        },
         "deployment": {
-            "type": "object",
             "properties": {
-                "name": {
-                    "type": "string",
-                    "examples": [
-                        "tuf"
-                    ]
-                },
-                "replicas": {
-                    "type": "integer",
-                    "examples": [
-                        1
-                    ]
-                },
-                "registry": {
-                    "type": "string",
-                    "examples": [
-                        "ghcr.io"
-                    ]
-                },
-                "repository": {
-                    "type": "string",
-                    "examples": [
-                        "sigstore/scaffolding/server"
-                    ]
-                },
-                "version": {
-                    "type": "string",
-                    "examples": [
-                        "sha256:c77d098e0e62f791cc87b63ae43a5fea505225e0ec38686c4a392c0cad7238bf"
-                    ]
+                "affinity": {
+                    "properties": {},
+                    "type": "object"
                 },
                 "imagePullPolicy": {
-                    "type": "string",
-                    "examples": [
-                        "IfNotPresent"
-                    ]
-                },
-                "port": {
-                    "type": "integer",
-                    "examples": [
-                        8080
-                    ]
-                }
-            },
-            "examples": [{
-                "name": "tuf",
-                "replicas": 1,
-                "registry": "ghcr.io",
-                "repository": "sigstore/scaffolding/server",
-                "version": "sha256:c77d098e0e62f791cc87b63ae43a5fea505225e0ec38686c4a392c0cad7238bf",
-                "imagePullPolicy": "IfNotPresent",
-                "port": 8080
-            }]
-        },
-        "secrets": {
-            "type": "object",
-            "properties": {
-                "rekor": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "name": {
-                            "type": "string",
-                            "examples": [
-                                "rekor-public-key"
-                            ]
-                        },
-                        "key": {
-                            "type": "string",
-                            "examples": [
-                                "public"
-                            ]
-                        },
-                        "path": {
-                            "type": "string",
-                            "examples": [
-                                "rekor.pub"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "create": false,
-                        "name": "rekor-public-key",
-                        "key": "public",
-                        "path": "rekor.pub"
-                    }]
-                },
-                "fulcio": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "name": {
-                            "type": "string",
-                            "examples": [
-                                "fulcio-server-secret"
-                            ]
-                        },
-                        "key": {
-                            "type": "string",
-                            "examples": [
-                                "cert"
-                            ]
-                        },
-                        "path": {
-                            "type": "string",
-                            "examples": [
-                                "fulcio_v1.crt.pem"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "create": false,
-                        "name": "fulcio-server-secret",
-                        "key": "cert",
-                        "path": "fulcio_v1.crt.pem"
-                    }]
-                },
-                "ctlog": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "name": {
-                            "type": "string",
-                            "examples": [
-                                "ctlog-public-key"
-                            ]
-                        },
-                        "key": {
-                            "type": "string",
-                            "examples": [
-                                "key"
-                            ]
-                        },
-                        "path": {
-                            "type": "string",
-                            "examples": [
-                                "ctfe.pub"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "create": false,
-                        "name": "ctlog-public-key",
-                        "key": "key",
-                        "path": "ctfe.pub"
-                    }]
-                },
-                "tsa": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "name": {
-                            "type": "string",
-                            "examples": [
-                                "tsa-cert-chain"
-                            ]
-                        },
-                        "key": {
-                            "type": "string",
-                            "examples": [
-                                "cert-chain"
-                            ]
-                        },
-                        "path": {
-                            "type": "string",
-                            "examples": [
-                                "tsa.certchain.pem"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "create": false,
-                        "name": "tsa-cert-chain",
-                        "key": "cert-chain",
-                        "path": "tsa.certchain.pem"
-                    }]
-                }
-            },
-            "examples": [{
-                "rekor": {
-                    "create": false,
-                    "name": "rekor-public-key",
-                    "key": "public",
-                    "path": "rekor.pub"
-                },
-                "fulcio": {
-                    "create": false,
-                    "name": "fulcio-server-secret",
-                    "key": "cert",
-                    "path": "fulcio_v1.crt.pem"
-                },
-                "ctlog": {
-                    "create": false,
-                    "name": "ctlog-public-key",
-                    "key": "key",
-                    "path": "ctfe.pub"
-                },
-                "tsa": {
-                    "create": false,
-                    "name": "tsa-cert-chain",
-                    "key": "cert-chain",
-                    "path": "tsa.certchain.pem"
-                }
-            }]
-        },
-        "ingress": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean",
-                    "examples": [
-                        true
-                    ]
+                    "type": "string"
                 },
                 "name": {
-                    "type": "string",
-                    "examples": [
-                        "tuf-server"
-                    ]
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "replicas": {
+                    "type": "integer"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tolerations": {
+                    "type": "array"
+                },
+                "version": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "enabled": {
+            "type": "boolean"
+        },
+        "forceNamespace": {
+            "type": "string"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "ingress": {
+            "properties": {
+                "annotations": {
+                    "properties": {},
+                    "type": "object"
                 },
                 "className": {
-                    "type": "string",
-                    "examples": [
-                        "nginx"
-                    ]
+                    "type": "string"
                 },
-                "annotations": {
-                    "type": "object",
-                    "properties": {},
-                    "examples": [{}]
+                "create": {
+                    "type": "boolean"
                 },
                 "http": {
-                    "type": "object",
                     "properties": {
                         "hosts": {
-                            "type": "array",
                             "items": {
-                                "type": "object",
                                 "properties": {
-                                    "path": {
-                                        "type": "string",
-                                        "examples": [
-                                            "/"
-                                        ]
-                                    },
                                     "host": {
-                                        "type": "string",
-                                        "examples": [
-                                            "tuf.localhost"
-                                        ]
+                                        "type": "string"
+                                    },
+                                    "path": {
+                                        "type": "string"
                                     }
                                 },
-                                "examples": [{
-                                    "path": "/",
-                                    "host": "tuf.localhost"
-                                }]
+                                "type": "object"
                             },
-                            "examples": [
-                                [{
-                                    "path": "/",
-                                    "host": "tuf.localhost"
-                                }]
-                            ]
+                            "type": "array"
                         }
                     },
-                    "examples": [{
-                        "hosts": [{
-                            "path": "/",
-                            "host": "tuf.localhost"
-                        }]
-                    }]
-                }
-            },
-            "examples": [{
-                "name": "tuf-server",
-                "className": "nginx",
-                "annotations": {},
-                "http": {
-                    "hosts": [{
-                        "path": "/",
-                        "host": "tuf.localhost"
-                    }]
-                }
-            }]
-        },
-        "service": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "examples": [
-                        "tuf-server"
-                    ]
+                    "type": "object"
                 },
-                "port": {
-                    "type": "integer",
-                    "examples": [
-                        80
-                    ]
+                "name": {
+                    "type": "string"
                 }
             },
-            "examples": [{
-                "name": "tuf-server",
-                "port": 80
-            }]
+            "type": "object"
         },
         "namespace": {
-            "type": "object",
             "properties": {
                 "create": {
-                    "type": "boolean",
-                    "examples": [
-                        false
-                    ]
+                    "type": "boolean"
                 },
                 "name": {
-                    "type": "string",
-                    "examples": [
-                        "fulcio-system"
-                    ]
+                    "type": "string"
                 }
             },
-            "examples": [{
-                "create": false,
-                "name": "fulcio-system"
-            }]
-        }
-    },
-    "examples": [{
-        "forceNamespace": "",
-        "imagePullSecrets": [],
-        "serviceAccountName": "tuf",
-        "roleName": "tuf",
-        "roleBindingName": "tuf",
-        "fullnameOverride": "tuf",
-        "enabled": true,
-        "deployment": {
-            "name": "tuf",
-            "replicas": 1,
-            "registry": "ghcr.io",
-            "repository": "sigstore/scaffolding/server",
-            "version": "sha256:c77d098e0e62f791cc87b63ae43a5fea505225e0ec38686c4a392c0cad7238bf",
-            "imagePullPolicy": "IfNotPresent",
-            "port": 8080
+            "type": "object"
+        },
+        "roleBindingName": {
+            "type": "string"
+        },
+        "roleName": {
+            "type": "string"
         },
         "secrets": {
-            "rekor": {
-                "create": false,
-                "name": "rekor-public-key",
-                "key": "public",
-                "path": "rekor.pub"
+            "properties": {
+                "ctlog": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "fulcio": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "rekor": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tsa": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
             },
-            "fulcio": {
-                "create": false,
-                "name": "fulcio-server-secret",
-                "key": "cert",
-                "path": "fulcio_v1.crt.pem"
-            },
-            "ctlog": {
-                "create": false,
-                "name": "ctlog-public-key",
-                "key": "key",
-                "path": "ctfe.pub"
-            },
-            "tsa": {
-                "create": false,
-                "name": "tsa-cert-chain",
-                "key": "key",
-                "path": "tsa.certchain.pem"
-            }
-        },
-        "ingress": {
-            "create": true,
-            "name": "tuf-server",
-            "className": "nginx",
-            "annotations": {},
-            "http": {
-                "hosts": [{
-                    "path": "/",
-                    "host": "tuf.localhost"
-                }]
-            }
+            "type": "object"
         },
         "service": {
-            "name": "tuf-server",
-            "port": 80
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
         },
-        "namespace": {
-            "create": false,
-            "name": "fulcio-system"
+        "serviceAccountName": {
+            "type": "string"
         }
-    }]
+    },
+    "type": "object"
 }

--- a/charts/tuf/values.yaml
+++ b/charts/tuf/values.yaml
@@ -15,6 +15,9 @@ deployment:
   version: sha256:496b443c82be2c4a14a6e3dfbfa9ccae5b6eaedd7a3aca58b84ddae9492d9906
   imagePullPolicy: IfNotPresent
   port: 8080
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
 
 secrets:
   rekor:


### PR DESCRIPTION
Partly resolves https://github.com/sigstore/helm-charts/issues/696

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change
Adds tolerations, nodeSelector and affinity to charts.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->
[Request for tolerations, nodeSelector and affinity to be allowed to configure for all charts](https://github.com/sigstore/helm-charts/issues/696)

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

[initial PR w/ all changes in one.](https://github.com/sigstore/helm-charts/pull/754)

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
```
❯ ct lint --config ct.yaml
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 tuf => (version: "0.1.13", path: "charts/tuf")
------------------------------------------------------------------------------------------------------------------------

"sigstore" already exists with the same configuration, skipping
Linting chart "tuf => (version: \"0.1.13\", path: \"charts/tuf\")"
Checking chart "tuf => (version: \"0.1.13\", path: \"charts/tuf\")" for a version bump...
Old chart version: 0.1.12
New chart version: 0.1.13
Chart version ok.
Validating /Users/x308080/Projects/helmcharts-2/charts/tuf/Chart.yaml...
Validation success! 👍

Linting chart with values file "charts/tuf/ci/ci-values.yaml"...

==> Linting charts/tuf
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ tuf => (version: "0.1.13", path: "charts/tuf")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```

cc @hectorj2f / @cpanato