### PR TITLE
feat: Add ability to configure resources for rekor initContainer

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.3.6
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.6](https://img.shields.io/badge/AppVersion-1.3.6-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.6](https://img.shields.io/badge/AppVersion-1.3.6-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 
@@ -20,12 +20,13 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://sigstore.github.io/helm-charts | trillian | 0.2.23 |
+| https://sigstore.github.io/helm-charts | trillian | 0.2.24 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| backfillredis.affinity | object | `{}` |  |
 | backfillredis.enabled | bool | `false` |  |
 | backfillredis.endIndex | int | `-1` |  |
 | backfillredis.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -33,12 +34,15 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | backfillredis.image.repository | string | `"sigstore/rekor/backfill-redis"` |  |
 | backfillredis.image.version | string | `"sha256:a13cd8b2a554d6116888fd1f383cf6e91fc1716df5eda392b82e6bfc66995ec3"` |  |
 | backfillredis.name | string | `"backfillredis"` |  |
+| backfillredis.nodeSelector | object | `{}` |  |
 | backfillredis.rekorAddress | string | `"rekor.rekor-system.svc"` |  |
 | backfillredis.resources | object | `{}` |  |
 | backfillredis.securityContext.runAsNonRoot | bool | `true` |  |
 | backfillredis.securityContext.runAsUser | int | `65533` |  |
 | backfillredis.startIndex | int | `-1` |  |
+| backfillredis.tolerations | list | `[]` |  |
 | backfillredis.ttlSecondsAfterFinished | int | `3600` |  |
+| createtree.affinity | object | `{}` |  |
 | createtree.annotations | object | `{}` |  |
 | createtree.force | bool | `false` |  |
 | createtree.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -46,12 +50,14 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | createtree.image.repository | string | `"sigstore/scaffolding/createtree"` |  |
 | createtree.image.version | string | `"sha256:eb1a94738f34964c7456d18d30b8a45a654af89bb5371f69b2403df373be0826"` |  |
 | createtree.name | string | `"createtree"` |  |
+| createtree.nodeSelector | object | `{}` |  |
 | createtree.resources | object | `{}` |  |
 | createtree.securityContext.runAsNonRoot | bool | `true` |  |
 | createtree.securityContext.runAsUser | int | `65533` |  |
 | createtree.serviceAccount.annotations | object | `{}` |  |
 | createtree.serviceAccount.create | bool | `true` |  |
 | createtree.serviceAccount.name | string | `""` |  |
+| createtree.tolerations | list | `[]` |  |
 | createtree.ttlSecondsAfterFinished | int | `3600` |  |
 | forceNamespace | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
@@ -59,6 +65,7 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | initContainerImage.curl.registry | string | `"docker.io"` |  |
 | initContainerImage.curl.repository | string | `"curlimages/curl"` |  |
 | initContainerImage.curl.version | string | `"sha256:4bfa3e2c0164fb103fb9bfd4dc956facce32b6c5d47cc09fcec883ce9535d5ac"` | 8.5.0 |
+| initContainerResources | object | `{}` |  |
 | mysql.enabled | bool | `false` |  |
 | mysql.gcp.cloudsql.registry | string | `"gcr.io"` |  |
 | mysql.gcp.cloudsql.repository | string | `"cloud-sql-connectors/cloud-sql-proxy:2.9.0-alpine"` |  |
@@ -92,6 +99,7 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | mysql.strategy.type | string | `"Recreate"` |  |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"rekor-system"` |  |
+| redis.affinity | object | `{}` |  |
 | redis.args[0] | string | `"--bind"` |  |
 | redis.args[1] | string | `"0.0.0.0"` |  |
 | redis.args[2] | string | `"--appendonly"` |  |
@@ -103,6 +111,7 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | redis.image.repository | string | `"redis"` |  |
 | redis.image.version | string | `"sha256:c5a607fb6e1bb15d32bbcf14db22787d19e428d59e31a5da67511b49bb0f1ccc"` | 6.2.14-alpine3.19 |
 | redis.name | string | `"redis"` |  |
+| redis.nodeSelector | object | `{}` |  |
 | redis.port | int | `6379` |  |
 | redis.readinessProbe.exec.command[0] | string | `"/bin/sh"` |  |
 | redis.readinessProbe.exec.command[1] | string | `"-i"` |  |
@@ -123,6 +132,8 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | redis.serviceAccount.annotations | object | `{}` |  |
 | redis.serviceAccount.create | bool | `true` |  |
 | redis.serviceAccount.name | string | `""` |  |
+| redis.tolerations | list | `[]` |  |
+| server.affinity | object | `{}` |  |
 | server.attestation_storage.bucket | string | `"file:///var/run/attestations"` |  |
 | server.attestation_storage.enabled | bool | `true` |  |
 | server.attestation_storage.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
@@ -168,6 +179,7 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | server.livenessProbe.timeoutSeconds | int | `1` |  |
 | server.logging.production | bool | `false` |  |
 | server.name | string | `"server"` |  |
+| server.nodeSelector | object | `{}` |  |
 | server.podAnnotations."prometheus.io/path" | string | `"/metrics"` |  |
 | server.podAnnotations."prometheus.io/port" | string | `"2112"` |  |
 | server.podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
@@ -202,6 +214,7 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | server.sharding.filename | string | `"sharding-config.yaml"` |  |
 | server.sharding.mountPath | string | `"/sharding"` |  |
 | server.signer | string | `"memory"` |  |
+| server.tolerations | list | `[]` |  |
 | trillian.adminServer | string | `""` |  |
 | trillian.enabled | bool | `true` |  |
 | trillian.forceNamespace | string | `"trillian-system"` |  |
@@ -216,3 +229,5 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | trillian.namespace.create | bool | `true` |  |
 | trillian.namespace.name | string | `"trillian-system"` |  |
 
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.13.1](https://github.com/norwoodj/helm-docs/releases/v1.13.1)

--- a/charts/rekor/templates/server/deployment.yaml
+++ b/charts/rekor/templates/server/deployment.yaml
@@ -46,6 +46,8 @@ spec:
           securityContext:
 {{ toYaml .Values.server.initContainerSecurityContext | indent 12 }}
 {{- end }}
+          resources:
+{{ toYaml .Values.initContainerResources | indent 12 }}
       {{- if .Values.server.extraInitContainers }}
 {{ toYaml .Values.server.extraInitContainers | indent 8 }}
       {{- end }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -171,6 +171,22 @@
             },
             "type": "object"
         },
+        "initContainerResources": {
+            "properties": {
+                "requests": {
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
         "mysql": {
             "properties": {
                 "enabled": {

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -10,6 +10,7 @@ initContainerImage:
     # -- 8.5.0
     version: "sha256:4bfa3e2c0164fb103fb9bfd4dc956facce32b6c5d47cc09fcec883ce9535d5ac"
     imagePullPolicy: IfNotPresent
+initContainerResources: {}
 
 redis:
   enabled: true


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change
It is best practice to configure resources for all containers and they are mandatory for a namespace configured with resource quota. This change adds the ability to configure resources for rekor initContainer `wait-for-trillian-log-server` 

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
