### PR TITLE
adds tolerations, nodeSelector, and affinity to updatetree.

### DIFF
--- a/charts/updatetree/Chart.yaml
+++ b/charts/updatetree/Chart.yaml
@@ -4,7 +4,7 @@ description: Update the status of an existing Trillian tree
 
 type: application
 
-version: 0.0.9
+version: 0.0.10
 appVersion: 0.6.17
 
 

--- a/charts/updatetree/README.md
+++ b/charts/updatetree/README.md
@@ -16,12 +16,14 @@ Update the status of an existing Trillian tree
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| affinity | object | `{}` |  |
 | annotations | object | `{}` |  |
 | args.treeID | string | `""` |  |
 | args.treeState | string | `""` | valid tree states are ACTIVE, FROZEN and DRAINING |
 | enabled | bool | `false` |  |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"trillian-system"` |  |
+| nodeSelector | object | `{}` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.runAsUser | int | `65533` |  |
 | serviceAccount.annotations | object | `{}` |  |
@@ -29,9 +31,9 @@ Update the status of an existing Trillian tree
 | serviceAccount.name | string | `"trillian-logserver"` |  |
 | spec.image | string | `"ghcr.io/sigstore/scaffolding/updatetree:v0.6.17@sha256:9fe03dde7324490cc7a84c75dfa3f1de267fc71c1a473fc67491c690e22c32ab"` |  |
 | spec.replicaCount | int | `1` |  |
+| tolerations | list | `[]` |  |
 | trillian.adminServer | string | `""` |  |
 | trillian.logServer.name | string | `"trillian-logserver"` |  |
 | trillian.logServer.portRPC | int | `8091` |  |
 | trillian.namespace | string | `"trillian-system"` |  |
 | ttlSecondsAfterFinished | int | `3600` |  |
-

--- a/charts/updatetree/templates/job.yaml
+++ b/charts/updatetree/templates/job.yaml
@@ -32,4 +32,16 @@ spec:
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
     {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/updatetree/values.schema.json
+++ b/charts/updatetree/values.schema.json
@@ -1,328 +1,108 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://example.com/example.json",
-    "type": "object",
-    "default": {},
-    "title": "Root Schema",
-    "required": [
-        "enabled",
-        "namespace",
-        "serviceAccount",
-        "spec",
-        "securityContext",
-        "args",
-        "annotations",
-        "trillian"
-    ],
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
-        "enabled": {
-            "type": "boolean",
-            "default": false,
-            "title": "The enabled Schema",
-            "examples": [
-                false
-            ]
-        },
-        "namespace": {
-            "type": "object",
-            "default": {},
-            "title": "The namespace Schema",
-            "required": [
-                "name",
-                "create"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The name Schema",
-                    "examples": [
-                        "trillian-system"
-                    ]
-                },
-                "create": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The create Schema",
-                    "examples": [
-                        false
-                    ]
-                }
-            },
-            "examples": [
-                {
-                    "name": "trillian-system",
-                    "create": false
-                }
-            ]
-        },
-        "serviceAccount": {
-            "type": "object",
-            "default": {},
-            "title": "The serviceAccount Schema",
-            "required": [
-                "name",
-                "annotations",
-                "create"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The name Schema",
-                    "examples": [
-                        "trillian-logserver"
-                    ]
-                },
-                "annotations": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The annotations Schema",
-                    "required": [],
-                    "properties": {},
-                    "examples": [
-                        {}
-                    ]
-                },
-                "create": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The create Schema",
-                    "examples": [
-                        false
-                    ]
-                }
-            },
-            "examples": [
-                {
-                    "name": "trillian-logserver",
-                    "annotations": {},
-                    "create": false
-                }
-            ]
-        },
-        "spec": {
-            "type": "object",
-            "default": {},
-            "title": "The spec Schema",
-            "required": [
-                "replicaCount",
-                "image"
-            ],
-            "properties": {
-                "replicaCount": {
-                    "type": "integer",
-                    "default": 0,
-                    "title": "The replicaCount Schema",
-                    "examples": [
-                        1
-                    ]
-                },
-                "image": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The image Schema",
-                    "examples": [
-                        "ghcr.io/sigstore/scaffolding/updatetree:v0.6.7@sha256:357cf3545cd459634fe6a461a7690bc5f425c353e48c80da551cfec6887d627d"
-                    ]
-                }
-            },
-            "examples": [
-                {
-                    "replicaCount": 1,
-                    "image": "ghcr.io/sigstore/scaffolding/updatetree:v0.6.7@sha256:357cf3545cd459634fe6a461a7690bc5f425c353e48c80da551cfec6887d627d"
-                }
-            ]
-        },
-        "ttlSecondsAfterFinished": {
-            "type": "integer",
-            "default": 0,
-            "title": "The ttlSecondsAfterFinished Schema",
-            "examples": [
-                3600
-            ]
-        },
-        "securityContext": {
-            "type": "object",
-            "default": {},
-            "title": "The securityContext Schema",
-            "required": [
-                "runAsNonRoot",
-                "runAsUser"
-            ],
-            "properties": {
-                "runAsNonRoot": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The runAsNonRoot Schema",
-                    "examples": [
-                        true
-                    ]
-                },
-                "runAsUser": {
-                    "type": "integer",
-                    "default": 0,
-                    "title": "The runAsUser Schema",
-                    "examples": [
-                        65533
-                    ]
-                }
-            },
-            "examples": [
-                {
-                    "runAsNonRoot": true,
-                    "runAsUser": 65533
-                }
-            ]
-        },
-        "args": {
-            "type": "object",
-            "default": {},
-            "title": "The args Schema",
-            "required": [
-                "treeID",
-                "treeState"
-            ],
-            "properties": {
-                "treeID": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The treeID Schema",
-                    "examples": [
-                        ""
-                    ]
-                },
-                "treeState": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The treeState Schema",
-                    "examples": [
-                        ""
-                    ]
-                }
-            },
-            "examples": [
-                {
-                    "treeID": "",
-                    "treeState": ""
-                }
-            ]
+        "affinity": {
+            "properties": {},
+            "type": "object"
         },
         "annotations": {
-            "type": "object",
-            "default": {},
-            "title": "The annotations Schema",
-            "required": [],
             "properties": {},
-            "examples": [
-                {}
-            ]
+            "type": "object"
+        },
+        "args": {
+            "properties": {
+                "treeID": {
+                    "type": "string"
+                },
+                "treeState": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "enabled": {
+            "type": "boolean"
+        },
+        "namespace": {
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "nodeSelector": {
+            "properties": {},
+            "type": "object"
+        },
+        "securityContext": {
+            "properties": {
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "serviceAccount": {
+            "properties": {
+                "annotations": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "spec": {
+            "properties": {
+                "image": {
+                    "type": "string"
+                },
+                "replicaCount": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "tolerations": {
+            "type": "array"
         },
         "trillian": {
-            "type": "object",
-            "default": {},
-            "title": "The trillian Schema",
-            "required": [
-                "namespace",
-                "adminServer",
-                "logServer"
-            ],
             "properties": {
-                "namespace": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The namespace Schema",
-                    "examples": [
-                        "trillian-system"
-                    ]
-                },
                 "adminServer": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The adminServer Schema",
-                    "examples": [
-                        ""
-                    ]
+                    "type": "string"
                 },
                 "logServer": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The logServer Schema",
-                    "required": [
-                        "name",
-                        "portRPC"
-                    ],
                     "properties": {
                         "name": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The name Schema",
-                            "examples": [
-                                "trillian-logserver"
-                            ]
+                            "type": "string"
                         },
                         "portRPC": {
-                            "type": "integer",
-                            "default": 0,
-                            "title": "The portRPC Schema",
-                            "examples": [
-                                8091
-                            ]
+                            "type": "integer"
                         }
                     },
-                    "examples": [
-                        {
-                            "name": "trillian-logserver",
-                            "portRPC": 8091
-                        }
-                    ]
+                    "type": "object"
+                },
+                "namespace": {
+                    "type": "string"
                 }
             },
-            "examples": [
-                {
-                    "namespace": "trillian-system",
-                    "adminServer": "",
-                    "logServer": {
-                        "name": "trillian-logserver",
-                        "portRPC": 8091
-                    }
-                }
-            ]
+            "type": "object"
+        },
+        "ttlSecondsAfterFinished": {
+            "type": "integer"
         }
     },
-    "examples": [
-        {
-            "enabled": false,
-            "namespace": {
-                "name": "trillian-system",
-                "create": false
-            },
-            "serviceAccount": {
-                "name": "trillian-logserver",
-                "annotations": {},
-                "create": false
-            },
-            "spec": {
-                "replicaCount": 1,
-                "image": "ghcr.io/sigstore/scaffolding/updatetree:v0.6.7@sha256:357cf3545cd459634fe6a461a7690bc5f425c353e48c80da551cfec6887d627d"
-            },
-            "securityContext": {
-                "runAsNonRoot": true,
-                "runAsUser": 65533
-            },
-            "args": {
-                "treeID": "",
-                "treeState": ""
-            },
-            "annotations": {},
-            "trillian": {
-                "namespace": "trillian-system",
-                "adminServer": "",
-                "logServer": {
-                    "name": "trillian-logserver",
-                    "portRPC": 8091
-                }
-            }
-        }
-    ]
+    "type": "object"
 }

--- a/charts/updatetree/values.yaml
+++ b/charts/updatetree/values.yaml
@@ -26,3 +26,7 @@ trillian:
   logServer:
     name: trillian-logserver
     portRPC: 8091
+
+tolerations: []
+nodeSelector: {}
+affinity: {}


### PR DESCRIPTION
Partly resolves https://github.com/sigstore/helm-charts/issues/696

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change
Adds tolerations, nodeSelector and affinity to charts.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->
[Request for tolerations, nodeSelector and affinity to be allowed to configure for all charts](https://github.com/sigstore/helm-charts/issues/696)

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

[initial PR w/ all changes in one.](https://github.com/sigstore/helm-charts/pull/754)

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
```
❯ ct lint --config ct.yaml
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 updatetree => (version: "0.0.10", path: "charts/updatetree")
------------------------------------------------------------------------------------------------------------------------

"sigstore" already exists with the same configuration, skipping
Linting chart "updatetree => (version: \"0.0.10\", path: \"charts/updatetree\")"
Checking chart "updatetree => (version: \"0.0.10\", path: \"charts/updatetree\")" for a version bump...
Old chart version: 0.0.9
New chart version: 0.0.10
Chart version ok.
Validating /Users/x308080/Projects/helmcharts-2/charts/updatetree/Chart.yaml...
Validation success! 👍

Linting chart with values file "charts/updatetree/ci/ci-values.yaml"...

==> Linting charts/updatetree
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ updatetree => (version: "0.0.10", path: "charts/updatetree")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```

cc @hectorj2f / @cpanato