### PR TITLE
bump fulcio chart to point to correct trillian dep

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.6.4
+version: 2.6.5
 appVersion: 1.6.5
 
 keywords:
@@ -19,7 +19,7 @@ maintainers:
 
 dependencies:
   - name: ctlog
-    version: 0.2.60
+    version: 0.3.0
     repository: https://sigstore.github.io/helm-charts
     condition: ctlog.enabled
 

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.6.4](https://img.shields.io/badge/Version-2.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.5](https://img.shields.io/badge/AppVersion-1.6.5-informational?style=flat-square)
+![Version: 2.6.5](https://img.shields.io/badge/Version-2.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.5](https://img.shields.io/badge/AppVersion-1.6.5-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 
@@ -71,7 +71,7 @@ helm uninstall [RELEASE_NAME]
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://sigstore.github.io/helm-charts | ctlog | 0.2.60 |
+| https://sigstore.github.io/helm-charts | ctlog | 0.3.0 |
 
 ## Values
 


### PR DESCRIPTION
when I bumped the charts before, I apparently forgot to bump the trillian dep to `0.3.0`