### PR TITLE
adds optional cronJob to copySecretJob to avoid stale secrets.

### DIFF
--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.6.61
+version: 0.6.62
 keywords:
   - security
   - pki

--- a/charts/scaffold/README.md
+++ b/charts/scaffold/README.md
@@ -49,6 +49,11 @@ helm uninstall [RELEASE_NAME]
 |-----|------|---------|-------------|
 | copySecretJob.affinity | object | `{}` |  |
 | copySecretJob.backoffLimit | int | `6` |  |
+| copySecretJob.copySecretCronJob.backoffLimit | int | `2` |  |
+| copySecretJob.copySecretCronJob.enabled | bool | `false` |  |
+| copySecretJob.copySecretCronJob.failedJobsHistoryLimit | int | `1` |  |
+| copySecretJob.copySecretCronJob.schedule | string | `"*/5 * * * 1-5"` |  |
+| copySecretJob.copySecretCronJob.successfulJobsHistoryLimit | int | `1` |  |
 | copySecretJob.enabled | bool | `false` |  |
 | copySecretJob.imagePullPolicy | string | `"IfNotPresent"` |  |
 | copySecretJob.name | string | `"copy-secrets-job"` |  |
@@ -91,6 +96,30 @@ helm uninstall [RELEASE_NAME]
 | rekor.server.fullnameOverride | string | `"rekor-server"` |  |
 | rekor.tolerations | list | `[]` |  |
 | rekor.trillian.enabled | bool | `false` |  |
+| secrets.ctlog.create | bool | `false` |  |
+| secrets.ctlog.deploymentName | string | `"ctlog"` |  |
+| secrets.ctlog.key | string | `"public"` |  |
+| secrets.ctlog.name | string | `"ctlog-public-key"` |  |
+| secrets.ctlog.namespace | string | `"ctlog-system"` |  |
+| secrets.ctlog.path | string | `"ctfe.pub"` |  |
+| secrets.fulcio.create | bool | `false` |  |
+| secrets.fulcio.deploymentName | string | `"fulcio-server"` |  |
+| secrets.fulcio.key | string | `"cert"` |  |
+| secrets.fulcio.name | string | `"fulcio-server-secret"` |  |
+| secrets.fulcio.namespace | string | `"fulcio-system"` |  |
+| secrets.fulcio.path | string | `"fulcio_v1.crt.pem"` |  |
+| secrets.rekor.create | bool | `false` |  |
+| secrets.rekor.deploymentName | string | `"rekor-server"` |  |
+| secrets.rekor.key | string | `"key"` |  |
+| secrets.rekor.name | string | `"rekor-public-key"` |  |
+| secrets.rekor.namespace | string | `"rekor-system"` |  |
+| secrets.rekor.path | string | `"rekor.pub"` |  |
+| secrets.tsa.create | bool | `false` |  |
+| secrets.tsa.deploymentName | string | `"tsa-server"` |  |
+| secrets.tsa.key | string | `"cert-chain"` |  |
+| secrets.tsa.name | string | `"tsa-cert-chain"` |  |
+| secrets.tsa.namespace | string | `"tsa-system"` |  |
+| secrets.tsa.path | string | `"tsa.certchain.pem"` |  |
 | trillian.affinity | object | `{}` |  |
 | trillian.enabled | bool | `true` |  |
 | trillian.forceNamespace | string | `"trillian-system"` |  |
@@ -121,14 +150,6 @@ helm uninstall [RELEASE_NAME]
 | tuf.namespace.create | bool | `true` |  |
 | tuf.namespace.name | string | `"tuf-system"` |  |
 | tuf.nodeSelector | object | `{}` |  |
-| tuf.secrets.ctlog.name | string | `"ctlog-public-key"` |  |
-| tuf.secrets.ctlog.path | string | `"ctfe.pub"` |  |
-| tuf.secrets.fulcio.name | string | `"fulcio-server-secret"` |  |
-| tuf.secrets.fulcio.path | string | `"fulcio_v1.crt.pem"` |  |
-| tuf.secrets.rekor.name | string | `"rekor-public-key"` |  |
-| tuf.secrets.rekor.path | string | `"rekor.pub"` |  |
-| tuf.secrets.tsa.name | string | `"tsa-cert-chain"` |  |
-| tuf.secrets.tsa.path | string | `"tsa.certchain.pem"` |  |
 | tuf.tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/scaffold/README.md
+++ b/charts/scaffold/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.6.61](https://img.shields.io/badge/Version-0.6.61-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.62](https://img.shields.io/badge/Version-0.6.62-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Scaffolding the components of the sigstore architecture
 

--- a/charts/scaffold/templates/_helpers.tpl
+++ b/charts/scaffold/templates/_helpers.tpl
@@ -8,4 +8,3 @@ Create the image path for the passed in image field
 {{- printf "%s/%s:%s" .registry .repository .version -}}
 {{- end -}}
 {{- end -}}
-

--- a/charts/scaffold/templates/clusterrole.yaml
+++ b/charts/scaffold/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create", "patch"]
+    verbs: ["get", "create", "patch"{{- if .Values.copySecretJob.copySecretCronJob.enabled }}, "delete"{{- end }}]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list"]

--- a/charts/scaffold/templates/clusterrole.yaml
+++ b/charts/scaffold/templates/clusterrole.yaml
@@ -9,5 +9,5 @@ rules:
     verbs: ["get", "create", "patch"{{- if .Values.copySecretJob.copySecretCronJob.enabled }}, "delete"{{- end }}]
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list"{{- if .Values.copySecretJob.copySecretCronJob.enabled }}, "update"{{- end }}]
 {{- end }}

--- a/charts/scaffold/templates/copy-secrets-cronjob.yaml
+++ b/charts/scaffold/templates/copy-secrets-cronjob.yaml
@@ -1,0 +1,100 @@
+{{- if and .Values.copySecretJob.enabled .Values.copySecretJob.copySecretCronJob.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+{{ include "tuf.namespace" .Subcharts.tuf | indent 2 }}
+  name: {{ .Values.copySecretJob.name }}-scheduled
+spec:
+  schedule: "{{ .Values.copySecretJob.copySecretCronJob.schedule }}"
+  successfulJobsHistoryLimit: {{ default 2 .Values.copySecretJob.copySecretCronJob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ default 2 .Values.copySecretJob.copySecretCronJob.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ default 6 .Values.copySecretJob.copySecretCronJob.backoffLimit }}
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ .Values.copySecretJob.serviceaccount }}
+          initContainers:
+          - name: wait-for-rekor-deployment-readiness
+            image: {{ template "scaffold.image" .Values.copySecretJob }}
+            imagePullPolicy: {{ .Values.copySecretJob.pullPolicy }}
+            command: ["/bin/sh"]
+            args: [
+                "-c",
+                "kubectl rollout status deployment {{ .Values.tuf.secrets.rekor.deploymentName }} --timeout=120s -n {{ .Values.tuf.secrets.rekor.namespace }}"
+            ]
+          - name: wait-for-fulcio-deployment-readiness
+            image: {{ template "scaffold.image" .Values.copySecretJob }}
+            imagePullPolicy: {{ .Values.copySecretJob.pullPolicy }}
+            command: ["/bin/sh"]
+            args: [
+                "-c",
+                "kubectl rollout status deployment {{ .Values.tuf.secrets.fulcio.deploymentName }} --timeout=120s -n {{ .Values.tuf.secrets.fulcio.namespace }}"
+            ]
+          - name: wait-for-ctlog-deployment-readiness
+            image: {{ template "scaffold.image" .Values.copySecretJob }}
+            imagePullPolicy: {{ .Values.copySecretJob.pullPolicy }}
+            command: ["/bin/sh"]
+            args: [
+                "-c",
+                "kubectl rollout status deployment {{ .Values.tuf.secrets.ctlog.deploymentName }} --timeout=120s -n {{ .Values.tuf.secrets.ctlog.namespace }}"
+            ]
+          - name: wait-for-tsa-deployment-readiness
+            image: {{ template "scaffold.image" .Values.copySecretJob }}
+            imagePullPolicy: {{ .Values.copySecretJob.pullPolicy }}
+            command: ["/bin/sh"]
+            args: [
+                "-c",
+                "kubectl rollout status deployment {{ .Values.tuf.secrets.tsa.deploymentName }} --timeout=120s -n {{ .Values.tuf.secrets.tsa.namespace }}"
+            ]
+          containers:
+          - name: copy-rekor-secret
+            image: {{ template "scaffold.image" .Values.copySecretJob }}
+            imagePullPolicy: {{ .Values.copySecretJob.pullPolicy }}
+            command: ["/bin/sh"]
+            args: [
+                "-c",
+                "curl {{ .Values.tuf.secrets.rekor.deploymentName}}.{{ .Values.tuf.secrets.rekor.namespace }}.svc.cluster.local/api/v1/log/publicKey -o /tmp/key -v && \
+                kubectl apply -f - <<EOF\napiVersion: v1\nkind: Secret\nmetadata:\n  name: {{ .Values.tuf.secrets.rekor.name }}\n  namespace: {{ .Values.forceNamespace }}\ndata:\n  key: $(cat /tmp/key | base64 -w 0)\nEOF\n"
+            ]
+          - name: copy-fulcio-secret
+            image: {{ template "scaffold.image" .Values.copySecretJob }}
+            imagePullPolicy: {{ .Values.copySecretJob.pullPolicy }}
+            command: ["/bin/sh"]
+            args: [
+                "-c",
+                "kubectl -n {{ .Values.forceNamespace }} delete secret {{ .Values.tuf.secrets.fulcio.name }} --ignore-not-found && \
+                kubectl -n {{ .Values.tuf.secrets.fulcio.namespace }} get secrets {{ .Values.tuf.secrets.fulcio.name }} -oyaml | sed 's/namespace: .*/namespace: {{ .Values.forceNamespace }}/' | kubectl apply -f -"
+            ]
+          - name: copy-ctlog-secret
+            image: {{ template "scaffold.image" .Values.copySecretJob }}
+            imagePullPolicy: {{ .Values.copySecretJob.pullPolicy }}
+            command: ["/bin/sh"]
+            args: [
+                "-c",
+                "kubectl -n {{ .Values.forceNamespace }} delete secret {{ .Values.tuf.secrets.ctlog.name }} --ignore-not-found && \
+                kubectl -n {{ .Values.tuf.secrets.ctlog.namespace }} get secrets {{ .Values.tuf.secrets.ctlog.name }} -oyaml | sed 's/namespace: .*/namespace: {{ .Values.forceNamespace }}/' | kubectl apply -f -"
+            ]
+          - name: copy-tsa-secret
+            image: {{ template "scaffold.image" .Values.copySecretJob }}
+            imagePullPolicy: {{ .Values.copySecretJob.pullPolicy }}
+            command: ["/bin/sh"]
+            args: [
+                "-c",
+                "curl {{ .Values.tuf.secrets.tsa.deploymentName}}.{{ .Values.tuf.secrets.tsa.namespace }}.svc.cluster.local/api/v1/timestamp/certchain -o /tmp/cert-chain -v && \
+                kubectl apply -f - <<EOF\napiVersion: v1\nkind: Secret\nmetadata:\n  name: {{ .Values.tuf.secrets.tsa.name }}\n  namespace: {{ .Values.forceNamespace }}\ndata:\n  cert-chain: $(cat /tmp/cert-chain | base64 -w 0)\nEOF\n"
+            ]
+          {{- if .Values.copySecretJob.nodeSelector }}
+          nodeSelector:
+{{ toYaml .Values.copySecretJob.nodeSelector | indent 12 }}
+          {{- end }}
+          {{- if .Values.copySecretJob.tolerations }}
+          tolerations:
+{{ toYaml .Values.copySecretJob.tolerations | indent 12 }}
+          {{- end }}
+          {{- if .Values.copySecretJob.affinity }}
+          affinity:
+{{ toYaml .Values.copySecretJob.affinity | indent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/scaffold/templates/copy-secrets-cronjob.yaml
+++ b/charts/scaffold/templates/copy-secrets-cronjob.yaml
@@ -56,7 +56,7 @@ spec:
             args: [
                 "-c",
                 "curl {{ .Values.tuf.secrets.rekor.deploymentName}}.{{ .Values.tuf.secrets.rekor.namespace }}.svc.cluster.local/api/v1/log/publicKey -o /tmp/key -v && \
-                kubectl apply -f - <<EOF\napiVersion: v1\nkind: Secret\nmetadata:\n  name: {{ .Values.tuf.secrets.rekor.name }}\n  namespace: {{ .Values.forceNamespace }}\ndata:\n  key: $(cat /tmp/key | base64 -w 0)\nEOF\n"
+                kubectl apply -f - <<EOF\napiVersion: v1\nkind: Secret\nmetadata:\n  name: {{ .Values.tuf.secrets.rekor.name }}\n  namespace: {{ include "tuf.rawnamespace" .Subcharts.tuf }}\ndata:\n  key: $(cat /tmp/key | base64 -w 0)\nEOF\n"
             ]
           - name: copy-fulcio-secret
             image: {{ template "scaffold.image" .Values.copySecretJob }}
@@ -64,8 +64,8 @@ spec:
             command: ["/bin/sh"]
             args: [
                 "-c",
-                "kubectl -n {{ .Values.forceNamespace }} delete secret {{ .Values.tuf.secrets.fulcio.name }} --ignore-not-found && \
-                kubectl -n {{ .Values.tuf.secrets.fulcio.namespace }} get secrets {{ .Values.tuf.secrets.fulcio.name }} -oyaml | sed 's/namespace: .*/namespace: {{ .Values.forceNamespace }}/' | kubectl apply -f -"
+                "kubectl -n {{ include "tuf.rawnamespace" .Subcharts.tuf }} delete secret {{ .Values.tuf.secrets.fulcio.name }} --ignore-not-found && \
+                kubectl -n {{ .Values.tuf.secrets.fulcio.namespace }} get secrets {{ .Values.tuf.secrets.fulcio.name }} -oyaml | sed 's/namespace: .*/namespace: {{ include "tuf.rawnamespace" .Subcharts.tuf }}/' | kubectl apply -f -"
             ]
           - name: copy-ctlog-secret
             image: {{ template "scaffold.image" .Values.copySecretJob }}
@@ -73,8 +73,8 @@ spec:
             command: ["/bin/sh"]
             args: [
                 "-c",
-                "kubectl -n {{ .Values.forceNamespace }} delete secret {{ .Values.tuf.secrets.ctlog.name }} --ignore-not-found && \
-                kubectl -n {{ .Values.tuf.secrets.ctlog.namespace }} get secrets {{ .Values.tuf.secrets.ctlog.name }} -oyaml | sed 's/namespace: .*/namespace: {{ .Values.forceNamespace }}/' | kubectl apply -f -"
+                "kubectl -n {{ include "tuf.rawnamespace" .Subcharts.tuf }} delete secret {{ .Values.tuf.secrets.ctlog.name }} --ignore-not-found && \
+                kubectl -n {{ .Values.tuf.secrets.ctlog.namespace }} get secrets {{ .Values.tuf.secrets.ctlog.name }} -oyaml | sed 's/namespace: .*/namespace: {{ include "tuf.rawnamespace" .Subcharts.tuf }}/' | kubectl apply -f -"
             ]
           - name: copy-tsa-secret
             image: {{ template "scaffold.image" .Values.copySecretJob }}
@@ -83,7 +83,15 @@ spec:
             args: [
                 "-c",
                 "curl {{ .Values.tuf.secrets.tsa.deploymentName}}.{{ .Values.tuf.secrets.tsa.namespace }}.svc.cluster.local/api/v1/timestamp/certchain -o /tmp/cert-chain -v && \
-                kubectl apply -f - <<EOF\napiVersion: v1\nkind: Secret\nmetadata:\n  name: {{ .Values.tuf.secrets.tsa.name }}\n  namespace: {{ .Values.forceNamespace }}\ndata:\n  cert-chain: $(cat /tmp/cert-chain | base64 -w 0)\nEOF\n"
+                kubectl apply -f - <<EOF\napiVersion: v1\nkind: Secret\nmetadata:\n  name: {{ .Values.tuf.secrets.tsa.name }}\n  namespace: {{ include "tuf.rawnamespace" .Subcharts.tuf }}\ndata:\n  cert-chain: $(cat /tmp/cert-chain | base64 -w 0)\nEOF\n"
+            ]
+          - name: rollout-restart-tuf
+            image: {{ template "scaffold.image" .Values.copySecretJob }}
+            imagePullPolicy: {{ .Values.copySecretJob.pullPolicy }}
+            command: ["/bin/sh"]
+            args: [
+                "-c",
+                "kubectl -n {{ include "tuf.rawnamespace" .Subcharts.tuf }} rollout restart deployment {{ .Values.tuf.fullnameOverride}}"
             ]
           {{- if .Values.copySecretJob.nodeSelector }}
           nodeSelector:

--- a/charts/scaffold/templates/copy-secrets-job.yaml
+++ b/charts/scaffold/templates/copy-secrets-job.yaml
@@ -3,9 +3,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
 {{ include "tuf.namespace" .Subcharts.tuf | indent 2 }}
-  name: {{ .Values.copySecretJob.name }}
+  name: {{ .Values.copySecretJob.name }}{{- if not .Values.copySecretJob.copySecretCronJob.enabled }}{{- else }}-immediate{{- end }}
 spec:
-  backoffLimit: {{ .Values.copySecretJob.backoffLimit }}
+  backoffLimit: {{ default 6 .Values.copySecretJob.backoffLimit }}
   template:
     spec:
       restartPolicy: OnFailure

--- a/charts/scaffold/values.schema.json
+++ b/charts/scaffold/values.schema.json
@@ -10,6 +10,26 @@
                 "backoffLimit": {
                     "type": "integer"
                 },
+                "copySecretCronJob": {
+                    "properties": {
+                        "backoffLimit": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "failedJobsHistoryLimit": {
+                            "type": "integer"
+                        },
+                        "schedule": {
+                            "type": "string"
+                        },
+                        "successfulJobsHistoryLimit": {
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                },
                 "enabled": {
                     "type": "boolean"
                 },
@@ -221,6 +241,103 @@
             },
             "type": "object"
         },
+        "secrets": {
+            "properties": {
+                "ctlog": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "deploymentName": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "fulcio": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "deploymentName": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "rekor": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "deploymentName": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tsa": {
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "deploymentName": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
         "trillian": {
             "properties": {
                 "affinity": {
@@ -362,55 +479,6 @@
                 },
                 "nodeSelector": {
                     "properties": {},
-                    "type": "object"
-                },
-                "secrets": {
-                    "properties": {
-                        "ctlog": {
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "path": {
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "fulcio": {
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "path": {
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "rekor": {
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "path": {
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "tsa": {
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "path": {
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
                     "type": "object"
                 },
                 "tolerations": {

--- a/charts/scaffold/values.yaml
+++ b/charts/scaffold/values.yaml
@@ -86,19 +86,35 @@ tuf:
   nodeSelector: {}
   affinity: {}
 
-  secrets:
-    rekor:
-      name: rekor-public-key
-      path: rekor.pub
-    fulcio:
-      name: fulcio-server-secret
-      path: fulcio_v1.crt.pem
-    ctlog:
-      name: ctlog-public-key
-      path: ctfe.pub
-    tsa:
-      name: tsa-cert-chain
-      path: tsa.certchain.pem
+secrets:
+  rekor:
+    deploymentName: rekor-server
+    create: false
+    name: rekor-public-key
+    namespace: rekor-system
+    key: key
+    path: rekor.pub
+  fulcio:
+    deploymentName: fulcio-server
+    create: false
+    name: fulcio-server-secret
+    namespace: fulcio-system
+    key: cert
+    path: fulcio_v1.crt.pem
+  ctlog:
+    deploymentName: ctlog
+    create: false
+    name: ctlog-public-key
+    namespace: ctlog-system
+    key: public
+    path: ctfe.pub
+  tsa:
+    deploymentName: tsa-server
+    create: false
+    name: tsa-cert-chain
+    namespace: tsa-system
+    key: cert-chain
+    path: tsa.certchain.pem
 
 copySecretJob:
   enabled: false
@@ -109,6 +125,12 @@ copySecretJob:
   imagePullPolicy: IfNotPresent
   serviceaccount: tuf-secret-copy-job
   backoffLimit: 6
+  copySecretCronJob:
+    enabled: false
+    schedule: "*/5 * * * 1-5"
+    backoffLimit: 2
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 1
   tolerations: []
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
closes https://github.com/sigstore/helm-charts/issues/791

## Description of the change

This PR adds a cronJob in conjunction w/ the copy secrets job.

## Existing or Associated Issue(s)

- https://github.com/sigstore/helm-charts/issues/791

## Additional Information

I included the secret `delete` permission due to the following error:
`Error from server (Conflict): Operation cannot be fulfilled on secrets "<secret_name>": the object has been modified; please apply your changes to the latest version and try again`

^ When trying to apply changes to secrets, I would receive the patch permission error about the resource version. This happens when the resource version of the secret being patched does not match the current resource version stored (e.g. used to manage optimistic concurrency). So if the secret has been modified since retrieved, the resource version will no longer match, thus preventing any further patch operation(s) to avoid overwriting changes made by other operations.

We could also retrieve the latest version of the secret, and then apply our changes to the latest version, and then patch, but I thought simply deleting / applying was better.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
```
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 scaffold => (version: "0.6.62", path: "charts/scaffold")
------------------------------------------------------------------------------------------------------------------------

"sigstore" already exists with the same configuration, skipping
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "sigstore" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 6 charts
Downloading fulcio from repo https://sigstore.github.io/helm-charts
Downloading rekor from repo https://sigstore.github.io/helm-charts
Downloading trillian from repo https://sigstore.github.io/helm-charts
Downloading ctlog from repo https://sigstore.github.io/helm-charts
Downloading tuf from repo https://sigstore.github.io/helm-charts
Downloading tsa from repo https://sigstore.github.io/helm-charts
Deleting outdated charts
Linting chart "scaffold => (version: \"0.6.62\", path: \"charts/scaffold\")"
Checking chart "scaffold => (version: \"0.6.62\", path: \"charts/scaffold\")" for a version bump...
Old chart version: 0.6.61
New chart version: 0.6.62
Chart version ok.
Validating /Users/ianhundere/Projects/helm-charts/charts/scaffold/Chart.yaml...
Validation success! 👍

Linting chart with values file "charts/scaffold/ci/ci-values.yaml"...

==> Linting charts/scaffold
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ scaffold => (version: "0.6.62", path: "charts/scaffold")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```