### PR TITLE
make rbac object names unique

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.3.9
+version: 0.3.10
 appVersion: 1.7.2
 
 keywords:

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 

--- a/charts/trillian/templates/trillian-log-signer/rbac.yaml
+++ b/charts/trillian/templates/trillian-log-signer/rbac.yaml
@@ -2,7 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: trillian-leader-election
+  name: {{ printf "%s-election" (include "trillian.logSigner.fullname" .) }}
+  labels:
+    {{- include "trillian.logSigner.labels" . | nindent 4 }}
 {{ include "trillian.namespace" . | indent 2 }}
 rules:
 - apiGroups: ["coordination.k8s.io"]
@@ -12,13 +14,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: trillian-leader-election-binding
+  name: {{ printf "%s-election-binding" (include "trillian.logSigner.fullname" .) }}
+  labels:
+    {{- include "trillian.logSigner.labels" . | nindent 4 }}
 {{ include "trillian.namespace" . | indent 2 }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "trillian.serviceAccountName.logSigner" . }}
 roleRef:
   kind: Role
-  name: trillian-leader-election
+  name: {{ printf "%s-election" (include "trillian.logSigner.fullname" .) }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
the hardcoded names previously used caused an overlap when multiple versions of the same chart were deployed into the same namespace.