### PR TITLE
Drop the `.cluster.local` suffix

### DIFF
--- a/charts/scaffold/Chart.yaml
+++ b/charts/scaffold/Chart.yaml
@@ -4,7 +4,7 @@ description: Scaffolding the components of the sigstore architecture
 
 type: application
 
-version: 0.6.54
+version: 0.6.55
 keywords:
   - security
   - pki

--- a/charts/scaffold/README.md
+++ b/charts/scaffold/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.6.54](https://img.shields.io/badge/Version-0.6.54-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.55](https://img.shields.io/badge/Version-0.6.55-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Scaffolding the components of the sigstore architecture
 

--- a/charts/scaffold/templates/copy-secrets-job.yaml
+++ b/charts/scaffold/templates/copy-secrets-job.yaml
@@ -52,7 +52,7 @@ spec:
         command: ["/bin/sh"]
         args: [
             "-c",
-            "curl {{ .Values.rekor.server.fullnameOverride}}.{{ .Values.rekor.namespace.name }}.svc.cluster.local/api/v1/log/publicKey -o /tmp/key -v && kubectl create secret generic {{ .Values.tuf.secrets.rekor.name }} --from-file=key=/tmp/key"
+            "curl {{ .Values.rekor.server.fullnameOverride}}.{{ .Values.rekor.namespace.name }}.svc/api/v1/log/publicKey -o /tmp/key -v && kubectl create secret generic {{ .Values.tuf.secrets.rekor.name }} --from-file=key=/tmp/key"
         ]
       - name: copy-fulcio-secret
         image: {{ template "scaffold.image" .Values.copySecretJob }}
@@ -76,7 +76,7 @@ spec:
         command: ["/bin/sh"]
         args: [
             "-c",
-            "curl {{ .Values.tsa.server.fullnameOverride}}.{{ .Values.tsa.namespace.name }}.svc.cluster.local/api/v1/timestamp/certchain -o /tmp/cert-chain -v && kubectl create secret generic {{ .Values.tuf.secrets.tsa.name }} --from-file=cert-chain=/tmp/cert-chain"
+            "curl {{ .Values.tsa.server.fullnameOverride}}.{{ .Values.tsa.namespace.name }}.svc/api/v1/timestamp/certchain -o /tmp/cert-chain -v && kubectl create secret generic {{ .Values.tuf.secrets.tsa.name }} --from-file=cert-chain=/tmp/cert-chain"
         ]
       {{- if .Values.copySecretJob.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Description of the change

While `.cluster.local` is the standard suffix, it is configurable and not necessarily accurate.

Just using `.svc` and relying on ndots it used elsewhere through the helm chart, so drop the qualification here.

## Existing or Associated Issue(s)

N/A

## Additional Information

N/A

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
