### PR TITLE
feat: quality of life optional values to leases-cleanup job and webhook deployment

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.9.1
+version: 0.10.0
 appVersion: 0.12.0
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -170,6 +170,7 @@ helm uninstall [RELEASE_NAME]
 | loglevel | string | `"info"` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | webhook.affinity | object | `{}` |  |
+| webhook.automountServiceAccountToken | bool | `true` |  |
 | webhook.configData | object | `{}` |  |
 | webhook.customLabels | object | `{}` |  |
 | webhook.env | object | `{}` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -160,6 +160,7 @@ helm uninstall [RELEASE_NAME]
 | leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |
 | leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
 | leasescleanup.image.version | string | `"latest-dev"` |  |
+| leasescleanup.podSecurityContext.enabled | bool | `false` |  |
 | leasescleanup.resources.limits.cpu | string | `""` |  |
 | leasescleanup.resources.limits.memory | string | `""` |  |
 | leasescleanup.resources.requests.cpu | string | `""` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -172,6 +172,7 @@ helm uninstall [RELEASE_NAME]
 | webhook.configData | object | `{}` |  |
 | webhook.customLabels | object | `{}` |  |
 | webhook.env | object | `{}` |  |
+| webhook.envFrom | object | `{}` |  |
 | webhook.extraArgs | object | `{}` |  |
 | webhook.failurePolicy | string | `"Fail"` |  |
 | webhook.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -189,6 +189,7 @@ helm uninstall [RELEASE_NAME]
 | webhook.podSecurityContext.enabled | bool | `true` |  |
 | webhook.podSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
 | webhook.podSecurityContext.runAsUser | int | `1000` |  |
+| webhook.priorityClass | string | `""` |  |
 | webhook.registryCaBundle | object | `{}` |  |
 | webhook.replicaCount | int | `1` |  |
 | webhook.resources.limits.cpu | string | `"200m"` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
 
 The Helm chart for Policy  Controller
 

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -161,6 +161,7 @@ helm uninstall [RELEASE_NAME]
 | leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
 | leasescleanup.image.version | string | `"latest-dev"` |  |
 | leasescleanup.podSecurityContext.enabled | bool | `false` |  |
+| leasescleanup.priorityClass | string | `""` |  |
 | leasescleanup.resources.limits.cpu | string | `""` |  |
 | leasescleanup.resources.limits.memory | string | `""` |  |
 | leasescleanup.resources.requests.cpu | string | `""` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -160,6 +160,10 @@ helm uninstall [RELEASE_NAME]
 | leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |
 | leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
 | leasescleanup.image.version | string | `"latest-dev"` |  |
+| leasescleanup.resources.limits.cpu | string | `""` |  |
+| leasescleanup.resources.limits.memory | string | `""` |  |
+| leasescleanup.resources.requests.cpu | string | `""` |  |
+| leasescleanup.resources.requests.memory | string | `""` |  |
 | loglevel | string | `"info"` |  |
 | serviceMonitor.enabled | bool | `false` |  |
 | webhook.affinity | object | `{}` |  |

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -157,6 +157,7 @@ helm uninstall [RELEASE_NAME]
 | cosign.webhookTimeoutSeconds | object | `{}` |  |
 | imagePullSecrets | list | `[]` |  |
 | installCRDs | bool | `true` |  |
+| leasescleanup.automountServiceAccountToken | bool | `true` |  |
 | leasescleanup.image.pullPolicy | string | `"IfNotPresent"` |  |
 | leasescleanup.image.repository | string | `"cgr.dev/chainguard/kubectl"` |  |
 | leasescleanup.image.version | string | `"latest-dev"` |  |

--- a/charts/policy-controller/templates/webhook/cleanup-leases.yaml
+++ b/charts/policy-controller/templates/webhook/cleanup-leases.yaml
@@ -24,6 +24,27 @@ spec:
             - /bin/sh
             - -c
             - kubectl delete leases --all --ignore-not-found -n {{ .Release.Namespace }}
+          {{- if .Values.leasescleanup.resources }}
+          resources:
+            {{- if .Values.leasescleanup.resources.limits }}
+            limits:
+              {{- if .Values.leasescleanup.resources.limits.cpu }}
+              cpu: {{ .Values.leasescleanup.resources.limits.cpu }}
+              {{- end }}
+              {{- if .Values.leasescleanup.resources.limits.memory }}
+              memory: {{ .Values.leasescleanup.resources.limits.memory }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.leasescleanup.resources.requests }}
+            requests:
+              {{- if .Values.leasescleanup.resources.requests.cpu }}
+              cpu: {{ .Values.leasescleanup.resources.requests.cpu }}
+              {{- end }}
+              {{- if .Values.leasescleanup.resources.requests.memory }}
+              memory: {{ .Values.leasescleanup.resources.requests.memory }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
       restartPolicy: OnFailure
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/policy-controller/templates/webhook/cleanup-leases.yaml
+++ b/charts/policy-controller/templates/webhook/cleanup-leases.yaml
@@ -16,6 +16,11 @@ spec:
       name: leases-cleanup
     spec:
       serviceAccountName: {{ template "webhook.serviceAccountName" . }}-cleanup
+      {{- if .Values.leasescleanup.automountServiceAccountToken }}
+      automountServiceAccountToken: true
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
       containers:
         - name: kubectl
           image: "{{ template "leases-cleanup.image" .Values.leasescleanup.image }}"

--- a/charts/policy-controller/templates/webhook/cleanup-leases.yaml
+++ b/charts/policy-controller/templates/webhook/cleanup-leases.yaml
@@ -52,6 +52,9 @@ spec:
             {{- end }}
           {{- end }}
       restartPolicy: OnFailure
+      {{- if .Values.leasescleanup.priorityClass }}
+      priorityClassName: {{ .Values.leasescleanup.priorityClass }}
+      {{- end }} 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/policy-controller/templates/webhook/cleanup-leases.yaml
+++ b/charts/policy-controller/templates/webhook/cleanup-leases.yaml
@@ -45,6 +45,12 @@ spec:
               {{- end }}
             {{- end }}
           {{- end }}
+          {{- if .Values.leasescleanup.podSecurityContext.enabled }}
+          securityContext:
+            {{- with .Values.leasescleanup.podSecurityContext }}
+            {{- omit . "enabled" | toYaml | nindent 12 }}
+            {{- end }}
+          {{- end }}
       restartPolicy: OnFailure
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -77,6 +77,17 @@ spec:
           value: "{{ $value }}"
 {{- end }}
 {{- end }}
+{{- if .Values.webhook.envFrom }}
+        envFrom:
+{{- range $configMapName := .Values.webhook.envFrom.configmaps }}
+        - configMapRef:
+          name: "{{ $configMapName }}"
+{{- end }}
+{{- range $secretName := .Values.webhook.envFrom.secrets }}
+        - secretRef:
+          name: "{{ $secretName }}"
+{{- end }}
+{{- end }}
         {{- if or (semverCompare ">= 1.8-0" .Chart.AppVersion) .Values.webhook.extraArgs }}
         args:
         {{- if semverCompare ">= 1.8-0" .Chart.AppVersion }}

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -31,6 +31,9 @@ spec:
       tolerations:
         {{- toYaml .Values.commonTolerations | nindent 8 }}
       serviceAccountName: {{ include "webhook.serviceAccountName" . }}
+      {{- if .Values.webhook.priorityClass }}
+      priorityClassName: {{ .Values.webhook.priorityClass }}
+      {{- end }}
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
       {{- if .Values.webhook.affinity }}

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -31,6 +31,11 @@ spec:
       tolerations:
         {{- toYaml .Values.commonTolerations | nindent 8 }}
       serviceAccountName: {{ include "webhook.serviceAccountName" . }}
+      {{- if .Values.webhook.automountServiceAccountToken }}
+      automountServiceAccountToken: true
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
       {{- if .Values.webhook.priorityClass }}
       priorityClassName: {{ .Values.webhook.priorityClass }}
       {{- end }}

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -93,6 +93,51 @@
           "required": [],
           "title": "image",
           "type": "object"
+        },
+        "resources": {
+          "properties": {
+            "limits": {
+              "properties": {
+                "cpu": {
+                  "default": "",
+                  "required": [],
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "",
+                  "required": [],
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "limits",
+              "type": "object"
+            },
+            "requests": {
+              "properties": {
+                "cpu": {
+                  "default": "",
+                  "required": [],
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "",
+                  "required": [],
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "requests",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "resources",
+          "type": "object"
         }
       },
       "required": [],

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -206,7 +206,13 @@
           "title": "env",
           "type": "object"
         },
+        "envFrom": {
+          "required": [],
+          "title": "envFrom",
+          "type": "object"
+        },
         "extraArgs": {
+          "description": "configmaps:\n  - mycm1\n  - mycm2\nsecrets:\n  - mys1\n  - mys2",
           "required": [],
           "title": "extraArgs",
           "type": "object"

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -94,6 +94,19 @@
           "title": "image",
           "type": "object"
         },
+        "podSecurityContext": {
+          "properties": {
+            "enabled": {
+              "default": false,
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "podSecurityContext",
+          "type": "object"
+        },
         "resources": {
           "properties": {
             "limits": {

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -197,6 +197,12 @@
           "title": "affinity",
           "type": "object"
         },
+        "automountServiceAccountToken": {
+          "default": true,
+          "required": [],
+          "title": "automountServiceAccountToken",
+          "type": "boolean"
+        },
         "configData": {
           "required": [],
           "title": "configData",

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -69,6 +69,12 @@
     },
     "leasescleanup": {
       "properties": {
+        "automountServiceAccountToken": {
+          "default": true,
+          "required": [],
+          "title": "automountServiceAccountToken",
+          "type": "boolean"
+        },
         "image": {
           "properties": {
             "pullPolicy": {

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -107,6 +107,12 @@
           "title": "podSecurityContext",
           "type": "object"
         },
+        "priorityClass": {
+          "default": "",
+          "required": [],
+          "title": "priorityClass",
+          "type": "string"
+        },
         "resources": {
           "properties": {
             "limits": {

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -374,6 +374,13 @@
           "title": "podSecurityContext",
           "type": "object"
         },
+        "priorityClass": {
+          "default": "",
+          "description": "defaulting: 10\nvalidating: 10",
+          "required": [],
+          "title": "priorityClass",
+          "type": "string"
+        },
         "registryCaBundle": {
           "required": [],
           "title": "registryCaBundle",

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -82,6 +82,13 @@ leasescleanup:
     repository: cgr.dev/chainguard/kubectl
     version: latest-dev
     pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: ""
+      memory: ""
+    requests:
+      cpu: ""
+      memory: ""
 
 ## common node selector for all the pods
 commonNodeSelector: {}

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -106,6 +106,7 @@ leasescleanup:
     # capabilities:
     #   drop:
     #     - ALL
+  automountServiceAccountToken: true
 
 ## common node selector for all the pods
 commonNodeSelector: {}

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -78,6 +78,7 @@ webhook:
     # validating: 10
 
 leasescleanup:
+  priorityClass: ""
   image:
     repository: cgr.dev/chainguard/kubectl
     version: latest-dev

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -23,6 +23,13 @@ webhook:
     version: sha256:6b51f336dec9e9adff29606855dbd2c7910c5eb80d6579795a29cb3844428efc
     pullPolicy: IfNotPresent
   env: {}
+  envFrom: {}
+    # configmaps:
+    #   - mycm1
+    #   - mycm2
+    # secrets:
+    #   - mys1
+    #   - mys2
   extraArgs: {}
   resources:
     limits:

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -84,6 +84,7 @@ webhook:
     # defaulting: 10
     # validating: 10
   priorityClass: ""
+  automountServiceAccountToken: true
 
 leasescleanup:
   priorityClass: ""

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -89,6 +89,14 @@ leasescleanup:
     requests:
       cpu: ""
       memory: ""
+  podSecurityContext:
+    enabled: false
+    # allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem: true
+    # runAsUser: 1000
+    # capabilities:
+    #   drop:
+    #     - ALL
 
 ## common node selector for all the pods
 commonNodeSelector: {}

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -76,6 +76,7 @@ webhook:
   webhookTimeoutSeconds: {}
     # defaulting: 10
     # validating: 10
+  priorityClass: ""
 
 leasescleanup:
   priorityClass: ""


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

this PR adds the following optional values, which allows to easily follow Kubernetes best practices/provide more flexibility

* leases cleanup job:
  * [x] `priorityClass`
  * [x]  `automountServiceAccountToken`
  * [x] `podSecurityContext`
  * [x] `resources`
* deployment webhook:
  * [x] `priorityClass`
  * [x] `automountServiceAccountToken`
  * [x] `envFrom`

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->
 
 Proof of work
 
 ```bash
helm template . \
--set webhook.envFrom.configmaps={cm1} \
--set 'webhook.envFrom.secrets={secr1,secr2}' \
--set webhook.priorityClass=critical \
--set webhook.automountServiceAccountToken=true \
--set leasescleanup.priorityClass=critical \
--set leasescleanup.automountServiceAccountToken=false \
--set leasescleanup.podSecurityContext.enabled=false \
--set leasescleanup.podSecurityContext.runAsUser=12345 \
--set leasescleanup.resources.requests.memory=12345Mi \
--set leasescleanup.resources.limits.cpu=12345m \
| grep -C 3 'leases-cleanup\|deployment_webhook.yaml\|cm1\|secr1\|secr2\|critical\|automountServiceAccountToken\|12345'
 ```
 
<img width="977" alt="Screenshot 2025-02-14 at 10 29 01" src="https://github.com/user-attachments/assets/add2f3b8-3dd6-4cb9-97a2-d50011136c5e" />


## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
