### PR TITLE
Add optional gRPC TLS certificate and key for rekor-tiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
 
       - name: Install Ingress Controller
-        run: "helm install ingress-nginx/ingress-nginx --generate-name --set controller.service.type='NodePort' --set controller.admissionWebhooks.enabled=false"
+        run: "helm install ingress-nginx/ingress-nginx --generate-name --set controller.service.type='NodePort' --set controller.admissionWebhooks.enabled=false --set controller.progressDeadlineSeconds=30"
 
       - name: Run chart-testing (install)
         run: ct install --config ct-install.yaml

--- a/charts/rekor-tiles/Chart.yaml
+++ b/charts/rekor-tiles/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rekor-tiles
 description: Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 type: application
-version: 0.2.5
-appVersion: "0.1.1"
+version: 0.2.6
+appVersion: "0.1.2"
 keywords:
   - security
   - transparency logs
@@ -16,4 +16,4 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: rekor-tiles
-      image: ghcr.io/sigstore/rekor-tiles:v0.1.1@sha256:0a35d562bb1e52385df2143e02e8c6da91ffeaba426ae00c24745a20d22932f8
+      image: ghcr.io/sigstore/rekor-tiles:v0.1.2@sha256:6b8858b5ead0e28256ea34a9f5ad879c8ec9a3d3d782753e5fa41090b6803f61

--- a/charts/rekor-tiles/README.md
+++ b/charts/rekor-tiles/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
 
 Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 
@@ -61,7 +61,7 @@ If using Tink or another KMS, provide the KMS configuration through values.yaml.
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |
 | image.repository | string | `"sigstore/rekor-tiles"` |  |
-| image.version | string | `"v0.1.1@sha256:0a35d562bb1e52385df2143e02e8c6da91ffeaba426ae00c24745a20d22932f8"` |  |
+| image.version | string | `"v0.1.2@sha256:6b8858b5ead0e28256ea34a9f5ad879c8ec9a3d3d782753e5fa41090b6803f61"` |  |
 | imagePullSecrets | list | `[]` |  |
 | livenessProbe.httpGet.path | string | `"/healthz"` |  |
 | livenessProbe.httpGet.port | int | `3000` |  |
@@ -85,6 +85,7 @@ If using Tink or another KMS, provide the KMS configuration through values.yaml.
 | server.extraArgs | list | `[]` |  |
 | server.gcp | object | `{}` |  |
 | server.grpc.port | string | `"3001"` |  |
+| server.grpcSvcTLS | object | `{}` |  |
 | server.hostname | string | `"localhost"` |  |
 | server.http.metricsPort | string | `"2112"` |  |
 | server.http.port | string | `"3000"` |  |

--- a/charts/rekor-tiles/templates/_helpers.tpl
+++ b/charts/rekor-tiles/templates/_helpers.tpl
@@ -126,6 +126,10 @@ Server Arguments
 {{- if .Values.server.readOnly }}
 - "--read-only"
 {{- end }}
+{{- if .Values.server.grpcSvcTLS }}
+- "--grpc-tls-cert-file=/var/run/grpc-tls/cert.pem"
+- "--grpc-tls-key-file=/var/run/grpc-tls/key.pem"
+{{- end }}
 {{- if .Values.server.signer }}
 {{- if (.Values.server.signer.file).path }}
 - {{ printf "--signer-filepath=%s" .Values.server.signer.file.path | quote }}

--- a/charts/rekor-tiles/templates/deployment.yaml
+++ b/charts/rekor-tiles/templates/deployment.yaml
@@ -65,6 +65,11 @@ spec:
               mountPath: {{ (.Values.server.signer.file.secret).mountPath }}
               readOnly: true
 {{- end }}
+{{- if .Values.server.grpcSvcTLS }}
+            - name: grpc-tls
+              mountPath: /var/run/grpc-tls
+              readOnly: true
+{{- end }}
 {{- if .Values.server.signer.tink }}
             - name: tink-config
               mountPath: /etc/tink-config
@@ -79,6 +84,16 @@ spec:
             items:
               - key: {{ (.Values.server.signer.file.secret).key }}
                 path: {{ (.Values.server.signer.file.secret).mountSubPath }}
+{{- end }}
+{{- if .Values.server.grpcSvcTLS }}
+        - name: grpc-tls
+          secret:
+            secretName: {{ .Values.server.grpcSvcTLS.secretName }}
+            items:
+              - key: {{ .Values.server.grpcSvcTLS.certField }}
+                path: cert.pem
+              - key: {{ .Values.server.grpcSvcTLS.keyField }}
+                path: key.pem
 {{- end }}
 {{- if .Values.server.signer.tink }}
         - name: tink-config

--- a/charts/rekor-tiles/values.yaml
+++ b/charts/rekor-tiles/values.yaml
@@ -9,8 +9,8 @@ image:
   repository: sigstore/rekor-tiles
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  # crane digest ghcr.io/sigstore/rekor-tiles:v0.1.1
-  version: v0.1.1@sha256:0a35d562bb1e52385df2143e02e8c6da91ffeaba426ae00c24745a20d22932f8
+  # crane digest ghcr.io/sigstore/rekor-tiles:v0.1.2
+  version: v0.1.2@sha256:6b8858b5ead0e28256ea34a9f5ad879c8ec9a3d3d782753e5fa41090b6803f61
 
 namespace:
   create: false
@@ -110,6 +110,7 @@ server:
     metricsPort: "2112"
   serverConfig: {}
   readOnly: false
+  grpcSvcTLS: {}
   signer: {}
     # file:
     #   path: /pki/signer.pem


### PR DESCRIPTION
In GCP deployments, gRPC requires a TLS connection. This PR adds a volume to store TLS files, which for the public deployment will come from an ExternalSecrets config.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
