### PR TITLE
rekor-tiles: Set port names in deployment spec

### DIFF
--- a/charts/rekor-tiles/Chart.yaml
+++ b/charts/rekor-tiles/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rekor-tiles
 description: Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 type: application
-version: 0.2.17
+version: 0.2.18
 appVersion: "0.1.11"
 keywords:
   - security

--- a/charts/rekor-tiles/README.md
+++ b/charts/rekor-tiles/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.2.17](https://img.shields.io/badge/Version-0.2.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
+![Version: 0.2.18](https://img.shields.io/badge/Version-0.2.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.11](https://img.shields.io/badge/AppVersion-0.1.11-informational?style=flat-square)
 
 Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 
@@ -103,7 +103,7 @@ If using Tink or another KMS, provide the KMS configuration through values.yaml.
 | service.ports[1].port | int | `3001` |  |
 | service.ports[1].protocol | string | `"TCP"` |  |
 | service.ports[1].targetPort | int | `3001` |  |
-| service.ports[2].name | string | `"2112-tcp"` |  |
+| service.ports[2].name | string | `"metrics"` |  |
 | service.ports[2].port | int | `2112` |  |
 | service.ports[2].protocol | string | `"TCP"` |  |
 | service.ports[2].targetPort | int | `2112` |  |

--- a/charts/rekor-tiles/templates/_helpers.tpl
+++ b/charts/rekor-tiles/templates/_helpers.tpl
@@ -155,7 +155,8 @@ Server Arguments
 
 {{- define "rekor-tiles.containerPorts" -}}
 {{- range . }}
-- containerPort: {{ (ternary .port .targetPort (empty .targetPort)) | int }}
+- name: {{ .name }}
+  containerPort: {{ (ternary .port .targetPort (empty .targetPort)) | int }}
   protocol: {{ default "TCP" .protocol }}
 {{- end -}}
 {{- end -}}

--- a/charts/rekor-tiles/values.yaml
+++ b/charts/rekor-tiles/values.yaml
@@ -56,7 +56,7 @@ service:
       port: 3001
       protocol: TCP
       targetPort: 3001
-    - name: 2112-tcp
+    - name: metrics
       port: 2112
       protocol: TCP
       targetPort: 2112


### PR DESCRIPTION
Also use descriptive name for the metrics port.

The purpose is to test the theory that PodMonitoring requires port names to fully work: "The container metadata label is only populated if the port is referenced by name because port numbers are not unique across containers."

@cmurphy do you think this is worth testing out (requires also updating the relevant podmonitoring yaml to `port: metrics` )?