### PR TITLE
trillian: values schema for envCredentials to be an array

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.3.3
+version: 0.3.4
 appVersion: 1.7.1
 
 keywords:

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
@@ -190,4 +190,4 @@ helm uninstall [RELEASE_NAME]
 | namespace.name | string | `"trillian-system"` |  |
 | quotaSystem.driver | string | `"mysql"` |  |
 | storageSystem.driver | string | `"mysql"` |  |
-| storageSystem.envCredentials | string | `nil` |  |
+| storageSystem.envCredentials | list | `[]` |  |

--- a/charts/trillian/values.schema.json
+++ b/charts/trillian/values.schema.json
@@ -697,7 +697,7 @@
                     "type": "string"
                 },
                 "envCredentials": {
-                    "type": ["string", "null"]
+                    "type": ["array", "string", "null"]
                 }
             },
             "type": "object"

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -20,7 +20,7 @@ initContainerImage:
 
 storageSystem:
   driver: mysql
-  envCredentials: null
+  envCredentials: []
 quotaSystem:
   driver: mysql
 


### PR DESCRIPTION
## Description of the change

This changes the values schema for `trillian.storageSystem.envCredentials` to a more suitable type.

## Existing or Associated Issue(s)

N/A

## Additional Information

This var is rendered as the `env:` for the `trillian-log-signer` and `trillian-log-server` deployments. The default value is something like this: https://github.com/sigstore/helm-charts/blob/main/charts/trillian/templates/_helpers.tpl#L354-L377. It used to be able to be done in previous versions when there was no strict typing.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
