### PR TITLE
bump prober to v0.7.22, support probing tsa

### DIFF
--- a/charts/sigstore-prober/Chart.yaml
+++ b/charts/sigstore-prober/Chart.yaml
@@ -4,8 +4,8 @@ description: Sigstore API Endpoint Prober
 
 type: application
 
-version: 0.0.35
-appVersion: 0.7.21
+version: 0.0.36
+appVersion: 0.7.22
 
 
 keywords:
@@ -21,4 +21,4 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: sigstore-prober
-      image: ghcr.io/sigstore/scaffolding/prober:v0.7.21@sha256:74a2e4f962e73b64460bf2f91818919b25802791fd39b95779f1bb8adad4e798
+      image: ghcr.io/sigstore/scaffolding/prober:v0.7.22@sha256:6b9b02d9238f83fc6f9a14ba935cb8cab3d8b436838619e9b61429a6b9181fc9

--- a/charts/sigstore-prober/README.md
+++ b/charts/sigstore-prober/README.md
@@ -1,6 +1,6 @@
 # sigstore-prober
 
-![Version: 0.0.35](https://img.shields.io/badge/Version-0.0.35-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.21](https://img.shields.io/badge/AppVersion-0.7.21-informational?style=flat-square)
+![Version: 0.0.36](https://img.shields.io/badge/Version-0.0.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.22](https://img.shields.io/badge/AppVersion-0.7.22-informational?style=flat-square)
 
 Sigstore API Endpoint Prober
 
@@ -30,8 +30,9 @@ Sigstore API Endpoint Prober
 | spec.args.rekorHost | string | `"https://rekor.sigstore.dev"` |  |
 | spec.args.rekorRequests | list | `[]` |  |
 | spec.args.trustRekorAPIPublicKey | bool | `false` |  |
+| spec.args.tsaHost | string | `"https://timestamp.sigstore.dev"` |  |
 | spec.args.writeProber | bool | `false` |  |
-| spec.image | string | `"ghcr.io/sigstore/scaffolding/prober:v0.7.21@sha256:74a2e4f962e73b64460bf2f91818919b25802791fd39b95779f1bb8adad4e798"` |  |
+| spec.image | string | `"ghcr.io/sigstore/scaffolding/prober:v0.7.22@sha256:6b9b02d9238f83fc6f9a14ba935cb8cab3d8b436838619e9b61429a6b9181fc9"` |  |
 | spec.imagePullPolicy | string | `"Always"` |  |
 | spec.matchLabels.app | string | `"sigstore-prober"` |  |
 | spec.replicaCount | int | `1` |  |

--- a/charts/sigstore-prober/templates/_helpers.tpl
+++ b/charts/sigstore-prober/templates/_helpers.tpl
@@ -31,6 +31,9 @@ Create args for sigstore prober components
 {{- if .Values.spec.args.fulcioGrpcHost }}
 - "-fulcio-grpc-url={{ .Values.spec.args.fulcioGrpcHost }}"
 {{- end }}
+{{- if .Values.spec.args.tsaHost }}
+- "-tsa-url={{ .Values.spec.args.tsaHost }}"
+{{- end }}
 {{- if .Values.spec.args.writeProber }}
 - "-write-prober={{ .Values.spec.args.writeProber }}"
 {{- end }}

--- a/charts/sigstore-prober/values.schema.json
+++ b/charts/sigstore-prober/values.schema.json
@@ -64,6 +64,9 @@
                         "trustRekorAPIPublicKey": {
                             "type": "boolean"
                         },
+                        "tsaHost": {
+                            "type": "string"
+                        },
                         "writeProber": {
                             "type": "boolean"
                         }

--- a/charts/sigstore-prober/values.yaml
+++ b/charts/sigstore-prober/values.yaml
@@ -6,7 +6,7 @@ serviceAccount:
   create: false
 spec:
   replicaCount: 1
-  image: ghcr.io/sigstore/scaffolding/prober:v0.7.21@sha256:74a2e4f962e73b64460bf2f91818919b25802791fd39b95779f1bb8adad4e798
+  image: ghcr.io/sigstore/scaffolding/prober:v0.7.22@sha256:6b9b02d9238f83fc6f9a14ba935cb8cab3d8b436838619e9b61429a6b9181fc9
   imagePullPolicy: Always
   matchLabels:
     app: sigstore-prober
@@ -21,6 +21,7 @@ spec:
     fulcioHost: https://fulcio.sigstore.dev
     fulcioGrpcHost: fulcio.sigstore.dev
     rekorHost: https://rekor.sigstore.dev
+    tsaHost: https://timestamp.sigstore.dev
     frequency: 10
     writeProber: false
     rekorRequests: []


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
