### PR TITLE
Leases cleanup add security context

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.6.9
+version: 0.6.10
 appVersion: 0.8.2
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -159,6 +159,14 @@ helm uninstall [RELEASE_NAME]
 | leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |
 | leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
 | leasescleanup.image.version | string | `"latest-dev"` |  |
+| leasescleanup.podSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| leasescleanup.podSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| leasescleanup.podSecurityContext.enabled | bool | `true` |  |
+| leasescleanup.podSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
+| leasescleanup.podSecurityContext.runAsUser | int | `1000` |  |
+| leasescleanup.securityContext.enabled | bool | `false` |  |
+| leasescleanup.securityContext.runAsNonRoot | bool | `true` |  |
+| leasescleanup.securityContext.runAsUser | int | `1000` |  |
 | loglevel | string | `"info"` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | webhook.configData | object | `{}` |  |

--- a/charts/policy-controller/templates/webhook/cleanup-leases.yaml
+++ b/charts/policy-controller/templates/webhook/cleanup-leases.yaml
@@ -24,6 +24,18 @@ spec:
             - /bin/sh
             - -c
             - kubectl delete leases --all --ignore-not-found -n {{ .Release.Namespace }}
+  {{- if .Values.leasescleanup.podSecurityContext.enabled }}
+          securityContext:
+          {{- with .Values.leasescleanup.podSecurityContext }}
+          {{- omit . "enabled" | toYaml | nindent 10}}
+          {{- end }}
+  {{- end }}
+      {{- if .Values.leasescleanup.securityContext.enabled }}
+      securityContext:
+        {{- with .Values.leasescleanup.securityContext }}
+        {{- omit . "enabled" | toYaml | nindent 8}}
+        {{- end }}
+      {{- end }}
       restartPolicy: OnFailure
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -72,6 +72,18 @@ leasescleanup:
     repository: cgr.dev/chainguard/kubectl
     version: latest-dev
     pullPolicy: IfNotPresent
+  securityContext:
+    enabled: false
+    runAsUser: 1000
+    runAsNonRoot: true
+  podSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsUser: 1000
+    capabilities:
+      drop:
+        - ALL
 
 ## common node selector for all the pods
 commonNodeSelector: {}


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

securityContxect to cleanup-leases job

* In a cluster with https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/ or other similar best practice policies, the lease job does not clean up, as it fails to be created, output similar errors:

`run-as-non-root: 'validation error: Running as root is not allowed. Either the field..`

This also relates to issue listed, leases dont get cleaned up the application fails to start if re-deployed. 

## Existing or Associated Issue(s)

https://github.com/sigstore/helm-charts/issues/217#issuecomment-1160155615

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

Add podSecurity context and security context to values.yaml and corresponding cleanup-lease job.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
