### PR TITLE
handle extraArgs consistently in ctlog chart as in other charts

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.58
+version: 0.2.59
 appVersion: 0.7.15
 
 keywords:

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -1,6 +1,6 @@
 # ctlog
 
-![Version: 0.2.58](https://img.shields.io/badge/Version-0.2.58-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.15](https://img.shields.io/badge/AppVersion-0.7.15-informational?style=flat-square)
+![Version: 0.2.59](https://img.shields.io/badge/Version-0.2.59-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.15](https://img.shields.io/badge/AppVersion-0.7.15-informational?style=flat-square)
 
 Certificate Log
 

--- a/charts/ctlog/templates/_helpers.tpl
+++ b/charts/ctlog/templates/_helpers.tpl
@@ -110,15 +110,9 @@ Server Arguments
 - {{ printf "--metrics_endpoint=0.0.0.0:%d" (.Values.server.portHTTPMetrics | int) | quote }}
 - "--log_config=/ctfe-keys/config"
 - "--alsologtostderr"
-{{- if .Values.server.extraArgs -}}
-{{- range $key, $value := .Values.server.extraArgs }}
-{{- if $value }}
-- {{ printf "%v=%v" $key $value | quote }}
-{{- else }}
-- {{ printf $key | quote }}
-{{- end }}
-{{- end }}
-{{- end -}}
+{{- range .Values.server.extraArgs }}
+- {{ . | quote }}
+{{ end }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
ctlog chart expected extraArgs as a map instead of a list of strings; this makes it consistent with others