### PR TITLE
fixes tolerations, nodeSelector and affinity indention for trillian createdb job

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.2.24
+version: 0.2.25
 appVersion: 1.6.0
 
 keywords:

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.2.23](https://img.shields.io/badge/Version-0.2.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 0.2.25](https://img.shields.io/badge/Version-0.2.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
@@ -40,6 +40,7 @@ helm uninstall [RELEASE_NAME]
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| createdb.affinity | object | `{}` |  |
 | createdb.dbname | string | `"trillian"` |  |
 | createdb.enabled | bool | `true` |  |
 | createdb.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -47,9 +48,11 @@ helm uninstall [RELEASE_NAME]
 | createdb.image.repository | string | `"sigstore/scaffolding/createdb"` |  |
 | createdb.image.version | string | `"sha256:ea809b5f603764df5fb7e1f46f7e7be24b6717890c560e7e67fdb0a640a8a755"` | v0.6.17 |
 | createdb.name | string | `"createdb"` |  |
+| createdb.nodeSelector | object | `{}` |  |
 | createdb.serviceAccount.annotations | object | `{}` |  |
 | createdb.serviceAccount.create | bool | `false` |  |
 | createdb.serviceAccount.name | string | `""` |  |
+| createdb.tolerations | list | `[]` |  |
 | createdb.ttlSecondsAfterFinished | int | `3600` |  |
 | forceNamespace | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/trillian/templates/createdb/createdb-job.yaml
+++ b/charts/trillian/templates/createdb/createdb-job.yaml
@@ -98,15 +98,15 @@ spec:
         - name: exit-dir
           emptyDir: {}
 {{- end }}
-{{- if .Values.createdb.nodeSelector }}
-  nodeSelector:
-{{ toYaml .Values.createdb.nodeSelector | indent 4 }}
-{{- end }}
-{{- if .Values.createdb.tolerations }}
-  tolerations:
-{{ toYaml .Values.createdb.tolerations | indent 4 }}
-{{- end }}
-{{- if .Values.createdb.affinity }}
-  affinity:
-{{ toYaml .Values.createdb.affinity | indent 4 }}
-{{- end }}
+    {{- if .Values.createdb.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.createdb.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.createdb.tolerations }}
+      tolerations:
+{{ toYaml .Values.createdb.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.createdb.affinity }}
+      affinity:
+{{ toYaml .Values.createdb.affinity | indent 8 }}
+    {{- end }}


### PR DESCRIPTION
closes https://github.com/sigstore/helm-charts/issues/696 . . . for real this time. 😅 

## Description of the change

adds tolerations, nodeSelector, and affinity to createdb-job...correctly.

## Existing or Associated Issue(s)

- https://github.com/sigstore/helm-charts/issues/696
- [original pull request](https://github.com/sigstore/helm-charts/pull/757)

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
```
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 trillian => (version: "0.2.25", path: "charts/trillian")
------------------------------------------------------------------------------------------------------------------------

"sigstore" already exists with the same configuration, skipping
Linting chart "trillian => (version: \"0.2.25\", path: \"charts/trillian\")"
Checking chart "trillian => (version: \"0.2.25\", path: \"charts/trillian\")" for a version bump...
Old chart version: 0.2.24
New chart version: 0.2.25
Chart version ok.
Validating /Users/x308080/Desktop/helm-charts/charts/trillian/Chart.yaml...
Validation success! 👍
==> Linting charts/trillian
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ trillian => (version: "0.2.25", path: "charts/trillian")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```

cc @sabre1041 / @cpanato when y'all are able