### PR TITLE
Adding support for yaml on fulcio config

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.3.23
+version: 2.4.0
 appVersion: 1.5.1
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.3.23](https://img.shields.io/badge/Version-2.3.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 
@@ -78,6 +78,7 @@ helm uninstall [RELEASE_NAME]
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config.contents | object | `{}` |  |
+| config.format | string | `"json"` |  |
 | createcerts.affinity | object | `{}` |  |
 | createcerts.annotations | object | `{}` |  |
 | createcerts.enabled | bool | `true` |  |

--- a/charts/fulcio/templates/fulcio-configmap.yaml
+++ b/charts/fulcio/templates/fulcio-configmap.yaml
@@ -6,8 +6,17 @@ metadata:
   labels:
     {{- include "fulcio.labels" . | nindent 4 }}
 data:
+# We now expect a new field "format" for checking the format of the
+# config's content.
+# If the field format is empty, the default case is consider that is a
+# json or is empty and should use the defaults as defined on the file _helpers.tpl
+{{- if and (eq .Values.config.format "yaml") (.Values.config.contents) -}}
+  config.yaml: |-
+    {{ toYaml .Values.config.contents | indent 2 }}
+{{- else -}}
   config.json: |-
 {{ include "fulcio.configmap.contents" . | indent 4 }}
+{{- end }}
   {{- if (eq .Values.server.args.certificateAuthority "kmsca")}}
   chain.pem: {{.Values.server.args.kms_cert_chain | quote }}
   {{- end }}

--- a/charts/fulcio/templates/fulcio-configmap.yaml
+++ b/charts/fulcio/templates/fulcio-configmap.yaml
@@ -11,8 +11,10 @@ data:
 # If the field format is empty, the default case is consider that is a
 # json or is empty and should use the defaults as defined on the file _helpers.tpl
 {{- if and (eq .Values.config.format "yaml") (.Values.config.contents) -}}
+  {{- with .Values.config.contents }}
   config.yaml: |-
-    {{ toYaml .Values.config.contents | indent 2 }}
+    {{ toYaml . | indent 2 }}
+  {{- end }}
 {{- else -}}
   config.json: |-
 {{ include "fulcio.configmap.contents" . | indent 4 }}

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -63,6 +63,7 @@ spec:
             - "--kms-cert-chain-path=/etc/fulcio-config/chain.pem"
             {{- end }}
             - "--ct-log-url={{ if .Values.server.args.disable_ct_log }}{{ else if .Values.server.args.ct_log_url }}{{ .Values.server.args.ct_log_url }}{{ else }}http://{{ .Values.ctlog.name }}.{{ .Values.ctlog.namespace.name }}.svc/{{ .Values.ctlog.createctconfig.logPrefix }}{{ end }}"
+            - --config-path=/etc/fulcio-config/config.{{- if and (eq .Values.config.format "yaml") (.Values.config.contents) -}}yaml{{- else }}json{{- end }}
             {{- if .Values.server.grpcSvcTLS }}
             - "--grpc-tls-certificate=/var/run/grpc-tls/cert.pem"
             - "--grpc-tls-key=/var/run/grpc-tls/key.pem"

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - "--kms-cert-chain-path=/etc/fulcio-config/chain.pem"
             {{- end }}
             - "--ct-log-url={{ if .Values.server.args.disable_ct_log }}{{ else if .Values.server.args.ct_log_url }}{{ .Values.server.args.ct_log_url }}{{ else }}http://{{ .Values.ctlog.name }}.{{ .Values.ctlog.namespace.name }}.svc/{{ .Values.ctlog.createctconfig.logPrefix }}{{ end }}"
-            - --config-path=/etc/fulcio-config/config.{{- if and (eq .Values.config.format "yaml") (.Values.config.contents) -}}yaml{{- else }}json{{- end }}
+            - '--config-path=/etc/fulcio-config/config.{{- if and (eq .Values.config.format "yaml") (.Values.config.contents) -}}yaml{{- else }}json{{- end }}'
             {{- if .Values.server.grpcSvcTLS }}
             - "--grpc-tls-certificate=/var/run/grpc-tls/cert.pem"
             - "--grpc-tls-key=/var/run/grpc-tls/key.pem"

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -6,6 +6,9 @@
                 "contents": {
                     "properties": {},
                     "type": "object"
+                },
+                "format": {
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -6,6 +6,7 @@ imagePullSecrets: []
 
 config:
   contents: {}
+  format: json
 
 server:
   replicaCount: 1


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change
It adds support for yaml format on fulcio config.
It algo expects that the config has a property called `format` defining if it is a `yaml` or a `json`. To avoid any breaking changes, if the field is not set, the json format and defaults are used.
<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
