### PR TITLE
Conditionally set Rekor Redis argument flags

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.6.12
+version: 1.6.13
 appVersion: 1.3.10
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.6.12](https://img.shields.io/badge/Version-1.6.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.10](https://img.shields.io/badge/AppVersion-1.3.10-informational?style=flat-square)
+![Version: 1.6.13](https://img.shields.io/badge/Version-1.6.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.10](https://img.shields.io/badge/AppVersion-1.3.10-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 

--- a/charts/rekor/templates/_helpers.tpl
+++ b/charts/rekor/templates/_helpers.tpl
@@ -157,7 +157,11 @@ Define the rekor.namespace template if set with forceNamespace or .Release.Names
 Return the hostname for redis
 */}}
 {{- define "redis.hostname" -}}
+{{- if .Values.redis.enabled -}}
 {{- default (include "rekor.redis.fullname" .) .Values.redis.hostname }}
+{{- else -}}
+{{- .Values.redis.hostname -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -342,8 +346,10 @@ Server Arguments
 - {{ printf "--trillian_log_server.address=%s.%s" .Values.trillian.logServer.name .Values.trillian.forceNamespace | quote }}
 - {{ printf "--trillian_log_server.port=%d" (.Values.trillian.logServer.portRPC | int) | quote }}
 - {{ printf "--trillian_log_server.sharding_config=%s/%s" .Values.server.sharding.mountPath .Values.server.sharding.filename | quote }}
+{{- if include "redis.hostname" . }}
 - {{ printf "--redis_server.address=%s" (include "redis.hostname" .) | quote }}
 - {{ printf "--redis_server.port=%d" (.Values.redis.port | int) | quote }}
+{{- end }}
 {{- if (.Values.server.searchIndex).storageProvider }}
 - {{ printf "--search_index.storage_provider=%s" (.Values.server.searchIndex.storageProvider) | quote }}
 {{- end }}


### PR DESCRIPTION
This changes the logic for how redis.hostname is set. Either Redis is deployed via K8s, at which point the hostname is either set to the fullname by default or the provided hostname, or Redis is externally managed at which point the hostname is set to the provided hostname. The flags to Rekor will only be set when hostname is not empty, so they will not be set if Redis is disabled or an empty hostname is provided, which is the default.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
