### PR TITLE
fulcio: AWS KMS support

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.5.4
+version: 2.6.0
 appVersion: 1.6.4
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.5.4](https://img.shields.io/badge/Version-2.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.4](https://img.shields.io/badge/AppVersion-1.6.4-informational?style=flat-square)
+![Version: 2.6.0](https://img.shields.io/badge/Version-2.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.4](https://img.shields.io/badge/AppVersion-1.6.4-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 
@@ -121,6 +121,8 @@ helm uninstall [RELEASE_NAME]
 | server.args.grpcPort | int | `5554` |  |
 | server.args.hsm_caroot_id | string | `nil` |  |
 | server.args.port | int | `5555` |  |
+| server.awsKmsCredentialsSecretName | string | `"aws-kms-credentials"` | ubernetes secret name containing IAM credentials for use with AWS KMS |
+| server.awsKmsRegion | string | `"us-east-1"` | AWS region if using AWS KMS for signing key |
 | server.grpcSvcPort | int | `5554` |  |
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"gcr.io"` |  |
@@ -156,6 +158,7 @@ helm uninstall [RELEASE_NAME]
 | server.ingresses[0].name | string | `"gce-ingress"` |  |
 | server.ingresses[0].staticGlobalIP | string | `"lb-ext-ip"` |  |
 | server.ingresses[0].tls | list | `[]` |  |
+| server.kmsType | string | `"none"` | KMS type for signing key (possible values: "" / "none", "aws") |
 | server.logging.production | bool | `false` |  |
 | server.name | string | `"server"` |  |
 | server.nodeSelector | object | `{}` |  |

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -121,7 +121,7 @@ helm uninstall [RELEASE_NAME]
 | server.args.grpcPort | int | `5554` |  |
 | server.args.hsm_caroot_id | string | `nil` |  |
 | server.args.port | int | `5555` |  |
-| server.awsKmsCredentialsSecretName | string | `"aws-kms-credentials"` | ubernetes secret name containing IAM credentials for use with AWS KMS |
+| server.awsKmsCredentialsSecretName | string | `"aws-kms-credentials"` | kubernetes secret name containing IAM credentials for use with AWS KMS |
 | server.awsKmsRegion | string | `"us-east-1"` | AWS region if using AWS KMS for signing key |
 | server.grpcSvcPort | int | `5554` |  |
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -71,14 +71,28 @@ spec:
             {{- range .Values.server.extraArgs }}
             - {{ . | quote }}
             {{- end }}
-          {{- if eq .Values.server.args.certificateAuthority "fileca" }}
           env:
+            {{- if eq .Values.server.args.certificateAuthority "fileca" }}
             - name: PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.server.secret }}
                   key: password
-          {{- end }}
+            {{- end }}
+            {{- if and (eq .Values.server.args.certificateAuthority "kmsca") (eq .Values.server.kmsType "aws") }}
+            - name: AWS_DEFAULT_REGION
+              value: {{ .Values.server.awsKmsRegion }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.server.awsKmsCredentialsSecretName }}
+                  key: accessKeyId
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.server.awsKmsCredentialsSecretName }}
+                  key: secretAccessKey
+            {{- end }}
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -201,6 +201,12 @@
                     },
                     "type": "object"
                 },
+                "awsKmsCredentialsSecretName": {
+                    "type": "string"
+                },
+                "awsKmsRegion": {
+                    "type": "string"
+                },
                 "grpcSvcPort": {
                     "type": "integer"
                 },
@@ -405,6 +411,9 @@
                         "type": "object"
                     },
                     "type": "array"
+                },
+                "kmsType": {
+                    "type": "string"
                 },
                 "logging": {
                     "properties": {

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -13,7 +13,13 @@ server:
   name: server
   svcPort: 80
   grpcSvcPort: 5554
+  # -- KMS type for signing key (possible values: "" / "none", "aws")
+  kmsType: none
   secret: fulcio-server-secret
+  # -- kubernetes secret name containing IAM credentials for use with AWS KMS
+  awsKmsCredentialsSecretName: aws-kms-credentials
+  # -- AWS region if using AWS KMS for signing key
+  awsKmsRegion: us-east-1
   logging:
     production: false
   image:


### PR DESCRIPTION
## Description of the change

This commit adds support for AWS KMS keys to the fulcio chart. The following variables were added:

- `kmsType` - The KMS type (e.g., `aws`)
- `awsKmsCredentialsSecretName` - The name of an existing Kubernetes secret containing the IAM credentials to authenticate with AWS KMS
  - The secret should contain two key value pairs: `accessKeyId` and `secretAccessKey`
- `awsKmsRegion` - The AWS region string where the KMS key is hosted

Users must set `kmsType` to the value `aws` in order to use this feature.

## Existing or Associated Issue(s)

N/A

## Additional Information

I tested these changes using a privately-hosted Sigstore instance. To use AWS KMS keys, users will need to supply the following changes via the values files:

- Set `kmsType` to `aws` in values.yaml
- Set `certificateAuthority` to a `kmsca` in values.yaml
- Set `kms_resource` to a `awskms://` string in values.yaml
- Set `kms_cert_chain` to a PEM blob containing the signers certificate (should be the first certificate in the file), optionally followed by any parent certificates
- Set `awsKmsRegion` to the desired region string in values.yaml
- Create a Kubernetes secret containing the AWS IAM credentials. It should be named using the same string passed to the `awsKmsCredentialsSecretName`

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command. (**Note: This fails for me with the error: `Error loading configuration: 'chart_schema.yaml' neither specified nor found in default locations`)