### PR TITLE
add support for cloud sql IAM user in rekor chart

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.6.3
+version: 1.6.4
 appVersion: 1.3.9
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.6.3](https://img.shields.io/badge/Version-1.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.9](https://img.shields.io/badge/AppVersion-1.3.9-informational?style=flat-square)
+![Version: 1.6.4](https://img.shields.io/badge/Version-1.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.9](https://img.shields.io/badge/AppVersion-1.3.9-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 

--- a/charts/rekor/templates/_helpers.tpl
+++ b/charts/rekor/templates/_helpers.tpl
@@ -349,7 +349,11 @@ Server Arguments
 {{- end }}
 {{- if eq (.Values.server.searchIndex).storageProvider "mysql" }}
 {{- if and (.Values.mysql.gcp.enabled) (.Values.mysql.gcp.cloudsql.unixDomainSocket.enabled) }}
+{{- if .Values.mysql.gcp.cloudsql.iamUsername }}
+- {{ printf "--search_index.mysql.dsn=$(%s)@unix(%s/%s)/$(MYSQL_DATABASE)?parseTime=true" .Values.mysql.gcp.cloudsql.iamUsername .Values.mysql.gcp.cloudsql.unixDomainSocket.path .Values.mysql.gcp.instance | quote }}
+{{- else }}
 - {{ printf "--search_index.mysql.dsn=$(MYSQL_USER):$(MYSQL_PASSWORD)@unix(%s/%s)/$(MYSQL_DATABASE)?parseTime=true" .Values.mysql.gcp.cloudsql.unixDomainSocket.path .Values.mysql.gcp.instance | quote }}
+{{- end }}
 {{- else }}
 - "--search_index.mysql.dsn=$(MYSQL_USER):$(MYSQL_PASSWORD)@tcp($(MYSQL_HOSTNAME):$(MYSQL_PORT))/$(MYSQL_DATABASE)"
 {{- end }}

--- a/charts/rekor/templates/server/deployment.yaml
+++ b/charts/rekor/templates/server/deployment.yaml
@@ -60,6 +60,9 @@ spec:
           image: "{{ template "rekor.image" .Values.mysql.gcp.cloudsql }}"
           command:
             - "/cloud-sql-proxy"
+            {{- if (((.Values.mysql).gcp).cloudsql).iamUsername }}
+            - "--auto-iam-authn"
+            {{- end }}
             {{- if ((((.Values.mysql).gcp).cloudsql).unixDomainSocket).enabled }}
             - "--unix-socket"
             - {{ .Values.mysql.gcp.cloudsql.unixDomainSocket.path | quote }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -266,6 +266,9 @@
                         "instance": {
                             "type": "string"
                         },
+                        "iamUsername": {
+                            "type": "string"
+                        },
                         "scaffoldSQLProxy": {
                             "properties": {
                                 "registry": {


### PR DESCRIPTION
supports specifying a Cloud SQL IAM username which requires a different DSN and cloud-sql-proxy command line argument