### PR TITLE
tuf: Support deployment resources customization

### DIFF
--- a/charts/tuf/Chart.yaml
+++ b/charts/tuf/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tuf
 description: A framework for securing software update systems - the scaffolding implementation
 type: application
-version: 0.1.20
+version: 0.1.21
 appVersion: 0.7.15
 
 home: https://sigstore.dev/

--- a/charts/tuf/README.md
+++ b/charts/tuf/README.md
@@ -1,6 +1,6 @@
 # tuf
 
-![Version: 0.1.20](https://img.shields.io/badge/Version-0.1.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.15](https://img.shields.io/badge/AppVersion-0.7.15-informational?style=flat-square)
+![Version: 0.1.21](https://img.shields.io/badge/Version-0.1.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.15](https://img.shields.io/badge/AppVersion-0.7.15-informational?style=flat-square)
 
 A framework for securing software update systems - the scaffolding implementation
 
@@ -21,6 +21,7 @@ A framework for securing software update systems - the scaffolding implementatio
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | deployment.affinity | object | `{}` |  |
+| deployment.containerSecurityContext | object | `{}` |  |
 | deployment.imagePullPolicy | string | `"IfNotPresent"` |  |
 | deployment.name | string | `"tuf"` |  |
 | deployment.nodeSelector | object | `{}` |  |
@@ -28,6 +29,8 @@ A framework for securing software update systems - the scaffolding implementatio
 | deployment.registry | string | `"ghcr.io"` |  |
 | deployment.replicas | int | `1` |  |
 | deployment.repository | string | `"sigstore/scaffolding/server"` |  |
+| deployment.resources | object | `{}` |  |
+| deployment.securityContext | object | `{}` |  |
 | deployment.tolerations | list | `[]` |  |
 | deployment.version | string | `"sha256:982c6173b6f2f976fd9f58eb543ca9ec5f0d1b7c1a6f7bb0c4b96cff1618c62e"` |  |
 | enabled | bool | `true` |  |

--- a/charts/tuf/templates/deployment.yaml
+++ b/charts/tuf/templates/deployment.yaml
@@ -39,11 +39,22 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-
         volumeMounts:
           - name: tuf-secrets
             mountPath: "/var/run/tuf-secrets"
             readOnly: true
+      {{- if .Values.deployment.resources }}
+        resources:
+{{ toYaml .Values.deployment.resources | indent 10 }}
+      {{- end }}
+      {{- if .Values.deployment.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.deployment.containerSecurityContext | indent 10 }}
+      {{- end }}
+    {{- if .Values.deployment.securityContext }}
+      securityContext:
+{{ toYaml .Values.deployment.securityContext | indent 8 }}
+    {{- end }}
       volumes:
       - name: tuf-secrets
         projected:

--- a/charts/tuf/values.schema.json
+++ b/charts/tuf/values.schema.json
@@ -7,6 +7,10 @@
                     "properties": {},
                     "type": "object"
                 },
+                "containerSecurityContext": {
+                    "properties": {},
+                    "type": "object"
+                },
                 "imagePullPolicy": {
                     "type": "string"
                 },
@@ -28,6 +32,13 @@
                 },
                 "repository": {
                     "type": "string"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "properties": {},
+                    "type": "object"
                 },
                 "tolerations": {
                     "type": "array"

--- a/charts/tuf/values.yaml
+++ b/charts/tuf/values.yaml
@@ -15,6 +15,9 @@ deployment:
   version: sha256:982c6173b6f2f976fd9f58eb543ca9ec5f0d1b7c1a6f7bb0c4b96cff1618c62e
   imagePullPolicy: IfNotPresent
   port: 8080
+  resources: {}
+  containerSecurityContext: {}
+  securityContext: {}
   tolerations: []
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
## Description of the change

This pull request adds support for customizing the following values in the tuf `Deployment` resource:

- Container resources
- Container security context
- Deployment security context

## Existing or Associated Issue(s)

This work was originally implemented in pull request #460 which is unmerged. This current pull request supersedes Vipul's work.

## Additional Information

I think I modified the `values.schema.json` correctly?

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.