### PR TITLE
specify each chart independently for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,51 @@ updates:
           - "patch"
   - package-ecosystem: "helm"
     directories:
-      - "/charts/**"
+      - "/charts/ctlog"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "helm"
+    directories:
+      - "/charts/fulcio"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "helm"
+    directories:
+      - "/charts/policy-controller"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "helm"
+    directories:
+      - "/charts/rekor"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "helm"
+    directories:
+      - "/charts/scaffold"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "helm"
+    directories:
+      - "/charts/sigstore-prober"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "helm"
+    directories:
+      - "/charts/trillian"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "helm"
+    directories:
+      - "/charts/tsa"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "helm"
+    directories:
+      - "/charts/tuf"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "helm"
+    directories:
+      - "/charts/updatetree"
     schedule:
       interval: weekly


### PR DESCRIPTION
[previous approach with glob didn't sit well](https://github.com/sigstore/helm-charts/actions/runs/14431885758/job/40467638371) with ol' dependabot