### PR TITLE
fix: policy-controller imagePullSecrets for leanup-leases job

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.10.3
+version: 0.10.4
 appVersion: 0.13.0
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.10.3](https://img.shields.io/badge/Version-0.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.0](https://img.shields.io/badge/AppVersion-0.13.0-informational?style=flat-square)
+![Version: 0.10.4](https://img.shields.io/badge/Version-0.10.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.0](https://img.shields.io/badge/AppVersion-0.13.0-informational?style=flat-square)
 
 The Helm chart for Policy  Controller
 

--- a/charts/policy-controller/templates/webhook/cleanup-leases.yaml
+++ b/charts/policy-controller/templates/webhook/cleanup-leases.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       name: leases-cleanup
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "webhook.serviceAccountName" . }}-cleanup
       {{- if .Values.leasescleanup.automountServiceAccountToken }}
       automountServiceAccountToken: true


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

Closes #1007

When using the Value:
```
imagePullSecrets:
  - name: pull-secret
```
This only is rendered for the Deployment webhook in [policy-controller/templates/webhook/deployment_webhook.yaml](https://github.com/sigstore/helm-charts/blob/main/charts/policy-controller/templates/webhook/deployment_webhook.yaml#L27-L30) but not for the job [policy-controller/templates/webhook/cleanup-leases.yaml](https://github.com/sigstore/helm-charts/blob/main/charts/policy-controller/templates/webhook/cleanup-leases.yaml).  Failing if your registry requires authentication. 


## Existing or Associated Issue(s)

<!-- List any related issues. -->
policy-controller leanup-leases job missing imagePullSecrets support #1007

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
