### PR TITLE
tsa: don't print null values into config map

### DIFF
--- a/charts/tsa/Chart.yaml
+++ b/charts/tsa/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.2.5
 
 keywords:

--- a/charts/tsa/README.md
+++ b/charts/tsa/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.5](https://img.shields.io/badge/AppVersion-1.2.5-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.5](https://img.shields.io/badge/AppVersion-1.2.5-informational?style=flat-square)
 
 Timestamp Authority issuing RFC3161 signed timestamps.
 
@@ -104,7 +104,7 @@ helm uninstall [RELEASE_NAME]
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"ghcr.io"` |  |
 | server.image.repository | string | `"sigstore/timestamp-server"` |  |
-| server.image.version | string | `"sha256:67cf36ea6ec081d664c5701c0447af1f0af02529a2b9117a358da0cd7b0f83be"` | v1.2.5 |
+| server.image.version | string | `"v1.2.5@sha256:67cf36ea6ec081d664c5701c0447af1f0af02529a2b9117a358da0cd7b0f83be"` | v1.2.5 |
 | server.ingress.http.annotations | object | `{}` |  |
 | server.ingress.http.className | string | `"nginx"` |  |
 | server.ingress.http.enabled | bool | `true` |  |

--- a/charts/tsa/templates/tsa-configmap.yaml
+++ b/charts/tsa/templates/tsa-configmap.yaml
@@ -16,4 +16,6 @@ data:
   {{- if (eq .Values.server.args.signer "file")}}
   chain.pem: {{.Values.server.args.cert_chain | quote }}
   {{- end }}
+  {{- if .Values.server.args.creds }}
   cloud_credentials: {{.Values.server.args.creds | quote }}
+  {{- end }}

--- a/charts/tsa/values.yaml
+++ b/charts/tsa/values.yaml
@@ -17,7 +17,7 @@ server:
     pullPolicy: IfNotPresent
     # crane digest ghcr.io/sigstore/timestamp-server:v1.2.5
     # -- v1.2.5
-    version: sha256:67cf36ea6ec081d664c5701c0447af1f0af02529a2b9117a358da0cd7b0f83be
+    version: v1.2.5@sha256:67cf36ea6ec081d664c5701c0447af1f0af02529a2b9117a358da0cd7b0f83be
   args:
     port: 5555
     # Valid values: tink, kms, file


### PR DESCRIPTION
we're seeing https://github.com/argoproj/argo-cd/issues/15566 now because an empty value in a config map gets removed but introduces never-ending sync loop in argo