### PR TITLE
adds tolerations, nodeSelector, and affinity to scaffold.

### DIFF
--- a/charts/scaffold/Chart.lock
+++ b/charts/scaffold/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: fulcio
   repository: https://sigstore.github.io/helm-charts
-  version: 2.3.19
+  version: 2.3.20
 - name: rekor
   repository: https://sigstore.github.io/helm-charts
-  version: 1.4.0
+  version: 1.4.2
 - name: trillian
   repository: https://sigstore.github.io/helm-charts
-  version: 0.2.22
+  version: 0.2.24
 - name: ctlog
   repository: https://sigstore.github.io/helm-charts
-  version: 0.2.52
+  version: 0.2.53
 - name: tuf
   repository: https://sigstore.github.io/helm-charts
-  version: 0.1.12
+  version: 0.1.14
 - name: tsa
   repository: https://sigstore.github.io/helm-charts
-  version: 1.0.2
-digest: sha256:9f99a82164d1b86071eb345985e53d41b0304fecdd7fde7649dc9486477975f7
-generated: "2024-05-14T11:49:22.640407283-07:00"
+  version: 1.0.3
+digest: sha256:caf960fdcf37c5819ddd2c2719cc557d28d59923cca4fd8c273f8dc0c94a15a5
+generated: "2024-06-27T09:57:50.636761-04:00"

--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.6.50
+version: 0.6.51
 keywords:
   - security
   - pki
@@ -16,27 +16,27 @@ maintainers:
 
 dependencies:
   - name: fulcio
-    version: 2.3.19
+    version: 2.3.20
     repository: https://sigstore.github.io/helm-charts
     condition: fulcio.enabled
   - name: rekor
-    version: 1.4.0
+    version: 1.4.2
     repository: https://sigstore.github.io/helm-charts
     condition: rekor.enabled
   - name: trillian
-    version: 0.2.22
+    version: 0.2.24
     repository: https://sigstore.github.io/helm-charts
     condition: trillian.enabled
   - name: ctlog
-    version: 0.2.52
+    version: 0.2.53
     repository: https://sigstore.github.io/helm-charts
     condition: ctlog.enabled
   - name: tuf
-    version: 0.1.12
+    version: 0.1.14
     repository: https://sigstore.github.io/helm-charts
     condition: tuf.enabled
   - name: tsa
-    version: 1.0.2
+    version: 1.0.3
     repository: https://sigstore.github.io/helm-charts
     condition: tsa.enabled
 

--- a/charts/scaffold/templates/copy-secrets-job.yaml
+++ b/charts/scaffold/templates/copy-secrets-job.yaml
@@ -78,4 +78,16 @@ spec:
             "-c",
             "curl {{ .Values.tsa.server.fullnameOverride}}.{{ .Values.tsa.namespace.name }}.svc.cluster.local/api/v1/timestamp/certchain -o /tmp/cert-chain -v && kubectl create secret generic {{ .Values.tuf.secrets.tsa.name }} --from-file=cert-chain=/tmp/cert-chain"
         ]
+      {{- if .Values.copySecretJob.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.copySecretJob.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.copySecretJob.tolerations }}
+      tolerations:
+{{ toYaml .Values.copySecretJob.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.copySecretJob.affinity }}
+      affinity:
+{{ toYaml .Values.copySecretJob.affinity | indent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/scaffold/values.schema.json
+++ b/charts/scaffold/values.schema.json
@@ -1,1190 +1,424 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://example.com/example.json",
-    "type": "object",
-    "default": {},
-    "title": "Root Schema",
-    "required": [
-        "fulcio",
-        "ctlog",
-        "rekor",
-        "trillian",
-        "tuf",
-        "copySecretJob",
-        "tsa"
-    ],
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
-        "fulcio": {
-            "type": "object",
-            "default": {},
-            "title": "The fulcio Schema",
-            "required": [
-                "enabled",
-                "namespace",
-                "forceNamespace",
-                "server",
-                "createcerts",
-                "ctlog"
-            ],
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The enabled Schema",
-                    "examples": [
-                        true
-                    ]
-                },
-                "namespace": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The namespace Schema",
-                    "required": [
-                        "name",
-                        "create"
-                    ],
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The name Schema",
-                            "examples": [
-                                "fulcio-system"
-                            ]
-                        },
-                        "create": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "The create Schema",
-                            "examples": [
-                                true
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "name": "fulcio-system",
-                        "create": true
-                    }]
-                },
-                "forceNamespace": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The forceNamespace Schema",
-                    "examples": [
-                        "fulcio-system"
-                    ]
-                },
-                "server": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The server Schema",
-                    "required": [
-                        "fullnameOverride"
-                    ],
-                    "properties": {
-                        "fullnameOverride": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The fullnameOverride Schema",
-                            "examples": [
-                                "fulcio-server"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "fullnameOverride": "fulcio-server"
-                    }]
-                },
-                "createcerts": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The createcerts Schema",
-                    "required": [
-                        "fullnameOverride"
-                    ],
-                    "properties": {
-                        "fullnameOverride": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The fullnameOverride Schema",
-                            "examples": [
-                                "fulcio-createcerts"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "fullnameOverride": "fulcio-createcerts"
-                    }]
-                },
-                "ctlog": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The ctlog Schema",
-                    "required": [
-                        "enabled",
-                        "createctconfig"
-                    ],
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "The enabled Schema",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "createctconfig": {
-                            "type": "object",
-                            "default": {},
-                            "title": "The createctconfig Schema",
-                            "required": [
-                                "logPrefix"
-                            ],
-                            "properties": {
-                                "logPrefix": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "The logPrefix Schema",
-                                    "examples": [
-                                        "sigstorescaffolding"
-                                    ]
-                                }
-                            },
-                            "examples": [{
-                                "logPrefix": "sigstorescaffolding"
-                            }]
-                        }
-                    },
-                    "examples": [{
-                        "enabled": false,
-                        "createctconfig": {
-                            "logPrefix": "sigstorescaffolding"
-                        }
-                    }]
-                }
-            },
-            "examples": [{
-                "enabled": true,
-                "namespace": {
-                    "name": "fulcio-system",
-                    "create": true
-                },
-                "forceNamespace": "fulcio-system",
-                "server": {
-                    "fullnameOverride": "fulcio-server"
-                },
-                "createcerts": {
-                    "fullnameOverride": "fulcio-createcerts"
-                },
-                "ctlog": {
-                    "enabled": false,
-                    "createctconfig": {
-                        "logPrefix": "sigstorescaffolding"
-                    }
-                }
-            }]
-        },
-        "ctlog": {
-            "type": "object",
-            "default": {},
-            "title": "The ctlog Schema",
-            "required": [
-                "enabled",
-                "namespace",
-                "forceNamespace",
-                "fullnameOverride",
-                "createcerts",
-                "createtree"
-            ],
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The enabled Schema",
-                    "examples": [
-                        true
-                    ]
-                },
-                "namespace": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The namespace Schema",
-                    "required": [
-                        "name",
-                        "create"
-                    ],
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The name Schema",
-                            "examples": [
-                                "ctlog-system"
-                            ]
-                        },
-                        "create": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "The create Schema",
-                            "examples": [
-                                true
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "name": "ctlog-system",
-                        "create": true
-                    }]
-                },
-                "forceNamespace": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The forceNamespace Schema",
-                    "examples": [
-                        "ctlog-system"
-                    ]
-                },
-                "fullnameOverride": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The fullnameOverride Schema",
-                    "examples": [
-                        "ctlog"
-                    ]
-                },
-                "createcerts": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The createcerts Schema",
-                    "required": [
-                        "fullnameOverride"
-                    ],
-                    "properties": {
-                        "fullnameOverride": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The fullnameOverride Schema",
-                            "examples": [
-                                "ctlog-createcerts"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "fullnameOverride": "ctlog-createcerts"
-                    }]
-                },
-                "createtree": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The createtree Schema",
-                    "required": [
-                        "fullnameOverride",
-                        "displayName"
-                    ],
-                    "properties": {
-                        "fullnameOverride": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The fullnameOverride Schema",
-                            "examples": [
-                                "ctlog-createtree"
-                            ]
-                        },
-                        "displayName": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The displayName Schema",
-                            "examples": [
-                                "ctlog-tree"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "fullnameOverride": "ctlog-createtree",
-                        "displayName": "ctlog-tree"
-                    }]
-                }
-            },
-            "examples": [{
-                "enabled": true,
-                "namespace": {
-                    "name": "ctlog-system",
-                    "create": true
-                },
-                "forceNamespace": "ctlog-system",
-                "fullnameOverride": "ctlog",
-                "createcerts": {
-                    "fullnameOverride": "ctlog-createcerts"
-                },
-                "createtree": {
-                    "fullnameOverride": "ctlog-createtree",
-                    "displayName": "ctlog-tree"
-                }
-            }]
-        },
-        "rekor": {
-            "type": "object",
-            "default": {},
-            "title": "The rekor Schema",
-            "required": [
-                "enabled",
-                "namespace",
-                "forceNamespace",
-                "fullnameOverride",
-                "server",
-                "redis",
-                "trillian"
-            ],
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The enabled Schema",
-                    "examples": [
-                        true
-                    ]
-                },
-                "namespace": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The namespace Schema",
-                    "required": [
-                        "name",
-                        "create"
-                    ],
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The name Schema",
-                            "examples": [
-                                "rekor-system"
-                            ]
-                        },
-                        "create": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "The create Schema",
-                            "examples": [
-                                true
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "name": "rekor-system",
-                        "create": true
-                    }]
-                },
-                "forceNamespace": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The forceNamespace Schema",
-                    "examples": [
-                        "rekor-system"
-                    ]
-                },
-                "fullnameOverride": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The fullnameOverride Schema",
-                    "examples": [
-                        "rekor"
-                    ]
-                },
-                "server": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The server Schema",
-                    "required": [
-                        "fullnameOverride"
-                    ],
-                    "properties": {
-                        "fullnameOverride": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The fullnameOverride Schema",
-                            "examples": [
-                                "rekor-server"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "fullnameOverride": "rekor-server"
-                    }]
-                },
-                "redis": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The redis Schema",
-                    "required": [
-                        "fullnameOverride"
-                    ],
-                    "properties": {
-                        "fullnameOverride": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The fullnameOverride Schema",
-                            "examples": [
-                                "rekor-redis"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "fullnameOverride": "rekor-redis"
-                    }]
-                },
-                "trillian": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The trillian Schema",
-                    "required": [
-                        "enabled"
-                    ],
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "The enabled Schema",
-                            "examples": [
-                                false
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "enabled": false
-                    }]
-                }
-            },
-            "examples": [{
-                "enabled": true,
-                "namespace": {
-                    "name": "rekor-system",
-                    "create": true
-                },
-                "forceNamespace": "rekor-system",
-                "fullnameOverride": "rekor",
-                "server": {
-                    "fullnameOverride": "rekor-server"
-                },
-                "redis": {
-                    "fullnameOverride": "rekor-redis"
-                },
-                "trillian": {
-                    "enabled": false
-                }
-            }]
-        },
-        "trillian": {
-            "type": "object",
-            "default": {},
-            "title": "The trillian Schema",
-            "required": [
-                "enabled",
-                "namespace",
-                "forceNamespace",
-                "fullnameOverride",
-                "logServer",
-                "logSigner",
-                "mysql"
-            ],
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The enabled Schema",
-                    "examples": [
-                        true
-                    ]
-                },
-                "namespace": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The namespace Schema",
-                    "required": [
-                        "name",
-                        "create"
-                    ],
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The name Schema",
-                            "examples": [
-                                "trillian-system"
-                            ]
-                        },
-                        "create": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "The create Schema",
-                            "examples": [
-                                true
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "name": "trillian-system",
-                        "create": true
-                    }]
-                },
-                "forceNamespace": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The forceNamespace Schema",
-                    "examples": [
-                        "trillian-system"
-                    ]
-                },
-                "fullnameOverride": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The fullnameOverride Schema",
-                    "examples": [
-                        "trillian"
-                    ]
-                },
-                "logServer": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The logServer Schema",
-                    "required": [
-                        "name",
-                        "fullnameOverride",
-                        "portHTTP",
-                        "portRPC"
-                    ],
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The name Schema",
-                            "examples": [
-                                "trillian-logserver"
-                            ]
-                        },
-                        "fullnameOverride": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The fullnameOverride Schema",
-                            "examples": [
-                                "trillian-logserver"
-                            ]
-                        },
-                        "portHTTP": {
-                            "type": "integer",
-                            "default": 0,
-                            "title": "The portHTTP Schema",
-                            "examples": [
-                                8090
-                            ]
-                        },
-                        "portRPC": {
-                            "type": "integer",
-                            "default": 0,
-                            "title": "The portRPC Schema",
-                            "examples": [
-                                8091
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "name": "trillian-logserver",
-                        "fullnameOverride": "trillian-logserver",
-                        "portHTTP": 8090,
-                        "portRPC": 8091
-                    }]
-                },
-                "logSigner": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The logSigner Schema",
-                    "required": [
-                        "name",
-                        "fullnameOverride"
-                    ],
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The name Schema",
-                            "examples": [
-                                "trillian-logsigner"
-                            ]
-                        },
-                        "fullnameOverride": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The fullnameOverride Schema",
-                            "examples": [
-                                "trillian-logsigner"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "name": "trillian-logsigner",
-                        "fullnameOverride": "trillian-logsigner"
-                    }]
-                },
-                "mysql": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The mysql Schema",
-                    "required": [
-                        "fullnameOverride"
-                    ],
-                    "properties": {
-                        "fullnameOverride": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The fullnameOverride Schema",
-                            "examples": [
-                                "trillian-mysql"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "fullnameOverride": "trillian-mysql"
-                    }]
-                }
-            },
-            "examples": [{
-                "enabled": true,
-                "namespace": {
-                    "name": "trillian-system",
-                    "create": true
-                },
-                "forceNamespace": "trillian-system",
-                "fullnameOverride": "trillian",
-                "logServer": {
-                    "name": "trillian-logserver",
-                    "fullnameOverride": "trillian-logserver",
-                    "portHTTP": 8090,
-                    "portRPC": 8091
-                },
-                "logSigner": {
-                    "name": "trillian-logsigner",
-                    "fullnameOverride": "trillian-logsigner"
-                },
-                "mysql": {
-                    "fullnameOverride": "trillian-mysql"
-                }
-            }]
-        },
-        "tuf": {
-            "type": "object",
-            "default": {},
-            "title": "The tuf Schema",
-            "required": [
-                "enabled",
-                "namespace",
-                "forceNamespace",
-                "fullnameOverride",
-                "secrets"
-            ],
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The enabled Schema",
-                    "examples": [
-                        false
-                    ]
-                },
-                "namespace": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The namespace Schema",
-                    "required": [
-                        "name",
-                        "create"
-                    ],
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The name Schema",
-                            "examples": [
-                                "tuf-system"
-                            ]
-                        },
-                        "create": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "The create Schema",
-                            "examples": [
-                                true
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "name": "tuf-system",
-                        "create": true
-                    }]
-                },
-                "forceNamespace": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The forceNamespace Schema",
-                    "examples": [
-                        "tuf-system"
-                    ]
-                },
-                "fullnameOverride": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The fullnameOverride Schema",
-                    "examples": [
-                        "tuf"
-                    ]
-                },
-                "secrets": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The secrets Schema",
-                    "required": [
-                        "rekor",
-                        "fulcio",
-                        "ctlog"
-                    ],
-                    "properties": {
-                        "rekor": {
-                            "type": "object",
-                            "default": {},
-                            "title": "The rekor Schema",
-                            "required": [
-                                "name",
-                                "path"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "The name Schema",
-                                    "examples": [
-                                        "rekor-public-key"
-                                    ]
-                                },
-                                "path": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "The path Schema",
-                                    "examples": [
-                                        "rekor-pubkey"
-                                    ]
-                                }
-                            },
-                            "examples": [{
-                                "name": "rekor-public-key",
-                                "path": "rekor-pubkey"
-                            }]
-                        },
-                        "fulcio": {
-                            "type": "object",
-                            "default": {},
-                            "title": "The fulcio Schema",
-                            "required": [
-                                "name",
-                                "path"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "The name Schema",
-                                    "examples": [
-                                        "fulcio-server-secret"
-                                    ]
-                                },
-                                "path": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "The path Schema",
-                                    "examples": [
-                                        "fulcio-cert"
-                                    ]
-                                }
-                            },
-                            "examples": [{
-                                "name": "fulcio-server-secret",
-                                "path": "fulcio-cert"
-                            }]
-                        },
-                        "ctlog": {
-                            "type": "object",
-                            "default": {},
-                            "title": "The ctlog Schema",
-                            "required": [
-                                "name",
-                                "path"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "The name Schema",
-                                    "examples": [
-                                        "ctlog-public-key"
-                                    ]
-                                },
-                                "path": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "The path Schema",
-                                    "examples": [
-                                        "ctlog-pubkey"
-                                    ]
-                                }
-                            },
-                            "examples": [{
-                                "name": "ctlog-public-key",
-                                "path": "ctlog-pubkey"
-                            }]
-                        }
-                    },
-                    "examples": [{
-                        "rekor": {
-                            "name": "rekor-public-key",
-                            "path": "rekor-pubkey"
-                        },
-                        "fulcio": {
-                            "name": "fulcio-server-secret",
-                            "path": "fulcio-cert"
-                        },
-                        "ctlog": {
-                            "name": "ctlog-public-key",
-                            "path": "ctlog-pubkey"
-                        }
-                    }]
-                }
-            },
-            "examples": [{
-                "enabled": false,
-                "namespace": {
-                    "name": "tuf-system",
-                    "create": true
-                },
-                "forceNamespace": "tuf-system",
-                "fullnameOverride": "tuf",
-                "secrets": {
-                    "rekor": {
-                        "name": "rekor-public-key",
-                        "path": "rekor.pub"
-                    },
-                    "fulcio": {
-                        "name": "fulcio-server-secret",
-                        "path": "fulcio_v1.crt.pem"
-                    },
-                    "ctlog": {
-                        "name": "ctlog-public-key",
-                        "path": "ctfe.pub"
-                    }
-                }
-            }]
-        },
         "copySecretJob": {
-            "type": "object",
-            "default": {},
-            "title": "The copySecretJob Schema",
-            "required": [
-                "enabled",
-                "name",
-                "registry",
-                "repository",
-                "version",
-                "imagePullPolicy",
-                "serviceaccount",
-                "backoffLimit"
-            ],
             "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The enabled Schema",
-                    "examples": [
-                        false
-                    ]
-                },
-                "name": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The name Schema",
-                    "examples": [
-                        "copy-secrets-job"
-                    ]
-                },
-                "registry": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The registry Schema",
-                    "examples": [
-                        "docker.io"
-                    ]
-                },
-                "repository": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The repository Schema",
-                    "examples": [
-                        "alpine/k8s"
-                    ]
-                },
-                "version": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The version Schema",
-                    "examples": [
-                        "sha256:fb0d2db81fb0f98abb1adf5246d6f0f4d19f34031afe4759cb7ad8e2eb8d2c01"
-                    ]
-                },
-                "imagePullPolicy": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The imagePullPolicy Schema",
-                    "examples": [
-                        "IfNotPresent"
-                    ]
-                },
-                "serviceaccount": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The serviceaccount Schema",
-                    "examples": [
-                        "tuf-secret-copy-job"
-                    ]
+                "affinity": {
+                    "properties": {},
+                    "type": "object"
                 },
                 "backoffLimit": {
-                    "type": "integer",
-                    "default": 0,
-                    "title": "The backoffLimit Schema",
-                    "examples": [
-                        6
-                    ]
-                }
-            },
-            "examples": [{
-                "enabled": false,
-                "name": "copy-secrets-job",
-                "registry": "docker.io",
-                "repository": "alpine/k8s",
-                "version": "sha256:fb0d2db81fb0f98abb1adf5246d6f0f4d19f34031afe4759cb7ad8e2eb8d2c01",
-                "imagePullPolicy": "IfNotPresent",
-                "serviceaccount": "tuf-secret-copy-job",
-                "backoffLimit": 6
-            }]
-        },
-        "tsa": {
-            "type": "object",
-            "default": {},
-            "title": "The tsa Schema",
-            "required": [
-                "enabled",
-                "namespace",
-                "forceNamespace",
-                "server"
-            ],
-            "properties": {
+                    "type": "integer"
+                },
                 "enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The enabled Schema",
-                    "examples": [
-                        true
-                    ]
+                    "type": "boolean"
                 },
-                "namespace": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The namespace Schema",
-                    "required": [
-                        "name",
-                        "create"
-                    ],
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The name Schema",
-                            "examples": [
-                                "tsa-system"
-                            ]
-                        },
-                        "create": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "The create Schema",
-                            "examples": [
-                                true
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "name": "tsa-system",
-                        "create": true
-                    }]
+                "imagePullPolicy": {
+                    "type": "string"
                 },
-                "forceNamespace": {
-                    "type": "string",
-                    "default": "",
-                    "title": "The forceNamespace Schema",
-                    "examples": [
-                        "tsa-system"
-                    ]
+                "name": {
+                    "type": "string"
                 },
-                "server": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The server Schema",
-                    "required": [
-                        "fullnameOverride"
-                    ],
-                    "properties": {
-                        "fullnameOverride": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The fullnameOverride Schema",
-                            "examples": [
-                                "tsa-server"
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "fullnameOverride": "tsa-server"
-                    }]
+                "nodeSelector": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "serviceaccount": {
+                    "type": "string"
+                },
+                "tolerations": {
+                    "type": "array"
+                },
+                "version": {
+                    "type": "string"
                 }
             },
-            "examples": [{
-                "enabled": true,
-                "namespace": {
-                    "name": "tsa-system",
-                    "create": true
-                },
-                "forceNamespace": "tsa-system",
-                "server": {
-                    "fullnameOverride": "tsa-server"
-                }
-            }]
-        }
-    },
-    "examples": [{
-        "fulcio": {
-            "enabled": true,
-            "namespace": {
-                "name": "fulcio-system",
-                "create": true
-            },
-            "forceNamespace": "fulcio-system",
-            "server": {
-                "fullnameOverride": "fulcio-server"
-            },
-            "createcerts": {
-                "fullnameOverride": "fulcio-createcerts"
-            },
-            "ctlog": {
-                "enabled": false,
-                "createctconfig": {
-                    "logPrefix": "sigstorescaffolding"
-                }
-            }
+            "type": "object"
         },
         "ctlog": {
-            "enabled": true,
-            "namespace": {
-                "name": "ctlog-system",
-                "create": true
-            },
-            "forceNamespace": "ctlog-system",
-            "fullnameOverride": "ctlog",
-            "createcerts": {
-                "fullnameOverride": "ctlog-createcerts"
-            },
-            "createtree": {
-                "fullnameOverride": "ctlog-createtree",
-                "displayName": "ctlog-tree"
-            }
-        },
-        "rekor": {
-            "enabled": true,
-            "namespace": {
-                "name": "rekor-system",
-                "create": true
-            },
-            "forceNamespace": "rekor-system",
-            "fullnameOverride": "rekor",
-            "server": {
-                "fullnameOverride": "rekor-server"
-            },
-            "redis": {
-                "fullnameOverride": "rekor-redis"
-            },
-            "trillian": {
-                "enabled": false
-            }
-        },
-        "trillian": {
-            "enabled": true,
-            "namespace": {
-                "name": "trillian-system",
-                "create": true
-            },
-            "forceNamespace": "trillian-system",
-            "fullnameOverride": "trillian",
-            "logServer": {
-                "name": "trillian-logserver",
-                "fullnameOverride": "trillian-logserver",
-                "portHTTP": 8090,
-                "portRPC": 8091
-            },
-            "logSigner": {
-                "name": "trillian-logsigner",
-                "fullnameOverride": "trillian-logsigner"
-            },
-            "mysql": {
-                "fullnameOverride": "trillian-mysql"
-            }
-        },
-        "tuf": {
-            "enabled": false,
-            "namespace": {
-                "name": "tuf-system",
-                "create": true
-            },
-            "forceNamespace": "tuf-system",
-            "fullnameOverride": "tuf",
-            "secrets": {
-                "rekor": {
-                    "name": "rekor-public-key",
-                    "path": "rekor-pubkey"
+            "properties": {
+                "affinity": {
+                    "properties": {},
+                    "type": "object"
                 },
-                "fulcio": {
-                    "name": "fulcio-server-secret",
-                    "path": "fulcio-cert"
+                "createcerts": {
+                    "properties": {
+                        "fullnameOverride": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "createtree": {
+                    "properties": {
+                        "displayName": {
+                            "type": "string"
+                        },
+                        "fullnameOverride": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "forceNamespace": {
+                    "type": "string"
+                },
+                "fullnameOverride": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "fulcio": {
+            "properties": {
+                "affinity": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "createcerts": {
+                    "properties": {
+                        "fullnameOverride": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
                 "ctlog": {
-                    "name": "ctlog-public-key",
-                    "path": "ctlog-pubkey"
+                    "properties": {
+                        "createctconfig": {
+                            "properties": {
+                                "logPrefix": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "forceNamespace": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "server": {
+                    "properties": {
+                        "fullnameOverride": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
                 }
-            }
+            },
+            "type": "object"
         },
-        "copySecretJob": {
-            "enabled": false,
-            "name": "copy-secrets-job",
-            "registry": "docker.io",
-            "repository": "alpine/k8s",
-            "version": "sha256:fb0d2db81fb0f98abb1adf5246d6f0f4d19f34031afe4759cb7ad8e2eb8d2c01",
-            "imagePullPolicy": "IfNotPresent",
-            "serviceaccount": "tuf-secret-copy-job",
-            "backoffLimit": 6
+        "rekor": {
+            "properties": {
+                "affinity": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "forceNamespace": {
+                    "type": "string"
+                },
+                "fullnameOverride": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "redis": {
+                    "properties": {
+                        "fullnameOverride": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "server": {
+                    "properties": {
+                        "fullnameOverride": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                },
+                "trillian": {
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "trillian": {
+            "properties": {
+                "affinity": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "forceNamespace": {
+                    "type": "string"
+                },
+                "fullnameOverride": {
+                    "type": "string"
+                },
+                "logServer": {
+                    "properties": {
+                        "fullnameOverride": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "portHTTP": {
+                            "type": "integer"
+                        },
+                        "portRPC": {
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                },
+                "logSigner": {
+                    "properties": {
+                        "fullnameOverride": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "mysql": {
+                    "properties": {
+                        "fullnameOverride": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "namespace": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            },
+            "type": "object"
         },
         "tsa": {
-            "enabled": true,
-            "namespace": {
-                "name": "tsa-system",
-                "create": true
+            "properties": {
+                "affinity": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "forceNamespace": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "server": {
+                    "properties": {
+                        "fullnameOverride": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                }
             },
-            "forceNamespace": "tsa-system",
-            "server": {
-                "fullnameOverride": "tsa-server"
-            }
+            "type": "object"
+        },
+        "tuf": {
+            "properties": {
+                "affinity": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "forceNamespace": {
+                    "type": "string"
+                },
+                "fullnameOverride": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "secrets": {
+                    "properties": {
+                        "ctlog": {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "path": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "fulcio": {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "path": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "rekor": {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "path": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "tsa": {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "path": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            },
+            "type": "object"
         }
-    }]
+    },
+    "type": "object"
 }

--- a/charts/scaffold/values.yaml
+++ b/charts/scaffold/values.yaml
@@ -14,6 +14,9 @@ fulcio:
     enabled: false
     createctconfig:
       logPrefix: sigstorescaffolding
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
 
 # CTLog
 ctlog:
@@ -28,6 +31,10 @@ ctlog:
   createtree:
     fullnameOverride: ctlog-createtree
     displayName: ctlog-tree
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
+
 # Rekor
 rekor:
   enabled: true
@@ -42,6 +49,9 @@ rekor:
     fullnameOverride: rekor-redis
   trillian:
     enabled: false
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
 
 # Trillian
 trillian:
@@ -61,6 +71,9 @@ trillian:
     fullnameOverride: trillian-logsigner
   mysql:
     fullnameOverride: trillian-mysql
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
 
 tuf:
   enabled: false
@@ -69,6 +82,9 @@ tuf:
     create: true
   forceNamespace: tuf-system
   fullnameOverride: tuf
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
 
   secrets:
     rekor:
@@ -93,6 +109,9 @@ copySecretJob:
   imagePullPolicy: IfNotPresent
   serviceaccount: tuf-secret-copy-job
   backoffLimit: 6
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
 
 tsa:
   enabled: false
@@ -102,3 +121,6 @@ tsa:
   forceNamespace: tsa-system
   server:
     fullnameOverride: tsa-server
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}


### PR DESCRIPTION
Partly resolves https://github.com/sigstore/helm-charts/issues/696

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change
Adds tolerations, nodeSelector and affinity to charts.

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->
[Request for tolerations, nodeSelector and affinity to be allowed to configure for all charts](https://github.com/sigstore/helm-charts/issues/696)

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

[initial PR w/ all changes in one.](https://github.com/sigstore/helm-charts/pull/754)

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
```
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 scaffold => (version: "0.6.51", path: "charts/scaffold")
------------------------------------------------------------------------------------------------------------------------

"sigstore" already exists with the same configuration, skipping
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "sigstore" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 6 charts
Downloading fulcio from repo https://sigstore.github.io/helm-charts
Downloading rekor from repo https://sigstore.github.io/helm-charts
Downloading trillian from repo https://sigstore.github.io/helm-charts
Downloading ctlog from repo https://sigstore.github.io/helm-charts
Downloading tuf from repo https://sigstore.github.io/helm-charts
Downloading tsa from repo https://sigstore.github.io/helm-charts
Deleting outdated charts
Linting chart "scaffold => (version: \"0.6.51\", path: \"charts/scaffold\")"
Checking chart "scaffold => (version: \"0.6.51\", path: \"charts/scaffold\")" for a version bump...
Old chart version: 0.6.50
New chart version: 0.6.51
Chart version ok.
Validating /Users/ianhundere/Desktop/helm-charts/charts/scaffold/Chart.yaml...
Validation success! 👍

Linting chart with values file "charts/scaffold/ci/ci-values.yaml"...

==> Linting charts/scaffold
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ scaffold => (version: "0.6.51", path: "charts/scaffold")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```
cc @hectorj2f / @cpanato