### PR TITLE
Update sigstore-prober to use signing config and trusted root

### DIFF
--- a/charts/sigstore-prober/Chart.yaml
+++ b/charts/sigstore-prober/Chart.yaml
@@ -4,7 +4,7 @@ description: Sigstore API Endpoint Prober
 
 type: application
 
-version: 0.0.39
+version: 0.1.0
 appVersion: 0.7.25
 
 

--- a/charts/sigstore-prober/README.md
+++ b/charts/sigstore-prober/README.md
@@ -1,6 +1,6 @@
 # sigstore-prober
 
-![Version: 0.0.39](https://img.shields.io/badge/Version-0.0.39-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.25](https://img.shields.io/badge/AppVersion-0.7.25-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.25](https://img.shields.io/badge/AppVersion-0.7.25-informational?style=flat-square)
 
 Sigstore API Endpoint Prober
 
@@ -24,13 +24,13 @@ Sigstore API Endpoint Prober
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `"default"` |  |
 | spec.args.frequency | int | `10` |  |
-| spec.args.fulcioGrpcHost | string | `"fulcio.sigstore.dev"` |  |
-| spec.args.fulcioHost | string | `"https://fulcio.sigstore.dev"` |  |
 | spec.args.fulcioRequests | list | `[]` |  |
-| spec.args.rekorHost | string | `"https://rekor.sigstore.dev"` |  |
+| spec.args.grpcPort | int | `5554` |  |
 | spec.args.rekorRequests | list | `[]` |  |
-| spec.args.trustRekorAPIPublicKey | bool | `false` |  |
-| spec.args.tsaHost | string | `"https://timestamp.sigstore.dev"` |  |
+| spec.args.rekorV2Url | string | `""` |  |
+| spec.args.signingConfig | string | `""` |  |
+| spec.args.staging | bool | `false` |  |
+| spec.args.trustedRoot | string | `""` |  |
 | spec.args.writeProber | bool | `false` |  |
 | spec.image | string | `"ghcr.io/sigstore/scaffolding/prober:v0.7.25@sha256:84b59e781ff4a0f4e6f230825af5af0dcbbf3c04030bb656d6f8603aeaeb619c"` |  |
 | spec.imagePullPolicy | string | `"Always"` |  |

--- a/charts/sigstore-prober/templates/_helpers.tpl
+++ b/charts/sigstore-prober/templates/_helpers.tpl
@@ -19,28 +19,31 @@ Create args for sigstore prober components
 {{- if .Values.spec.args.frequency }}
 - "-frequency={{ .Values.spec.args.frequency }}"
 {{- end }}
+{{- if .Values.spec.args.staging }}
+- "-staging"
+{{- end }}
+{{- if .Values.spec.args.signingConfig }}
+- "-signing-config=/var/run/sigstore/signing-config.json"
+{{- end }}
+{{- if .Values.spec.args.trustedRoot }}
+- "-trusted-root=/var/run/sigstore/trusted-root.json"
+{{- end }}
+{{- if .Values.spec.args.rekorV2Url }}
+- "-rekor-v2-url={{ .Values.spec.args.rekorV2Url }}"
+{{- end }}
+{{- if .Values.spec.args.writeProber }}
+- "-write-prober"
+{{- end }}
+{{- if .Values.spec.args.rekorRequests }}
+- "-rekor-requests={{ .Values.spec.args.rekorRequests | toJson }}"
+{{- end }}
+{{- if .Values.spec.args.fulcioRequests }}
+- "-fulcio-requests={{ .Values.spec.args.fulcioRequests | toJson }}"
+{{- end }}
+{{- if .Values.spec.args.grpcPort }}
+- "-grpc-port={{ .Values.spec.args.grpcPort }}"
+{{- end }}
 {{- if .Values.prometheus.port }}
 - "-addr=:{{ .Values.prometheus.port }}"
 {{- end }}
-{{- if .Values.spec.args.rekorHost }}
-- "-rekor-url={{ .Values.spec.args.rekorHost }}"
 {{- end }}
-{{- if .Values.spec.args.fulcioHost }}
-- "-fulcio-url={{ .Values.spec.args.fulcioHost }}"
-{{- end }}
-{{- if .Values.spec.args.fulcioGrpcHost }}
-- "-fulcio-grpc-url={{ .Values.spec.args.fulcioGrpcHost }}"
-{{- end }}
-{{- if .Values.spec.args.tsaHost }}
-- "-tsa-url={{ .Values.spec.args.tsaHost }}"
-{{- end }}
-{{- if .Values.spec.args.writeProber }}
-- "-write-prober={{ .Values.spec.args.writeProber }}"
-{{- end }}
-{{- if .Values.spec.args.rekorRequests }}
-- {{ printf "-rekor-requests=%s" (.Values.spec.args.rekorRequests | toJson) | quote }}
-{{- end }}
-{{- if .Values.spec.args.fulcioRequests }}
-- {{ printf "-fulcio-requests=%s" (.Values.spec.args.fulcioRequests | toJson) | quote }}
-{{- end }}
-{{- end -}}

--- a/charts/sigstore-prober/templates/configmap.yaml
+++ b/charts/sigstore-prober/templates/configmap.yaml
@@ -1,0 +1,16 @@
+{{- if or .Values.spec.args.signingConfig .Values.spec.args.trustedRoot }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "sigstore-prober.name" . }}-config
+  namespace: {{ .Values.namespace.name }}
+data:
+  {{- if .Values.spec.args.signingConfig }}
+  signing-config.json: |-
+{{ .Values.spec.args.signingConfig | indent 4 }}
+  {{- end }}
+  {{- if .Values.spec.args.trustedRoot }}
+  trusted-root.json: |-
+{{ .Values.spec.args.trustedRoot | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/sigstore-prober/templates/deployment.yaml
+++ b/charts/sigstore-prober/templates/deployment.yaml
@@ -18,23 +18,6 @@ spec:
         prometheus.io/port: "{{ .Values.prometheus.port }}"
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
-      {{- if .Values.spec.args.trustRekorAPIPublicKey }}
-      initContainers:
-      - name: public-key-fetcher
-        image: docker.io/curlimages/curl@sha256:4a3396ae573c44932d06ba33f8696db4429c419da87cbdc82965ee96a37dd0af
-        args:
-          - "--output"
-          - "/var/run/sigstore/public-key.pem"
-          - "{{ .Values.spec.args.rekorHost }}/api/v1/log/publicKey"
-        env:
-        volumeMounts:
-        - name: sigstore
-          mountPath: "/var/run/sigstore"
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 65534
-          allowPrivilegeEscalation: false
-      {{- end }}
       containers:
       - name: {{ template "sigstore-prober.name" . }}
         image: "{{ .Values.spec.image }}"
@@ -52,21 +35,20 @@ spec:
           runAsUser: 65534
           allowPrivilegeEscalation: false
         env:
-          # TUF_ROOT set to /tmp since the home dir for user 65534 is set to /nonexistant
-        - name: TUF_ROOT
+          # HOME set to /tmp since the default home dir for user 65534 is set to /nonexistant
+        - name: HOME
           value: "/tmp"
-      {{- if .Values.spec.args.trustRekorAPIPublicKey }}
-        - name: SIGSTORE_REKOR_PUBLIC_KEY
-          value: "/var/run/sigstore/public-key.pem"
-      {{- end }}
-      {{- if .Values.spec.args.trustRekorAPIPublicKey }}
+        {{- if or .Values.spec.args.signingConfig .Values.spec.args.trustedRoot }}
         volumeMounts:
-        - name: sigstore
+        - name: sigstore-config
           mountPath: "/var/run/sigstore"
           readOnly: true
+        {{- end }}
+      {{- if or .Values.spec.args.signingConfig .Values.spec.args.trustedRoot }}
       volumes:
-        - name: sigstore
-          emptyDir: {}
+        - name: sigstore-config
+          configMap:
+            name: {{ template "sigstore-prober.name" . }}-config
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/sigstore-prober/values.schema.json
+++ b/charts/sigstore-prober/values.schema.json
@@ -1,128 +1,286 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-        "affinity": {
-            "properties": {},
-            "type": "object"
-        },
-        "namespace": {
-            "properties": {
-                "create": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "nodeSelector": {
-            "properties": {},
-            "type": "object"
-        },
-        "prometheus": {
-            "properties": {
-                "port": {
-                    "type": "integer"
-                }
-            },
-            "type": "object"
-        },
-        "serviceAccount": {
-            "properties": {
-                "create": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "spec": {
-            "properties": {
-                "args": {
-                    "properties": {
-                        "frequency": {
-                            "type": "integer"
-                        },
-                        "fulcioHost": {
-                            "type": "string"
-                        },
-                        "fulcioGrpcHost": {
-                            "type": "string"
-                        },
-                        "fulcioRequests": {
-                            "type": "array"
-                        },
-                        "rekorHost": {
-                            "type": "string"
-                        },
-                        "rekorRequests": {
-                            "type": "array"
-                        },
-                        "trustRekorAPIPublicKey": {
-                            "type": "boolean"
-                        },
-                        "tsaHost": {
-                            "type": "string"
-                        },
-                        "writeProber": {
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "image": {
-                    "type": "string"
-                },
-                "imagePullPolicy": {
-                    "type": "string"
-                },
-                "matchLabels": {
-                    "properties": {
-                        "app": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "replicaCount": {
-                    "type": "integer"
-                },
-                "resources": {
-                    "properties": {
-                        "limits": {
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "requests": {
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "tolerations": {
-            "type": "array"
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "affinity": {
+      "additionalProperties": false,
+      "required": [],
+      "title": "affinity",
+      "type": "object"
     },
-    "type": "object"
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "namespace": {
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "default": true,
+          "required": [],
+          "title": "create",
+          "type": "boolean"
+        },
+        "name": {
+          "default": "sigstore-prober",
+          "required": [],
+          "title": "name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "create",
+        "name"
+      ],
+      "title": "namespace",
+      "type": "object"
+    },
+    "nodeSelector": {
+      "additionalProperties": false,
+      "required": [],
+      "title": "nodeSelector",
+      "type": "object"
+    },
+    "prometheus": {
+      "additionalProperties": false,
+      "properties": {
+        "port": {
+          "default": 8080,
+          "required": [],
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "port"
+      ],
+      "title": "prometheus",
+      "type": "object"
+    },
+    "serviceAccount": {
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "default": false,
+          "required": [],
+          "title": "create",
+          "type": "boolean"
+        },
+        "name": {
+          "default": "default",
+          "required": [],
+          "title": "name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "create"
+      ],
+      "title": "serviceAccount",
+      "type": "object"
+    },
+    "spec": {
+      "additionalProperties": false,
+      "properties": {
+        "args": {
+          "additionalProperties": false,
+          "properties": {
+            "frequency": {
+              "default": 10,
+              "required": [],
+              "title": "frequency",
+              "type": "integer"
+            },
+            "fulcioRequests": {
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "title": "fulcioRequests",
+              "type": "array"
+            },
+            "grpcPort": {
+              "default": 5554,
+              "required": [],
+              "title": "grpcPort",
+              "type": "integer"
+            },
+            "rekorRequests": {
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "title": "rekorRequests",
+              "type": "array"
+            },
+            "rekorV2Url": {
+              "default": "",
+              "required": [],
+              "title": "rekorV2Url",
+              "type": "string"
+            },
+            "signingConfig": {
+              "default": "",
+              "required": [],
+              "title": "signingConfig",
+              "type": "string"
+            },
+            "staging": {
+              "default": false,
+              "required": [],
+              "title": "staging",
+              "type": "boolean"
+            },
+            "trustedRoot": {
+              "default": "",
+              "required": [],
+              "title": "trustedRoot",
+              "type": "string"
+            },
+            "writeProber": {
+              "default": false,
+              "required": [],
+              "title": "writeProber",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "staging",
+            "signingConfig",
+            "trustedRoot",
+            "rekorV2Url",
+            "rekorRequests",
+            "fulcioRequests",
+            "writeProber",
+            "frequency",
+            "grpcPort"
+          ],
+          "title": "args",
+          "type": "object"
+        },
+        "image": {
+          "default": "ghcr.io/sigstore/scaffolding/prober:v0.7.25@sha256:84b59e781ff4a0f4e6f230825af5af0dcbbf3c04030bb656d6f8603aeaeb619c",
+          "required": [],
+          "title": "image",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "default": "Always",
+          "required": [],
+          "title": "imagePullPolicy",
+          "type": "string"
+        },
+        "matchLabels": {
+          "additionalProperties": false,
+          "properties": {
+            "app": {
+              "default": "sigstore-prober",
+              "required": [],
+              "title": "app",
+              "type": "string"
+            }
+          },
+          "required": [
+            "app"
+          ],
+          "title": "matchLabels",
+          "type": "object"
+        },
+        "replicaCount": {
+          "default": 1,
+          "required": [],
+          "title": "replicaCount",
+          "type": "integer"
+        },
+        "resources": {
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "200m",
+                  "required": [],
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "128Mi",
+                  "required": [],
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "memory",
+                "cpu"
+              ],
+              "title": "limits",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "50m",
+                  "required": [],
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "64Mi",
+                  "required": [],
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "memory",
+                "cpu"
+              ],
+              "title": "requests",
+              "type": "object"
+            }
+          },
+          "required": [
+            "requests",
+            "limits"
+          ],
+          "title": "resources",
+          "type": "object"
+        }
+      },
+      "required": [
+        "replicaCount",
+        "image",
+        "imagePullPolicy",
+        "matchLabels",
+        "resources",
+        "args"
+      ],
+      "title": "spec",
+      "type": "object"
+    },
+    "tolerations": {
+      "items": {
+        "required": []
+      },
+      "required": [],
+      "title": "tolerations",
+      "type": "array"
+    }
+  },
+  "required": [
+    "namespace",
+    "serviceAccount",
+    "spec",
+    "prometheus",
+    "tolerations",
+    "nodeSelector",
+    "affinity"
+  ],
+  "type": "object"
 }

--- a/charts/sigstore-prober/values.yaml
+++ b/charts/sigstore-prober/values.yaml
@@ -18,15 +18,15 @@ spec:
       memory: "128Mi"
       cpu: "200m"
   args:
-    fulcioHost: https://fulcio.sigstore.dev
-    fulcioGrpcHost: fulcio.sigstore.dev
-    rekorHost: https://rekor.sigstore.dev
-    tsaHost: https://timestamp.sigstore.dev
-    frequency: 10
-    writeProber: false
+    staging: false
+    signingConfig: ""
+    trustedRoot: ""
+    rekorV2Url: ""
     rekorRequests: []
     fulcioRequests: []
-    trustRekorAPIPublicKey: false
+    writeProber: false
+    grpcPort: 5554
+    frequency: 10
 prometheus:
   port: 8080
 tolerations: []


### PR DESCRIPTION
## Description of the change

This change updates the `sigstore-prober` chart to use a signing config and trusted root.

## Existing or Associated Issue(s)

Partially addresses sigstore/rekor-tiles#46

## Additional Information

Changes in the prober (sigstore/scaffolding#1663, sigstore/scaffolding#1719) have replaced URL flags with a signing config and trusted root as the primary mechanism for getting services.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
