### PR TITLE
Fix default trillian name

### DIFF
--- a/charts/ctlog/Chart.yaml
+++ b/charts/ctlog/Chart.yaml
@@ -4,7 +4,7 @@ description: Certificate Log
 
 type: application
 
-version: 0.2.60
+version: 0.2.61
 appVersion: 0.7.18
 
 keywords:

--- a/charts/ctlog/README.md
+++ b/charts/ctlog/README.md
@@ -121,7 +121,7 @@ Certificate Log
 | server.serviceAccount.mountToken | bool | `false` |  |
 | server.serviceAccount.name | string | `""` |  |
 | server.tolerations | list | `[]` |  |
-| trillian.logServer.name | string | `"trillian-logserver"` |  |
+| trillian.logServer.name | string | `"trillian-log-server"` |  |
 | trillian.logServer.portRPC | int | `8091` |  |
 | trillian.namespace | string | `"trillian-system"` |  |
 

--- a/charts/ctlog/values.yaml
+++ b/charts/ctlog/values.yaml
@@ -154,7 +154,7 @@ createctconfig:
 trillian:
   namespace: trillian-system
   logServer:
-    name: trillian-logserver
+    name: trillian-log-server
     portRPC: 8091
 
 # Force namespace of namespaced resources

--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -19,7 +19,7 @@ maintainers:
 
 dependencies:
   - name: ctlog
-    version: 0.2.60
+    version: 0.2.61
     repository: https://sigstore.github.io/helm-charts
     condition: ctlog.enabled
 


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Change default name name of trillian-log-server

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
