### PR TITLE
Add graceful shutdown settings for rekor-tiles

### DIFF
--- a/charts/rekor-tiles/Chart.yaml
+++ b/charts/rekor-tiles/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rekor-tiles
 description: Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: "0.1.8"
 keywords:
   - security

--- a/charts/rekor-tiles/README.md
+++ b/charts/rekor-tiles/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.2.11](https://img.shields.io/badge/Version-0.2.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.8](https://img.shields.io/badge/AppVersion-0.1.8-informational?style=flat-square)
+![Version: 0.2.12](https://img.shields.io/badge/Version-0.2.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.8](https://img.shields.io/badge/AppVersion-0.1.8-informational?style=flat-square)
 
 Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 
@@ -63,6 +63,8 @@ If using Tink or another KMS, provide the KMS configuration through values.yaml.
 | image.repository | string | `"sigstore/rekor-tiles"` |  |
 | image.version | string | `"v0.1.8@sha256:806b7e8728c68a911bd2d8e3ca3df0bdfb6fe0742be1f5a8663acd34c2cf8da1"` |  |
 | imagePullSecrets | list | `[]` |  |
+| lifecycle.preStop.exec.command[0] | string | `"sleep"` |  |
+| lifecycle.preStop.exec.command[1] | string | `"15"` |  |
 | livenessProbe.httpGet.path | string | `"/healthz"` |  |
 | livenessProbe.httpGet.port | int | `3000` |  |
 | nameOverride | string | `""` |  |
@@ -110,4 +112,5 @@ If using Tink or another KMS, provide the KMS configuration through values.yaml.
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| terminationGracePeriodSeconds | int | `65` |  |
 | tolerations | list | `[]` |  |

--- a/charts/rekor-tiles/templates/deployment.yaml
+++ b/charts/rekor-tiles/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 {{- if or .Values.server.signer.file .Values.server.signer.tink }}

--- a/charts/rekor-tiles/values.yaml
+++ b/charts/rekor-tiles/values.yaml
@@ -82,6 +82,12 @@ readinessProbe:
     path: /healthz
     port: 3000
 
+terminationGracePeriodSeconds: 65
+lifecycle:
+  preStop:
+    exec:
+      command: ["sleep", "15"]
+
 nodeSelector:
   iam.gke.io/gke-metadata-server-enabled: "true"   # support workload identity
 


### PR DESCRIPTION
Add a preStop hook to delay terminating the pod for 15 seconds while the load balancer drains the endpoint's connections. The delay matches the drain timeout set on the load balancer.

Set the terminationGracePeriodSeconds to 65 seconds, which is:
    preStop hook (15s)
  + default server idle timeout set in rekor-tiles binary (20s)
  + default log connection timeout set in rekor-tiles binary (30s)

See https://victoriametrics.com/blog/go-graceful-shutdown/index.html for information about this recommendation.

Partial https://github.com/sigstore/rekor-tiles/issues/370
Depends on https://github.com/sigstore/rekor-tiles/pull/444

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
