### PR TITLE
Update prober for insecure transport flag

### DIFF
--- a/charts/sigstore-prober/Chart.yaml
+++ b/charts/sigstore-prober/Chart.yaml
@@ -4,8 +4,8 @@ description: Sigstore API Endpoint Prober
 
 type: application
 
-version: 0.1.3
-appVersion: 0.7.27
+version: 0.1.4
+appVersion: 0.7.28
 
 
 keywords:
@@ -21,4 +21,4 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: sigstore-prober
-      image: ghcr.io/sigstore/scaffolding/prober:v0.7.27@sha256:0f578d895829faddd2af8f00ee88da6d8c56506ef1e4e2ac3cdd9254ef586c99
+      image: ghcr.io/sigstore/scaffolding/prober:v0.7.28@sha256:545d3990d399d4eb7ce0447c06284f5fe8219bcc5b38e77b2c36f866ceed225e

--- a/charts/sigstore-prober/README.md
+++ b/charts/sigstore-prober/README.md
@@ -1,6 +1,6 @@
 # sigstore-prober
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.27](https://img.shields.io/badge/AppVersion-0.7.27-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.28](https://img.shields.io/badge/AppVersion-0.7.28-informational?style=flat-square)
 
 Sigstore API Endpoint Prober
 
@@ -27,13 +27,14 @@ Sigstore API Endpoint Prober
 | spec.args.frequency | int | `10` |  |
 | spec.args.fulcioRequests | list | `[]` |  |
 | spec.args.grpcPort | int | `5554` |  |
+| spec.args.insecure | bool | `true` |  |
 | spec.args.rekorRequests | list | `[]` |  |
 | spec.args.rekorV2Url | string | `""` |  |
 | spec.args.signingConfig | string | `""` |  |
 | spec.args.staging | bool | `false` |  |
 | spec.args.trustedRoot | string | `""` |  |
 | spec.args.writeProber | bool | `false` |  |
-| spec.image | string | `"ghcr.io/sigstore/scaffolding/prober:v0.7.27@sha256:0f578d895829faddd2af8f00ee88da6d8c56506ef1e4e2ac3cdd9254ef586c99"` |  |
+| spec.image | string | `"ghcr.io/sigstore/scaffolding/prober:v0.7.28@sha256:545d3990d399d4eb7ce0447c06284f5fe8219bcc5b38e77b2c36f866ceed225e"` |  |
 | spec.imagePullPolicy | string | `"Always"` |  |
 | spec.matchLabels.app | string | `"sigstore-prober"` |  |
 | spec.replicaCount | int | `1` |  |

--- a/charts/sigstore-prober/templates/_helpers.tpl
+++ b/charts/sigstore-prober/templates/_helpers.tpl
@@ -43,6 +43,9 @@ Create args for sigstore prober components
 {{- if .Values.spec.args.grpcPort }}
 - "-grpc-port={{ .Values.spec.args.grpcPort }}"
 {{- end }}
+{{- if .Values.spec.args.insecure }}
+- "-insecure"
+{{- end }}
 {{- if .Values.prometheus.port }}
 - "-addr=:{{ .Values.prometheus.port }}"
 {{- end }}

--- a/charts/sigstore-prober/values.schema.json
+++ b/charts/sigstore-prober/values.schema.json
@@ -114,6 +114,12 @@
               "title": "grpcPort",
               "type": "integer"
             },
+            "insecure": {
+              "default": true,
+              "required": [],
+              "title": "insecure",
+              "type": "boolean"
+            },
             "rekorRequests": {
               "items": {
                 "required": []
@@ -162,13 +168,14 @@
             "fulcioRequests",
             "writeProber",
             "frequency",
-            "grpcPort"
+            "grpcPort",
+            "insecure"
           ],
           "title": "args",
           "type": "object"
         },
         "image": {
-          "default": "ghcr.io/sigstore/scaffolding/prober:v0.7.27@sha256:0f578d895829faddd2af8f00ee88da6d8c56506ef1e4e2ac3cdd9254ef586c99",
+          "default": "ghcr.io/sigstore/scaffolding/prober:v0.7.28@sha256:545d3990d399d4eb7ce0447c06284f5fe8219bcc5b38e77b2c36f866ceed225e",
           "required": [],
           "title": "image",
           "type": "string"

--- a/charts/sigstore-prober/values.yaml
+++ b/charts/sigstore-prober/values.yaml
@@ -7,7 +7,7 @@ serviceAccount:
   annotations: {}
 spec:
   replicaCount: 1
-  image: ghcr.io/sigstore/scaffolding/prober:v0.7.27@sha256:0f578d895829faddd2af8f00ee88da6d8c56506ef1e4e2ac3cdd9254ef586c99
+  image: ghcr.io/sigstore/scaffolding/prober:v0.7.28@sha256:545d3990d399d4eb7ce0447c06284f5fe8219bcc5b38e77b2c36f866ceed225e
   imagePullPolicy: Always
   matchLabels:
     app: sigstore-prober
@@ -27,6 +27,7 @@ spec:
     fulcioRequests: []
     writeProber: false
     grpcPort: 5554
+    insecure: true
     frequency: 10
 prometheus:
   port: 8080


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

This change updates the prober version from 0.7.27 to 0.7.28 and applies the insecure transport flag for gRPC requests. 

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
