### PR TITLE
Expose webhook affinity via values.yaml

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.8.0
+version: 0.8.1
 appVersion: 0.11.0
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 The Helm chart for Policy  Controller
 
@@ -161,6 +161,7 @@ helm uninstall [RELEASE_NAME]
 | leasescleanup.image.version | string | `"latest-dev"` |  |
 | loglevel | string | `"info"` |  |
 | serviceMonitor.enabled | bool | `false` |  |
+| webhook.affinity | object | `{}` |  |
 | webhook.configData | object | `{}` |  |
 | webhook.customLabels | object | `{}` |  |
 | webhook.env | object | `{}` |  |

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -33,6 +33,9 @@ spec:
       serviceAccountName: {{ include "webhook.serviceAccountName" . }}
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
+      {{- if .Values.webhook.affinity }}
+        {{- toYaml .Values.webhook.affinity | nindent 8 }}
+      {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -41,6 +44,7 @@ spec:
                   control-plane: {{ template "policy-controller.fullname" . }}-webhook
               topologyKey: kubernetes.io/hostname
             weight: 100
+      {{- end }}
       containers:
       - name: {{ template "policy-controller.name" . }}-{{ .Values.webhook.name }}
         image: "{{ template "policy-controller.image" .Values.webhook.image }}"

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -1,255 +1,592 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "properties": {
-        "commonAnnotations": {
-            "type": "object"
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "commonAnnotations": {
+      "additionalProperties": false,
+      "description": "# This will set some annotations in config maps and secrets. Use case: Disable versioning to deploy helm chart using spinnaker",
+      "required": [],
+      "title": "commonAnnotations",
+      "type": "object"
+    },
+    "commonNodeSelector": {
+      "additionalProperties": false,
+      "description": "# common node selector for all the pods",
+      "required": [],
+      "title": "commonNodeSelector",
+      "type": "object"
+    },
+    "commonTolerations": {
+      "description": "# common tolerations for all the pods",
+      "items": {
+        "required": []
+      },
+      "required": [],
+      "title": "commonTolerations",
+      "type": "array"
+    },
+    "cosign": {
+      "additionalProperties": false,
+      "properties": {
+        "cosignPub": {
+          "default": "",
+          "description": "add the values in base64 encoded",
+          "required": [],
+          "title": "cosignPub",
+          "type": "string"
         },
-        "commonNodeSelector": {
-            "type": "object"
-        },
-        "commonTolerations": {
-            "type": "array"
-        },
-        "cosign": {
-            "type": "object",
-            "properties": {
-                "cosignPub": {
-                    "type": "string"
-                },
-                "webhookName": {
-                    "type": "string"
-                }
-            }
-        },
-        "imagePullSecrets": {
-            "type": "array"
-        },
-        "installCRDs": {
-            "type": "boolean"
-        },
-        "leasescleanup": {
-            "type": "object",
-            "properties": {
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        },
-                        "version": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "loglevel": {
-            "type": "string"
-        },
-        "serviceMonitor": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "webhook": {
-            "type": "object",
-            "properties": {
-                "configData": {
-                    "type": "object"
-                },
-                "customLabels": {
-                    "type": "object"
-                },
-                "env": {
-                    "type": "object"
-                },
-                "extraArgs": {
-                    "type": "object"
-                },
-                "failurePolicy": {
-                    "type": "string"
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        },
-                        "version": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "name": {
-                    "type": "string"
-                },
-                "namespaceSelector": {
-                    "type": "object",
-                    "properties": {
-                        "matchExpressions": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "key": {
-                                        "type": "string"
-                                    },
-                                    "operator": {
-                                        "type": "string"
-                                    },
-                                    "values": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "podAnnotations": {
-                    "type": "object"
-                },
-                "podDisruptionBudget": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "minAvailable": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "podSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "allowPrivilegeEscalation": {
-                            "type": "boolean"
-                        },
-                        "capabilities": {
-                            "type": "object",
-                            "properties": {
-                                "drop": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "readOnlyRootFilesystem": {
-                            "type": "boolean"
-                        },
-                        "runAsUser": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "registryCaBundle": {
-                    "type": "object"
-                },
-                "replicaCount": {
-                    "type": "integer"
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "securityContext": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "runAsUser": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": "object"
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "serviceAccount": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": "object"
-                        },
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "volumeMounts": {
-                    "type": "array"
-                },
-                "volumes": {
-                    "type": "array"
-                },
-                "webhookNames": {
-                    "type": "object",
-                    "properties": {
-                        "defaulting": {
-                            "type": "string"
-                        },
-                        "validating": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+        "webhookName": {
+          "default": "policy.sigstore.dev",
+          "required": [],
+          "title": "webhookName",
+          "type": "string"
         }
+      },
+      "required": [
+        "cosignPub",
+        "webhookName"
+      ],
+      "title": "cosign",
+      "type": "object"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "imagePullSecrets": {
+      "items": {
+        "required": []
+      },
+      "required": [],
+      "title": "imagePullSecrets",
+      "type": "array"
+    },
+    "installCRDs": {
+      "default": true,
+      "required": [],
+      "title": "installCRDs",
+      "type": "boolean"
+    },
+    "leasescleanup": {
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "additionalProperties": false,
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "required": [],
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "cgr.dev/chainguard/kubectl",
+              "required": [],
+              "title": "repository",
+              "type": "string"
+            },
+            "version": {
+              "default": "latest-dev",
+              "required": [],
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "version",
+            "pullPolicy"
+          ],
+          "title": "image",
+          "type": "object"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "leasescleanup",
+      "type": "object"
+    },
+    "loglevel": {
+      "default": "info",
+      "required": [],
+      "title": "loglevel",
+      "type": "string"
+    },
+    "serviceMonitor": {
+      "additionalProperties": false,
+      "description": "# serviceMonitor makes policy controller metrics discoverable to prometheus",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "title": "serviceMonitor",
+      "type": "object"
+    },
+    "webhook": {
+      "additionalProperties": false,
+      "properties": {
+        "affinity": {
+          "additionalProperties": false,
+          "description": "The default affinity config is to spread the webhook across nodes.\nSee charts/policy-controller/templates/webhook/deployment_webhook.yaml#L39 for more info.",
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
+        "configData": {
+          "additionalProperties": false,
+          "required": [],
+          "title": "configData",
+          "type": "object"
+        },
+        "customLabels": {
+          "additionalProperties": false,
+          "required": [],
+          "title": "customLabels",
+          "type": "object"
+        },
+        "env": {
+          "additionalProperties": false,
+          "required": [],
+          "title": "env",
+          "type": "object"
+        },
+        "extraArgs": {
+          "additionalProperties": false,
+          "required": [],
+          "title": "extraArgs",
+          "type": "object"
+        },
+        "failurePolicy": {
+          "default": "Fail",
+          "required": [],
+          "title": "failurePolicy",
+          "type": "string"
+        },
+        "image": {
+          "additionalProperties": false,
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "required": [],
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "ghcr.io/sigstore/policy-controller/policy-controller",
+              "required": [],
+              "title": "repository",
+              "type": "string"
+            },
+            "version": {
+              "default": "sha256:f291fce5b9c1a69ba54990eda7e0fe4114043b1afefb0f4ee3e6f84ec9ef1605",
+              "description": "crane digest ghcr.io/sigstore/policy-controller/policy-controller:v0.8.2",
+              "required": [],
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [
+            "repository",
+            "version",
+            "pullPolicy"
+          ],
+          "title": "image",
+          "type": "object"
+        },
+        "name": {
+          "default": "webhook",
+          "required": [],
+          "title": "name",
+          "type": "string"
+        },
+        "namespaceSelector": {
+          "additionalProperties": false,
+          "properties": {
+            "matchExpressions": {
+              "items": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "key": {
+                        "default": "policy.sigstore.dev/include",
+                        "required": [],
+                        "title": "key",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "default": "In",
+                        "required": [],
+                        "title": "operator",
+                        "type": "string"
+                      },
+                      "values": {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "required": [],
+                              "type": "string"
+                            }
+                          ],
+                          "required": []
+                        },
+                        "required": [],
+                        "title": "values",
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator",
+                      "values"
+                    ],
+                    "type": "object"
+                  }
+                ],
+                "required": []
+              },
+              "required": [],
+              "title": "matchExpressions",
+              "type": "array"
+            }
+          },
+          "required": [
+            "matchExpressions"
+          ],
+          "title": "namespaceSelector",
+          "type": "object"
+        },
+        "podAnnotations": {
+          "additionalProperties": false,
+          "required": [],
+          "title": "podAnnotations",
+          "type": "object"
+        },
+        "podDisruptionBudget": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "default": true,
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "minAvailable": {
+              "default": 1,
+              "required": [],
+              "title": "minAvailable",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "enabled",
+            "minAvailable"
+          ],
+          "title": "podDisruptionBudget",
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "additionalProperties": false,
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "default": false,
+              "required": [],
+              "title": "allowPrivilegeEscalation",
+              "type": "boolean"
+            },
+            "capabilities": {
+              "additionalProperties": false,
+              "properties": {
+                "drop": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "required": [],
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "required": [],
+                  "title": "drop",
+                  "type": "array"
+                }
+              },
+              "required": [
+                "drop"
+              ],
+              "title": "capabilities",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "readOnlyRootFilesystem": {
+              "default": true,
+              "required": [],
+              "title": "readOnlyRootFilesystem",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "default": 1000,
+              "required": [],
+              "title": "runAsUser",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "enabled",
+            "allowPrivilegeEscalation",
+            "readOnlyRootFilesystem",
+            "runAsUser",
+            "capabilities"
+          ],
+          "title": "podSecurityContext",
+          "type": "object"
+        },
+        "registryCaBundle": {
+          "additionalProperties": false,
+          "required": [],
+          "title": "registryCaBundle",
+          "type": "object"
+        },
+        "replicaCount": {
+          "default": 1,
+          "required": [],
+          "title": "replicaCount",
+          "type": "integer"
+        },
+        "resources": {
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "200m",
+                  "required": [],
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "512Mi",
+                  "required": [],
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "cpu",
+                "memory"
+              ],
+              "title": "limits",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "100m",
+                  "required": [],
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "128Mi",
+                  "required": [],
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "cpu",
+                "memory"
+              ],
+              "title": "requests",
+              "type": "object"
+            }
+          },
+          "required": [
+            "limits",
+            "requests"
+          ],
+          "title": "resources",
+          "type": "object"
+        },
+        "securityContext": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "default": false,
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "default": 65532,
+              "required": [],
+              "title": "runAsUser",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "enabled",
+            "runAsUser"
+          ],
+          "title": "securityContext",
+          "type": "object"
+        },
+        "service": {
+          "additionalProperties": false,
+          "properties": {
+            "annotations": {
+              "additionalProperties": false,
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "port": {
+              "default": 443,
+              "required": [],
+              "title": "port",
+              "type": "integer"
+            },
+            "type": {
+              "default": "ClusterIP",
+              "required": [],
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "annotations",
+            "type",
+            "port"
+          ],
+          "title": "service",
+          "type": "object"
+        },
+        "serviceAccount": {
+          "additionalProperties": false,
+          "properties": {
+            "annotations": {
+              "additionalProperties": false,
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "create": {
+              "default": true,
+              "required": [],
+              "title": "create",
+              "type": "boolean"
+            },
+            "name": {
+              "default": "",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "annotations",
+            "create",
+            "name"
+          ],
+          "title": "serviceAccount",
+          "type": "object"
+        },
+        "volumeMounts": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "volumeMounts",
+          "type": "array"
+        },
+        "volumes": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "volumes",
+          "type": "array"
+        },
+        "webhookNames": {
+          "additionalProperties": false,
+          "properties": {
+            "defaulting": {
+              "default": "defaulting.clusterimagepolicy.sigstore.dev",
+              "required": [],
+              "title": "defaulting",
+              "type": "string"
+            },
+            "validating": {
+              "default": "validating.clusterimagepolicy.sigstore.dev",
+              "required": [],
+              "title": "validating",
+              "type": "string"
+            }
+          },
+          "required": [
+            "defaulting",
+            "validating"
+          ],
+          "title": "webhookNames",
+          "type": "object"
+        }
+      },
+      "required": [
+        "customLabels",
+        "configData",
+        "replicaCount",
+        "name",
+        "image",
+        "env",
+        "extraArgs",
+        "resources",
+        "securityContext",
+        "failurePolicy",
+        "podAnnotations",
+        "podSecurityContext",
+        "affinity",
+        "podDisruptionBudget",
+        "serviceAccount",
+        "service",
+        "volumeMounts",
+        "volumes",
+        "namespaceSelector",
+        "registryCaBundle",
+        "webhookNames"
+      ],
+      "title": "webhook",
+      "type": "object"
     }
+  },
+  "required": [
+    "cosign",
+    "installCRDs",
+    "imagePullSecrets",
+    "loglevel",
+    "webhook",
+    "leasescleanup",
+    "commonNodeSelector",
+    "commonTolerations",
+    "commonAnnotations",
+    "serviceMonitor"
+  ],
+  "type": "object"
 }

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -41,6 +41,9 @@ webhook:
     capabilities:
       drop:
         - ALL
+  # The default affinity config is to spread the webhook across nodes.
+  # See charts/policy-controller/templates/webhook/deployment_webhook.yaml#L39 for more info.
+  affinity: {}
   podDisruptionBudget:
     enabled: true
     minAvailable: 1


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Expose `affinity` via `values.yaml` for the Webhook

## Existing or Associated Issue(s)

<!-- List any related issues. -->
Supports #814

## Additional Information

I have the policy controller webhook deployed to my cluster, and have noticed that both replicas are on the same node. This is due to the `preferredDuring...` setting in the default affinity. I would also like to prefer different AZs, and `require` different nodes. To do this the user must be able to configure the affinity settings manually.

<img width="932" alt="image" src="https://github.com/user-attachments/assets/61910d4f-1101-4d66-aa14-85d828b096b1" />


## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
