### PR TITLE
Fix invalid field path for configMapRef and secretRef in envFrom

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.10.0
+version: 0.10.1
 appVersion: 0.12.0
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
+![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
 
 The Helm chart for Policy  Controller
 

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -86,11 +86,11 @@ spec:
         envFrom:
 {{- range $configMapName := .Values.webhook.envFrom.configmaps }}
         - configMapRef:
-          name: "{{ $configMapName }}"
+            name: "{{ $configMapName }}"
 {{- end }}
 {{- range $secretName := .Values.webhook.envFrom.secrets }}
         - secretRef:
-          name: "{{ $secretName }}"
+            name: "{{ $secretName }}"
 {{- end }}
 {{- end }}
         {{- if or (semverCompare ">= 1.8-0" .Chart.AppVersion) .Values.webhook.extraArgs }}


### PR DESCRIPTION
## Description of the change

In https://github.com/sigstore/helm-charts/pull/894, the `envFrom` field was introduced in the values file, but its format is incorrect, resulting in the following error.

```
STDERR:
  W0312 10:58:39.902314   15451 warnings.go:70] unknown field "spec.template.spec.containers[0].envFrom[0].name"
  Error: UPGRADE FAILED: cannot patch "policy-controller-webhook" with kind Deployment: Deployment.apps "policy-controller-webhook" is invalid: spec.template.spec.containers[0].envFrom: Invalid value: "": must specify one of: `configMapRef` or `secretRef`
```

As stated in the [official documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables), the `name` field of `configMapRef` and `secretRef` requires two levels of indentation.

## Existing or Associated Issue(s)

None

## Additional Information

None

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
