### PR TITLE
policy-controller: fix empty values

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.8.2
 
 maintainers:

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -70,6 +70,7 @@ spec:
           value: "{{ $value }}"
 {{- end }}
 {{- end }}
+        {{- if or (semverCompare ">= 1.8-0" .Chart.AppVersion) .Values.webhook.extraArgs }}
         args:
         {{- if semverCompare ">= 1.8-0" .Chart.AppVersion }}
         - -webhook-name={{ required "A valid cosign.webhookName is required" .Values.cosign.webhookName }}
@@ -78,6 +79,7 @@ spec:
         {{- end }}
         {{- range $key, $value := .Values.webhook.extraArgs }}
         - -{{ $key }}={{ $value }}
+        {{- end }}
         {{- end }}
         ports:
         - containerPort: 8443

--- a/charts/policy-controller/templates/webhook/poddisruptionbudget.yaml
+++ b/charts/policy-controller/templates/webhook/poddisruptionbudget.yaml
@@ -11,15 +11,17 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- end }}
+  {{- with .Values.annotations }}
   annotations:
-{{- if .Values.annotations }}
-{{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
-{{- end }}
-{{- end }}
+  {{- end }}
 spec:
+  {{- if .Values.webhook.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.webhook.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "policy-controller.selectorLabels" . | nindent 6 }}

--- a/charts/policy-controller/templates/webhook/secret_certs_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/secret_certs_webhook.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if or .Values.webhook.service.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.webhook.service.annotations }}
     {{ toYaml .Values.webhook.service.annotations | nindent 4 }}
@@ -8,6 +9,7 @@ metadata:
     {{- if .Values.commonAnnotations }}
     {{- toYaml .Values.commonAnnotations | nindent 4 }}
     {{- end }}
+  {{- end }}
   labels:
     {{- include "policy-controller.labels" . | nindent 4 }}
     control-plane: {{ template "policy-controller.fullname" . }}-webhook

--- a/charts/policy-controller/templates/webhook/service_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/service_webhook.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- with .Values.webhook.service.annotations }}
   annotations:
-    {{- if .Values.webhook.service.annotations }}
-    {{ toYaml .Values.webhook.service.annotations | nindent 4 }}
-    {{- end }}
+     {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "policy-controller.labels" . | nindent 4 }}
     control-plane: {{ template "policy-controller.fullname" . }}-webhook
@@ -27,10 +27,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  {{- with .Values.webhook.service.annotations }}
   annotations:
-    {{- if .Values.webhook.service.annotations }}
-    {{ toYaml .Values.webhook.service.annotations | nindent 4 }}
-    {{- end }}
+     {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "policy-controller.labels" . | nindent 4 }}
     control-plane: {{ template "policy-controller.fullname" . }}-webhook


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

This PR fixes the issue where only the key is output when the value is not provided for some fields such as `.Values.annotations` and `.Values.webhook.podDisruptionBudget.maxUnavailable`.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

The state in which only the key is output, such as `annotations: `, is not syntactically correct in yaml, so lint tools such as kubeconform output an error.
In this PR, the position of the conditional branch has been slightly changed so that if value is not specified, key is also not output.

`$ helm install policy-controller sigstore/policy-controller  -n policy-controller  --dry-run > old.yaml`
`$ helm install policy-controller ./charts/policy-controller -n policy-controller  --dry-run > new.yaml`
`$ dyff between .\old.yaml .\new.yaml`

old.yaml:
```yaml
...
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: policy-controller-webhook
  labels:
    helm.sh/chart: policy-controller-0.7.0
    app.kubernetes.io/name: policy-controller
    app.kubernetes.io/instance: policy-controller
    app.kubernetes.io/version: "0.8.2"
    app.kubernetes.io/managed-by: Helm
    control-plane: policy-controller-webhook
  annotations:
spec:
  minAvailable: 1
  maxUnavailable: 
  selector:
    matchLabels:
      app.kubernetes.io/name: policy-controller
      app.kubernetes.io/instance: policy-controller
      control-plane: policy-controller-webhook
...
```

new.yaml:
```yaml
...
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: policy-controller-webhook
  labels:
    helm.sh/chart: policy-controller-0.7.0
    app.kubernetes.io/name: policy-controller
    app.kubernetes.io/instance: policy-controller
    app.kubernetes.io/version: "0.8.2"
    app.kubernetes.io/managed-by: Helm
    control-plane: policy-controller-webhook
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: policy-controller
      app.kubernetes.io/instance: policy-controller
      control-plane: policy-controller-webhook
...
```

Output:
```
metadata  (document #6)
  - one map entry removed:
    annotations:

spec  (document #6)
  - one map entry removed:
    maxUnavailable:

metadata  (document #8)
  - one map entry removed:
    annotations:

metadata  (document #19)
  - one map entry removed:
    annotations:

metadata  (document #20)
  - one map entry removed:
    annotations:

spec.template.spec.containers.policy-controller-webhook  (document #21)
  - one map entry removed:
    args:
```

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
