### PR TITLE
trillian: add log signer etcd servers to values

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.3.7
+version: 0.3.8
 appVersion: 1.7.2
 
 keywords:

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.3.7](https://img.shields.io/badge/Version-0.3.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 0.3.8](https://img.shields.io/badge/Version-0.3.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
@@ -94,6 +94,7 @@ helm uninstall [RELEASE_NAME]
 | logServer.tolerations | list | `[]` |  |
 | logSigner.affinity | object | `{}` |  |
 | logSigner.enabled | bool | `true` |  |
+| logSigner.etcdServers | list | `[]` |  |
 | logSigner.extraArgs | list | `[]` |  |
 | logSigner.forceMaster | bool | `true` |  |
 | logSigner.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/trillian/templates/_helpers.tpl
+++ b/charts/trillian/templates/_helpers.tpl
@@ -228,6 +228,9 @@ Log Signer Arguments
 - {{ printf "--rpc_endpoint=0.0.0.0:%d" (.Values.logSigner.portRPC | int) | quote }}
 - {{ printf "--http_endpoint=0.0.0.0:%d" (.Values.logSigner.portHTTP | int) | quote }}
 - {{ printf "--force_master=%t" (ne .Values.logSigner.forceMaster false) | quote }}
+{{- if and (eq .Values.logSigner.forceMaster false) (.Values.logSigner.etcdServers) }}
+- {{ printf "--etcd_servers=%s" (join "," .Values.logSigner.etcdServers) | quote }}
+{{- end }}
 - "--alsologtostderr"
 {{-  range .Values.logSigner.extraArgs }}
 - {{ . | quote }}

--- a/charts/trillian/values.schema.json
+++ b/charts/trillian/values.schema.json
@@ -221,6 +221,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "etcdServers": {
+                    "type": "array"
+                },
                 "extraArgs": {
                     "type": "array"
                 },

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -168,6 +168,7 @@ logSigner:
   replicaCount: 1
   name: log-signer
   forceMaster: true
+  etcdServers: []
   portRPC: 8091
   portHTTP: 8090
   image:


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

Add `etcdServers` to values.yaml for high availability log signer setup

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 Workaround is to include `--etcd_servers` in `extraArgs`

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
