### PR TITLE
feat: add webhook timeout values

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.8.1
+version: 0.9.0
 appVersion: 0.11.0
 
 maintainers:

--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 
 name: policy-controller
 version: 0.9.0
-appVersion: 0.11.0
+appVersion: 0.12.0
 
 maintainers:
   - name: dlorenc
@@ -19,4 +19,4 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: policy-controller
-      image: ghcr.io/sigstore/policy-controller/policy-controller:v0.11.0@sha256:f3b57d4c906fcbd7229c3069c055ce2b2862e01106c2b85df1322f1e3a232829
+      image: ghcr.io/sigstore/policy-controller/policy-controller:v0.12.0@sha256:6b51f336dec9e9adff29606855dbd2c7910c5eb80d6579795a29cb3844428efc

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 The Helm chart for Policy  Controller
 
@@ -153,6 +153,8 @@ helm uninstall [RELEASE_NAME]
 | commonNodeSelector | object | `{}` |  |
 | commonTolerations | list | `[]` |  |
 | cosign.cosignPub | string | `""` |  |
+| cosign.timeoutSeconds.mutating | int | `10` |  |
+| cosign.timeoutSeconds.validating | int | `10` |  |
 | cosign.webhookName | string | `"policy.sigstore.dev"` |  |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` |  |
@@ -200,3 +202,5 @@ helm uninstall [RELEASE_NAME]
 | webhook.volumes | list | `[]` |  |
 | webhook.webhookNames.defaulting | string | `"defaulting.clusterimagepolicy.sigstore.dev"` |  |
 | webhook.webhookNames.validating | string | `"validating.clusterimagepolicy.sigstore.dev"` |  |
+| webhook.webhookTimeoutSeconds.defaulting | int | `10` |  |
+| webhook.webhookTimeoutSeconds.validating | int | `10` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -153,8 +153,6 @@ helm uninstall [RELEASE_NAME]
 | commonNodeSelector | object | `{}` |  |
 | commonTolerations | list | `[]` |  |
 | cosign.cosignPub | string | `""` |  |
-| cosign.timeoutSeconds.mutating | int | `10` |  |
-| cosign.timeoutSeconds.validating | int | `10` |  |
 | cosign.webhookName | string | `"policy.sigstore.dev"` |  |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` |  |
@@ -202,5 +200,3 @@ helm uninstall [RELEASE_NAME]
 | webhook.volumes | list | `[]` |  |
 | webhook.webhookNames.defaulting | string | `"defaulting.clusterimagepolicy.sigstore.dev"` |  |
 | webhook.webhookNames.validating | string | `"validating.clusterimagepolicy.sigstore.dev"` |  |
-| webhook.webhookTimeoutSeconds.defaulting | int | `10` |  |
-| webhook.webhookTimeoutSeconds.validating | int | `10` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -153,6 +153,7 @@ helm uninstall [RELEASE_NAME]
 | commonNodeSelector | object | `{}` |  |
 | commonTolerations | list | `[]` |  |
 | cosign.cosignPub | string | `""` |  |
+| cosign.timeoutSeconds | object | `{}` |  |
 | cosign.webhookName | string | `"policy.sigstore.dev"` |  |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` |  |
@@ -200,3 +201,4 @@ helm uninstall [RELEASE_NAME]
 | webhook.volumes | list | `[]` |  |
 | webhook.webhookNames.defaulting | string | `"defaulting.clusterimagepolicy.sigstore.dev"` |  |
 | webhook.webhookNames.validating | string | `"validating.clusterimagepolicy.sigstore.dev"` |  |
+| webhook.webhookTimeoutSeconds | object | `{}` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -153,8 +153,8 @@ helm uninstall [RELEASE_NAME]
 | commonNodeSelector | object | `{}` |  |
 | commonTolerations | list | `[]` |  |
 | cosign.cosignPub | string | `""` |  |
-| cosign.timeoutSeconds | object | `{}` |  |
 | cosign.webhookName | string | `"policy.sigstore.dev"` |  |
+| cosign.webhookTimeoutSeconds | object | `{}` |  |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` |  |
 | leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
 
 The Helm chart for Policy  Controller
 
@@ -170,7 +170,7 @@ helm uninstall [RELEASE_NAME]
 | webhook.failurePolicy | string | `"Fail"` |  |
 | webhook.image.pullPolicy | string | `"IfNotPresent"` |  |
 | webhook.image.repository | string | `"ghcr.io/sigstore/policy-controller/policy-controller"` |  |
-| webhook.image.version | string | `"sha256:f3b57d4c906fcbd7229c3069c055ce2b2862e01106c2b85df1322f1e3a232829"` |  |
+| webhook.image.version | string | `"sha256:6b51f336dec9e9adff29606855dbd2c7910c5eb80d6579795a29cb3844428efc"` |  |
 | webhook.name | string | `"webhook"` |  |
 | webhook.namespaceSelector.matchExpressions[0].key | string | `"policy.sigstore.dev/include"` |  |
 | webhook.namespaceSelector.matchExpressions[0].operator | string | `"In"` |  |

--- a/charts/policy-controller/templates/webhook/policy_webhook_configurations.yaml
+++ b/charts/policy-controller/templates/webhook/policy_webhook_configurations.yaml
@@ -28,6 +28,7 @@ webhooks:
     matchPolicy: Equivalent
     name: {{ required "A valid webhook.webhookNames.defaulting is required" .Values.webhook.webhookNames.defaulting }}
     sideEffects: None
+    timeoutSeconds: {{ .Values.webhook.webhookTimeoutSeconds.defaulting }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -44,3 +45,4 @@ webhooks:
     matchPolicy: Equivalent
     name: {{ required "A valid webhook.webhookNames.validating is required" .Values.webhook.webhookNames.validating }}
     sideEffects: None
+    timeoutSeconds: {{ .Values.webhook.webhookTimeoutSeconds.validating }}

--- a/charts/policy-controller/templates/webhook/policy_webhook_configurations.yaml
+++ b/charts/policy-controller/templates/webhook/policy_webhook_configurations.yaml
@@ -28,7 +28,11 @@ webhooks:
     matchPolicy: Equivalent
     name: {{ required "A valid webhook.webhookNames.defaulting is required" .Values.webhook.webhookNames.defaulting }}
     sideEffects: None
+    {{- if .Values.webhook.webhookTimeoutSeconds }}
+    {{- if .Values.webhook.webhookTimeoutSeconds.defaulting }}
     timeoutSeconds: {{ .Values.webhook.webhookTimeoutSeconds.defaulting }}
+    {{- end }}
+    {{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -45,4 +49,8 @@ webhooks:
     matchPolicy: Equivalent
     name: {{ required "A valid webhook.webhookNames.validating is required" .Values.webhook.webhookNames.validating }}
     sideEffects: None
+    {{- if .Values.webhook.webhookTimeoutSeconds }}
+    {{- if .Values.webhook.webhookTimeoutSeconds.validating }}
     timeoutSeconds: {{ .Values.webhook.webhookTimeoutSeconds.validating }}
+    {{- end }}
+    {{- end }}

--- a/charts/policy-controller/templates/webhook/webhook_mutating.yaml
+++ b/charts/policy-controller/templates/webhook/webhook_mutating.yaml
@@ -14,4 +14,8 @@ webhooks:
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   sideEffects: None
   reinvocationPolicy: IfNeeded
+  {{- if .Values.cosign.timeoutSeconds }}
+  {{- if .Values.cosign.timeoutSeconds.mutating }}
   timeoutSeconds: {{ .Values.cosign.timeoutSeconds.mutating }}
+  {{- end }}
+  {{- end }}

--- a/charts/policy-controller/templates/webhook/webhook_mutating.yaml
+++ b/charts/policy-controller/templates/webhook/webhook_mutating.yaml
@@ -14,3 +14,4 @@ webhooks:
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   sideEffects: None
   reinvocationPolicy: IfNeeded
+  timeoutSeconds: {{ .Values.cosign.timeoutSeconds.mutating }}

--- a/charts/policy-controller/templates/webhook/webhook_mutating.yaml
+++ b/charts/policy-controller/templates/webhook/webhook_mutating.yaml
@@ -14,8 +14,8 @@ webhooks:
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   sideEffects: None
   reinvocationPolicy: IfNeeded
-  {{- if .Values.cosign.timeoutSeconds }}
-  {{- if .Values.cosign.timeoutSeconds.mutating }}
-  timeoutSeconds: {{ .Values.cosign.timeoutSeconds.mutating }}
+  {{- if .Values.cosign.webhookTimeoutSeconds }}
+  {{- if .Values.cosign.webhookTimeoutSeconds.mutating }}
+  timeoutSeconds: {{ .Values.cosign.webhookTimeoutSeconds.mutating }}
   {{- end }}
   {{- end }}

--- a/charts/policy-controller/templates/webhook/webhook_validating.yaml
+++ b/charts/policy-controller/templates/webhook/webhook_validating.yaml
@@ -13,4 +13,8 @@ webhooks:
       namespace: {{ .Release.Namespace }}
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   sideEffects: None
+  {{- if .Values.cosign.timeoutSeconds }}
+  {{- if .Values.cosign.timeoutSeconds.validating }}
   timeoutSeconds: {{ .Values.cosign.timeoutSeconds.validating }}
+  {{- end }}
+  {{- end}}

--- a/charts/policy-controller/templates/webhook/webhook_validating.yaml
+++ b/charts/policy-controller/templates/webhook/webhook_validating.yaml
@@ -13,8 +13,8 @@ webhooks:
       namespace: {{ .Release.Namespace }}
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   sideEffects: None
-  {{- if .Values.cosign.timeoutSeconds }}
-  {{- if .Values.cosign.timeoutSeconds.validating }}
-  timeoutSeconds: {{ .Values.cosign.timeoutSeconds.validating }}
+  {{- if .Values.cosign.webhookTimeoutSeconds }}
+  {{- if .Values.cosign.webhookTimeoutSeconds.validating }}
+  timeoutSeconds: {{ .Values.cosign.webhookTimeoutSeconds.validating }}
   {{- end }}
   {{- end}}

--- a/charts/policy-controller/templates/webhook/webhook_validating.yaml
+++ b/charts/policy-controller/templates/webhook/webhook_validating.yaml
@@ -13,3 +13,4 @@ webhooks:
       namespace: {{ .Release.Namespace }}
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   sideEffects: None
+  timeoutSeconds: {{ .Values.cosign.timeoutSeconds.validating }}

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -39,22 +39,17 @@
           "additionalProperties": false,
           "properties": {
             "mutating": {
-              "default": 10,
               "required": [],
               "title": "mutating",
               "type": "integer"
             },
             "validating": {
-              "default": 10,
               "required": [],
               "title": "validating",
               "type": "integer"
             }
           },
-          "required": [
-            "mutating",
-            "validating"
-          ],
+          "required": [],
           "title": "timeoutSeconds",
           "type": "object"
         },
@@ -67,8 +62,7 @@
       },
       "required": [
         "cosignPub",
-        "webhookName",
-        "timeoutSeconds"
+        "webhookName"
       ],
       "title": "cosign",
       "type": "object"
@@ -576,22 +570,17 @@
           "additionalProperties": false,
           "properties": {
             "defaulting": {
-              "default": 10,
               "required": [],
               "title": "defaulting",
               "type": "integer"
             },
             "validating": {
-              "default": 10,
               "required": [],
               "title": "validating",
               "type": "integer"
             }
           },
-          "required": [
-            "defaulting",
-            "validating"
-          ],
+          "required": [],
           "title": "webhookTimeoutSeconds",
           "type": "object"
         }
@@ -617,8 +606,7 @@
         "volumes",
         "namespaceSelector",
         "registryCaBundle",
-        "webhookNames",
-        "webhookTimeoutSeconds"
+        "webhookNames"
       ],
       "title": "webhook",
       "type": "object"

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -35,7 +35,7 @@
           "title": "cosignPub",
           "type": "string"
         },
-        "timeoutSeconds": {
+        "webhookTimeoutSeconds": {
           "additionalProperties": false,
           "properties": {
             "mutating": {
@@ -50,7 +50,7 @@
             }
           },
           "required": [],
-          "title": "timeoutSeconds",
+          "title": "webhookTimeoutSeconds",
           "type": "object"
         },
         "webhookName": {

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -35,6 +35,12 @@
           "title": "cosignPub",
           "type": "string"
         },
+        "webhookName": {
+          "default": "policy.sigstore.dev",
+          "required": [],
+          "title": "webhookName",
+          "type": "string"
+        },
         "webhookTimeoutSeconds": {
           "additionalProperties": false,
           "properties": {
@@ -52,12 +58,6 @@
           "required": [],
           "title": "webhookTimeoutSeconds",
           "type": "object"
-        },
-        "webhookName": {
-          "default": "policy.sigstore.dev",
-          "required": [],
-          "title": "webhookName",
-          "type": "string"
         }
       },
       "required": [
@@ -206,8 +206,8 @@
               "type": "string"
             },
             "version": {
-              "default": "sha256:f3b57d4c906fcbd7229c3069c055ce2b2862e01106c2b85df1322f1e3a232829",
-              "description": "crane digest ghcr.io/sigstore/policy-controller/policy-controller:v0.11.0",
+              "default": "sha256:6b51f336dec9e9adff29606855dbd2c7910c5eb80d6579795a29cb3844428efc",
+              "description": "crane digest ghcr.io/sigstore/policy-controller/policy-controller:v0.12.0",
               "required": [],
               "title": "version",
               "type": "string"
@@ -570,11 +570,13 @@
           "additionalProperties": false,
           "properties": {
             "defaulting": {
+              "default": 10,
               "required": [],
               "title": "defaulting",
               "type": "integer"
             },
             "validating": {
+              "default": 10,
               "required": [],
               "title": "validating",
               "type": "integer"

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -35,6 +35,29 @@
           "title": "cosignPub",
           "type": "string"
         },
+        "timeoutSeconds": {
+          "additionalProperties": false,
+          "properties": {
+            "mutating": {
+              "default": 10,
+              "required": [],
+              "title": "mutating",
+              "type": "integer"
+            },
+            "validating": {
+              "default": 10,
+              "required": [],
+              "title": "validating",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "mutating",
+            "validating"
+          ],
+          "title": "timeoutSeconds",
+          "type": "object"
+        },
         "webhookName": {
           "default": "policy.sigstore.dev",
           "required": [],
@@ -44,7 +67,8 @@
       },
       "required": [
         "cosignPub",
-        "webhookName"
+        "webhookName",
+        "timeoutSeconds"
       ],
       "title": "cosign",
       "type": "object"
@@ -188,8 +212,8 @@
               "type": "string"
             },
             "version": {
-              "default": "sha256:f291fce5b9c1a69ba54990eda7e0fe4114043b1afefb0f4ee3e6f84ec9ef1605",
-              "description": "crane digest ghcr.io/sigstore/policy-controller/policy-controller:v0.8.2",
+              "default": "sha256:f3b57d4c906fcbd7229c3069c055ce2b2862e01106c2b85df1322f1e3a232829",
+              "description": "crane digest ghcr.io/sigstore/policy-controller/policy-controller:v0.11.0",
               "required": [],
               "title": "version",
               "type": "string"
@@ -547,6 +571,29 @@
           ],
           "title": "webhookNames",
           "type": "object"
+        },
+        "webhookTimeoutSeconds": {
+          "additionalProperties": false,
+          "properties": {
+            "defaulting": {
+              "default": 10,
+              "required": [],
+              "title": "defaulting",
+              "type": "integer"
+            },
+            "validating": {
+              "default": 10,
+              "required": [],
+              "title": "validating",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "defaulting",
+            "validating"
+          ],
+          "title": "webhookTimeoutSeconds",
+          "type": "object"
         }
       },
       "required": [
@@ -570,7 +617,8 @@
         "volumes",
         "namespaceSelector",
         "registryCaBundle",
-        "webhookNames"
+        "webhookNames",
+        "webhookTimeoutSeconds"
       ],
       "title": "webhook",
       "type": "object"

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -19,8 +19,8 @@ webhook:
   name: webhook
   image:
     repository: ghcr.io/sigstore/policy-controller/policy-controller
-    # crane digest ghcr.io/sigstore/policy-controller/policy-controller:v0.11.0
-    version: sha256:f3b57d4c906fcbd7229c3069c055ce2b2862e01106c2b85df1322f1e3a232829
+    # crane digest ghcr.io/sigstore/policy-controller/policy-controller:v0.12.0
+    version: sha256:6b51f336dec9e9adff29606855dbd2c7910c5eb80d6579795a29cb3844428efc
     pullPolicy: IfNotPresent
   env: {}
   extraArgs: {}

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -2,7 +2,7 @@ cosign:
   # add the values in base64 encoded
   cosignPub: ""
   webhookName: "policy.sigstore.dev"
-  # timeoutSeconds:
+  timeoutSeconds: {}
     # mutating: 10
     # validating: 10
 
@@ -73,7 +73,7 @@ webhook:
   webhookNames:
     defaulting: "defaulting.clusterimagepolicy.sigstore.dev"
     validating: "validating.clusterimagepolicy.sigstore.dev"
-  # webhookTimeoutSeconds:
+  webhookTimeoutSeconds: {}
     # defaulting: 10
     # validating: 10
 

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -2,7 +2,7 @@ cosign:
   # add the values in base64 encoded
   cosignPub: ""
   webhookName: "policy.sigstore.dev"
-  timeoutSeconds: {}
+  webhookTimeoutSeconds: {}
     # mutating: 10
     # validating: 10
 

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -2,6 +2,9 @@ cosign:
   # add the values in base64 encoded
   cosignPub: ""
   webhookName: "policy.sigstore.dev"
+  timeoutSeconds:
+    mutating: 10
+    validating: 10
 
 installCRDs: true
 
@@ -70,6 +73,9 @@ webhook:
   webhookNames:
     defaulting: "defaulting.clusterimagepolicy.sigstore.dev"
     validating: "validating.clusterimagepolicy.sigstore.dev"
+  webhookTimeoutSeconds:
+    defaulting: 10
+    validating: 10
 
 leasescleanup:
   image:

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -2,9 +2,9 @@ cosign:
   # add the values in base64 encoded
   cosignPub: ""
   webhookName: "policy.sigstore.dev"
-  timeoutSeconds:
-    mutating: 10
-    validating: 10
+  # timeoutSeconds:
+    # mutating: 10
+    # validating: 10
 
 installCRDs: true
 
@@ -73,9 +73,9 @@ webhook:
   webhookNames:
     defaulting: "defaulting.clusterimagepolicy.sigstore.dev"
     validating: "validating.clusterimagepolicy.sigstore.dev"
-  webhookTimeoutSeconds:
-    defaulting: 10
-    validating: 10
+  # webhookTimeoutSeconds:
+    # defaulting: 10
+    # validating: 10
 
 leasescleanup:
   image:


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Adds optional timeout values. The chart creates 4 webhook configuration objects (2 `ValidatingWebhookConfiguration` and 2 `MutatingWebhookConfiguration`. These are all created with the default `timeoutSeconds` ([docs](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts)) set to 10s. In some cases this is excessive (Kuberentes docs recommend this value to be as short as possible). In other cases user experience the need for longer timeouts, up to 20 seconds. This PR allows users to specify a specific timeout for each of the 4 configurations.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

see for instance https://sigstore.slack.com/archives/C03096V09F1/p1737372057769759

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
