### PR TITLE
rekor: Added support for AWS KMS settings.

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.4.8
+version: 1.5.0
 appVersion: 1.3.6
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -144,7 +144,7 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | server.attestation_storage.persistence.size | string | `"5Gi"` |  |
 | server.attestation_storage.persistence.storageClass | string | `""` |  |
 | server.attestation_storage.persistence.subPath | string | `""` |  |
-| server.awsKmsCredentialsSecretName | string | `"aws-kms-credentials"` | ubernetes secret name containing IAM credentials for use with AWS KMS |
+| server.awsKmsCredentialsSecretName | string | `"aws-kms-credentials"` | kubernetes secret name containing IAM credentials for use with AWS KMS |
 | server.awsKmsRegion | string | `"us-east-1"` | AWS region if using AWS KMS for signing key |
 | server.config.key | string | `"treeID"` |  |
 | server.config.treeID | string | `""` |  |

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.4.8](https://img.shields.io/badge/Version-1.4.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.6](https://img.shields.io/badge/AppVersion-1.3.6-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.6](https://img.shields.io/badge/AppVersion-1.3.6-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 
@@ -144,6 +144,8 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | server.attestation_storage.persistence.size | string | `"5Gi"` |  |
 | server.attestation_storage.persistence.storageClass | string | `""` |  |
 | server.attestation_storage.persistence.subPath | string | `""` |  |
+| server.awsKmsCredentialsSecretName | string | `"aws-kms-credentials"` | ubernetes secret name containing IAM credentials for use with AWS KMS |
+| server.awsKmsRegion | string | `"us-east-1"` | AWS region if using AWS KMS for signing key |
 | server.config.key | string | `"treeID"` |  |
 | server.config.treeID | string | `""` |  |
 | server.enabled | bool | `true` |  |
@@ -170,6 +172,7 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | server.ingresses[0].name | string | `"gce-ingress"` |  |
 | server.ingresses[0].staticGlobalIP | string | `"lb-ext-ip"` |  |
 | server.ingresses[0].tls | list | `[]` |  |
+| server.kmsType | string | `"none"` | KMS type for signing key (possible values: "" / "none", "aws") |
 | server.livenessProbe.failureThreshold | int | `3` |  |
 | server.livenessProbe.httpGet.path | string | `"/ping"` |  |
 | server.livenessProbe.httpGet.port | int | `3000` |  |

--- a/charts/rekor/templates/server/deployment.yaml
+++ b/charts/rekor/templates/server/deployment.yaml
@@ -104,6 +104,20 @@ spec:
 {{- if eq (.Values.server.searchIndex).storageProvider "mysql" }}
 {{- include "searchIndex.mysql.envCredentials" . | indent 12 }}
 {{- end }}
+            {{- if eq .Values.server.kmsType "aws" }}
+            - name: AWS_DEFAULT_REGION
+              value: {{ .Values.server.awsKmsRegion }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.server.awsKmsCredentialsSecretName }}
+                  key: accessKeyId
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.server.awsKmsCredentialsSecretName }}
+                  key: secretAccessKey
+            {{- end }}
           args:
 {{  include "rekor.server.args" . | indent 12 }}
           ports:

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -554,6 +554,12 @@
                     },
                     "type": "object"
                 },
+                "awsKmsCredentialsSecretName": {
+                    "type": "string"
+                },
+                "awsKmsRegion": {
+                    "type": "string"
+                },
                 "config": {
                     "properties": {
                         "key": {
@@ -697,6 +703,9 @@
                         "type": "object"
                     },
                     "type": "array"
+                },
+                "kmsType": {
+                    "type": "string"
                 },
                 "livenessProbe": {
                     "properties": {

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -119,6 +119,12 @@ server:
     pullPolicy: IfNotPresent
     # crane digest gcr.io/projectsigstore/rekor-server:v1.3.6
     version: sha256:1237f29e2105d7f5451bbe15a3aca8677ddd1bb80620ca2fd06f74262437cf51
+  # -- KMS type for signing key (possible values: "" / "none", "aws")
+  kmsType: none
+  # -- AWS region if using AWS KMS for signing key
+  awsKmsRegion: us-east-1
+  # -- kubernetes secret name containing IAM credentials for use with AWS KMS
+  awsKmsCredentialsSecretName: aws-kms-credentials
   logging:
     production: false
   ingress:


### PR DESCRIPTION
## Description of the change

*Note: This pull request was split out from [PR 831](https://github.com/sigstore/helm-charts/pull/831).*

This commit adds support for AWS KMS keys to the rekor chart. The following variables were added:

- `kmsType` - The KMS type (e.g., `aws`)
- `awsKmsCredentialsSecretName` - The name of an existing Kubernetes secret containing the IAM credentials to authenticate with AWS KMS
  - The secret should contain two key value pairs: `accessKeyId` and `secretAccessKey`
- `awsKmsRegion` - The AWS region string where the KMS key is hosted

Users must set `kmsType` to the value `aws` in order to use this feature.

## Existing or Associated Issue(s)

N/A

## Additional Information

I tested these changes using a privately-hosted Sigstore instance. To use AWS KMS keys, users will need to supply the following changes via the values files:

- Set `kmsType` to `aws` in values.yaml
- Set `signer` to a `awskms://` string in values.yaml
- Set `awsKmsRegion` to the desired region string in values.yaml
- Create a Kubernetes secret containing the AWS IAM credentials. It should be named using the same string passed to the `awsKmsCredentialsSecretName`

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command. (**Note: This fails for me with the error: `Error loading configuration: 'chart_schema.yaml' neither specified nor found in default locations`)