### PR TITLE
add additional env variables to fulcio chart

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.9.3
+version: 2.10.0
 appVersion: 1.8.7
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.9.3](https://img.shields.io/badge/Version-2.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 
@@ -127,6 +127,7 @@ helm uninstall [RELEASE_NAME]
 | server.affinity | object | `{}` |  |
 | server.args.aws_hsm_root_ca_path | string | `nil` |  |
 | server.args.certificateAuthority | string | `"fileca"` |  |
+| server.args.cloud_credential_config | string | `""` |  |
 | server.args.ct_log_url | string | `""` |  |
 | server.args.disable_ct_log | bool | `false` |  |
 | server.args.gcp_private_ca_parent | string | `"projects/test/locations/us-east1/caPools/test"` |  |
@@ -135,6 +136,7 @@ helm uninstall [RELEASE_NAME]
 | server.args.port | int | `5555` |  |
 | server.awsKmsCredentialsSecretName | string | `"aws-kms-credentials"` | kubernetes secret name containing IAM credentials for use with AWS KMS |
 | server.awsKmsRegion | string | `"us-east-1"` | AWS region if using AWS KMS for signing key |
+| server.env | object | `{}` |  |
 | server.grpcSvcPort | int | `5554` |  |
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"ghcr.io"` |  |

--- a/charts/fulcio/templates/fulcio-configmap.yaml
+++ b/charts/fulcio/templates/fulcio-configmap.yaml
@@ -24,3 +24,6 @@ data:
   chain.pem: {{ .Values.server.args.tink_kms_cert_chain | quote }}
   tink.keyset.enc: {{ .Values.server.args.tink_enc_keyset | quote }}
   {{- end }}
+  {{- if .Values.server.args.cloud_credential_config }}
+  cloud_credential_config: {{.Values.server.args.cloud_credential_config | quote }}
+  {{- end }}

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -95,15 +95,20 @@ spec:
             {{- range .Values.server.extraArgs }}
             - {{ . | quote }}
             {{- end }}
+        {{- if or .Values.server.env (eq .Values.server.args.certificateAuthority "fileca") (eq .Values.server.kmsType "aws") }}
           env:
-            {{- if eq .Values.server.args.certificateAuthority "fileca" }}
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.server.secret }}
-                  key: password
-            {{- end }}
-            {{- if and (eq .Values.server.args.certificateAuthority "kmsca") (eq .Values.server.kmsType "aws") }}
+          {{- range $key, $value := .Values.server.env }}
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
+          {{- end }}
+          {{- if eq .Values.server.args.certificateAuthority "fileca" }}
+          - name: PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.server.secret }}
+                key: password
+          {{- end }}
+          {{- if and (eq .Values.server.args.certificateAuthority "kmsca") (eq .Values.server.kmsType "aws") }}
             - name: AWS_DEFAULT_REGION
               value: {{ .Values.server.awsKmsRegion }}
             - name: AWS_ACCESS_KEY_ID
@@ -116,7 +121,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.server.awsKmsCredentialsSecretName }}
                   key: secretAccessKey
-            {{- end }}
+          {{- end }}
+        {{- end }}
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -252,6 +252,9 @@
                         "gcp_private_ca_parent": {
                             "type": "string"
                         },
+                        "cloud_credential_config": {
+                            "type": "string"
+                        },
                         "grpcPort": {
                             "type": "integer"
                         },
@@ -536,6 +539,10 @@
                             "type": "string"
                         }
                     }
+                },
+                "env": {
+                    "type": "object",
+                    "properties": {}
                 },
                 "serviceAccount": {
                     "type": "object",

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -39,9 +39,12 @@ server:
     pullPolicy: IfNotPresent
     # crane digest ghcr.io/sigstore/fulcio:v1.8.7
     version: v1.8.7@sha256:501cea5cdf281eb903d3744ca3d07e96f76ca6fe9a3b4b9e85d372357a32e2e8
+  env: {}
   args:
     port: 5555
     grpcPort: 5554
+    # valid values: GCP workload identity config json for trusted external cloud providers
+    cloud_credential_config: ""
     # Valid values: googleca, pkcs11ca, aws-hsm-root-ca-path, fileca, kmsca
     certificateAuthority: fileca
     # kms_resource: gcpkms://....


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Support GCP credentials for external cloud provider workloads and add additional env vars for specifying values like `VAULT_ADDR`

## Existing or Associated Issue(s)

This is a repickup of https://github.com/sigstore/helm-charts/pull/530

## Additional Information

## Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [X] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [X] JSON Schema generated.
- [X] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
