### PR TITLE
TSA: remove hardcoded credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,6 @@ NOTE: The public key that was used to sign a particular chart may not be identic
 * [scaffold](charts/scaffold)
 * [sigstore-prober](charts/sigstore-prober)
 * [trillian](charts/trillian)
+* [tsa](charts/tsa)
+* [tuf](charts/tuf)
 * [updatetree](charts/updatetree)

--- a/charts/tsa/Chart.yaml
+++ b/charts/tsa/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 1.1.3
+version: 1.1.4
 appVersion: 1.2.5
 
 keywords:

--- a/charts/tsa/README.md
+++ b/charts/tsa/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.5](https://img.shields.io/badge/AppVersion-1.2.5-informational?style=flat-square)
+![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.5](https://img.shields.io/badge/AppVersion-1.2.5-informational?style=flat-square)
 
 Timestamp Authority issuing RFC3161 signed timestamps.
 
@@ -100,7 +100,7 @@ helm uninstall [RELEASE_NAME]
 | server.args.tink_enc_keyset | string | `"keyset"` |  |
 | server.args.tink_hcvault_token | string | `"token"` |  |
 | server.args.tink_key_resource | string | `"resource"` |  |
-| server.env.GOOGLE_APPLICATION_CREDENTIALS | string | `"/etc/tsa-config/cloud_credentials"` |  |
+| server.env.GOOGLE_APPLICATION_CREDENTIALS | string | `""` |  |
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"ghcr.io"` |  |
 | server.image.repository | string | `"sigstore/timestamp-server"` |  |

--- a/charts/tsa/templates/tsa-deployment.yaml
+++ b/charts/tsa/templates/tsa-deployment.yaml
@@ -37,20 +37,18 @@ spec:
             {{- if eq .Values.server.args.signer "tink" }}
             - "--tink-key-resource={{ required "Tink key for signing timestamp responses is required" .Values.server.args.tink_key_resource }}"
             - "--tink-keyset-path=/etc/tsa-config/tink.keyset.enc"
-            - "--certificate-chain-path=/etc/tsa-config/chain.pem"
             {{- if hasPrefix "hcvault://" .Values.server.args.tink_key_resource }}
             - "--tink-hcvault-token={{ required "Tink authentication token for Hashicorp Vault API is required" .Values.server.args.tink_hcvault_token }}"
             {{- end }}
             {{- end }}
             {{- if eq .Values.server.args.signer "kms" }}
             - "--kms-key-resource={{ required "KMS key for signing timestamp responses is required" .Values.server.args.kms_key_resource }}"
-            - "--certificate-chain-path=/etc/tsa-config/chain.pem"
             {{- end }}
             {{- if eq .Values.server.args.signer "file" }}
             - "--file-signer-key-path=/var/run/tsa-secrets/key.pem"
             - "--file-signer-passwd=$(PASSWORD)"
-            - "--certificate-chain-path=/etc/tsa-config/chain.pem"
             {{- end }}
+            - "--certificate-chain-path=/etc/tsa-config/chain.pem"
             {{- if .Values.server.logging.production }}
             - "--log-type=prod"
             {{- end -}}

--- a/charts/tsa/values.yaml
+++ b/charts/tsa/values.yaml
@@ -10,7 +10,8 @@ server:
   logging:
     production: false
   env:
-    GOOGLE_APPLICATION_CREDENTIALS: /etc/tsa-config/cloud_credentials
+    # Credentials file read by kms/tink if set. Unset by default
+    GOOGLE_APPLICATION_CREDENTIALS: ""
   image:
     registry: ghcr.io
     repository: sigstore/timestamp-server


### PR DESCRIPTION
There's nothing urgent here but it allows removing `GOOGLE_APPLICATION_CREDENTIALS` from public good instance scaffold.

* tsa
   *  Don't hard code GOOGLE_APPLICATION_CREDENTIALS. I left the env variable in there since I think it may be useful in other use cases
   * remove a bit of repetition in tsa-deployment
   * bump version
* README: Add missing charts

Fixes #940