### PR TITLE
Regenerate schema, cleanup README for rekor-tiles chart

### DIFF
--- a/charts/rekor-tiles/Chart.yaml
+++ b/charts/rekor-tiles/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rekor-tiles
 description: Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "2.0.1"
 keywords:
   - security

--- a/charts/rekor-tiles/README.md
+++ b/charts/rekor-tiles/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 
@@ -11,7 +11,7 @@ Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transpare
 ## Quick Installation
 
 To install the helm chart with default values run following command.
-The [Values](#Values) section describes the configuration options for this chart.
+The [Values](#values) section describes the configuration options for this chart.
 
 ```shell
 helm dependency update .
@@ -30,13 +30,13 @@ helm uninstall [RELEASE_NAME]
 
 If using --signer-filepath for rekor-tiles, create the Secret to read the signing key from:
 
-```
+```shell
 kubectl create secret generic --from-literal signing-key=$(cat /path/to/private/key.pem) signing-key
 ```
 
 If password encrypted, provide the password in secret:
 
-```
+```shell
 kubectl create secret generic --from-literal signing-key=$(cat /path/to/private/key.pem) --from-literal password=foobar signing-key
 ```
 

--- a/charts/rekor-tiles/README.md.gotmpl
+++ b/charts/rekor-tiles/README.md.gotmpl
@@ -13,7 +13,7 @@
 ## Quick Installation
 
 To install the helm chart with default values run following command.
-The [Values](#Values) section describes the configuration options for this chart.
+The [Values](#values) section describes the configuration options for this chart.
 
 ```shell
 helm dependency update .
@@ -32,13 +32,13 @@ helm uninstall [RELEASE_NAME]
 
 If using --signer-filepath for rekor-tiles, create the Secret to read the signing key from:
 
-```
+```shell
 kubectl create secret generic --from-literal signing-key=$(cat /path/to/private/key.pem) signing-key
 ```
 
 If password encrypted, provide the password in secret:
 
-```
+```shell
 kubectl create secret generic --from-literal signing-key=$(cat /path/to/private/key.pem) --from-literal password=foobar signing-key
 ```
 

--- a/charts/rekor-tiles/values.schema.json
+++ b/charts/rekor-tiles/values.schema.json
@@ -1,338 +1,124 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "title": "Generated Schema",
+  "description": "Generated from JSON data",
+  "type": "object",
   "properties": {
-    "affinity": {
-      "additionalProperties": false,
-      "required": [],
-      "title": "affinity",
-      "type": "object"
-    },
-    "fullnameOverride": {
-      "default": "",
-      "title": "fullnameOverride",
-      "type": "string"
-    },
-    "global": {
-      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
-      "required": [],
-      "title": "global",
-      "type": "object"
+    "replicaCount": {
+      "type": "integer"
     },
     "image": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
-        "pullPolicy": {
-          "default": "IfNotPresent",
-          "title": "pullPolicy",
-          "type": "string"
-        },
         "registry": {
-          "default": "ghcr.io",
-          "title": "registry",
           "type": "string"
         },
         "repository": {
-          "default": "sigstore/rekor-tiles",
-          "title": "repository",
+          "type": "string"
+        },
+        "pullPolicy": {
           "type": "string"
         },
         "version": {
-          "default": "v2.0.1@sha256:640300626b3f3aa6c068df92a3f2336320c1327ba42ce84f44b893379adbadef",
-          "description": "Overrides the image tag whose default is the chart appVersion.\ncrane digest ghcr.io/sigstore/rekor-tiles:v2.0.1",
-          "title": "version",
           "type": "string"
         }
       },
       "required": [
+        "pullPolicy",
         "registry",
         "repository",
-        "pullPolicy",
         "version"
-      ],
-      "title": "image",
-      "type": "object"
-    },
-    "imagePullSecrets": {
-      "items": {
-        "required": []
-      },
-      "title": "imagePullSecrets",
-      "type": "array"
-    },
-    "lifecycle": {
-      "additionalProperties": false,
-      "properties": {
-        "preStop": {
-          "additionalProperties": false,
-          "properties": {
-            "exec": {
-              "additionalProperties": false,
-              "properties": {
-                "command": {
-                  "items": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ],
-                    "required": []
-                  },
-                  "title": "command",
-                  "type": "array"
-                }
-              },
-              "required": [
-                "command"
-              ],
-              "title": "exec",
-              "type": "object"
-            }
-          },
-          "required": [
-            "exec"
-          ],
-          "title": "preStop",
-          "type": "object"
-        }
-      },
-      "required": [
-        "preStop"
-      ],
-      "title": "lifecycle",
-      "type": "object"
-    },
-    "livenessProbe": {
-      "additionalProperties": false,
-      "properties": {
-        "httpGet": {
-          "additionalProperties": false,
-          "properties": {
-            "path": {
-              "default": "/healthz",
-              "title": "path",
-              "type": "string"
-            },
-            "port": {
-              "default": 3000,
-              "title": "port",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "path",
-            "port"
-          ],
-          "title": "httpGet",
-          "type": "object"
-        }
-      },
-      "required": [
-        "httpGet"
-      ],
-      "title": "livenessProbe",
-      "type": "object"
-    },
-    "nameOverride": {
-      "default": "",
-      "title": "nameOverride",
-      "type": "string"
+      ]
     },
     "namespace": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "create": {
-          "default": false,
-          "title": "create",
           "type": "boolean"
         },
         "name": {
-          "default": "rekor-tiles-system",
-          "title": "name",
           "type": "string"
         }
       },
       "required": [
         "create",
         "name"
-      ],
-      "title": "namespace",
-      "type": "object"
+      ]
     },
-    "neg": {
-      "additionalProperties": false,
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {}
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "serviceAccount": {
+      "type": "object",
       "properties": {
-        "grpc": {
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "default": "",
-              "title": "name",
-              "type": "string"
-            },
-            "port": {
-              "default": 3001,
-              "title": "port",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "name",
-            "port"
-          ],
-          "title": "grpc",
-          "type": "object"
+        "create": {
+          "type": "boolean"
         },
-        "http": {
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "default": "",
-              "title": "name",
-              "type": "string"
-            },
-            "port": {
-              "default": 80,
-              "title": "port",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "name",
-            "port"
-          ],
-          "title": "http",
-          "type": "object"
-        }
-      },
-      "required": [
-        "http",
-        "grpc"
-      ],
-      "title": "neg",
-      "type": "object"
-    },
-    "nodeSelector": {
-      "additionalProperties": false,
-      "properties": {
-        "iam.gke.io/gke-metadata-server-enabled": {
-          "default": "true",
-          "title": "iam.gke.io/gke-metadata-server-enabled",
+        "automount": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object",
+          "properties": {}
+        },
+        "name": {
           "type": "string"
         }
       },
       "required": [
-        "iam.gke.io/gke-metadata-server-enabled"
-      ],
-      "title": "nodeSelector",
-      "type": "object"
+        "annotations",
+        "automount",
+        "create",
+        "name"
+      ]
     },
     "podAnnotations": {
-      "additionalProperties": false,
-      "required": [],
-      "title": "podAnnotations",
-      "type": "object"
+      "type": "object",
+      "properties": {}
     },
     "podLabels": {
-      "additionalProperties": false,
-      "required": [],
-      "title": "podLabels",
-      "type": "object"
+      "type": "object",
+      "properties": {}
     },
     "podSecurityContext": {
-      "additionalProperties": false,
-      "required": [],
-      "title": "podSecurityContext",
-      "type": "object"
-    },
-    "readinessProbe": {
-      "additionalProperties": false,
-      "properties": {
-        "httpGet": {
-          "additionalProperties": false,
-          "properties": {
-            "path": {
-              "default": "/healthz",
-              "title": "path",
-              "type": "string"
-            },
-            "port": {
-              "default": 3000,
-              "title": "port",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "path",
-            "port"
-          ],
-          "title": "httpGet",
-          "type": "object"
-        }
-      },
-      "required": [
-        "httpGet"
-      ],
-      "title": "readinessProbe",
-      "type": "object"
-    },
-    "replicaCount": {
-      "default": 1,
-      "title": "replicaCount",
-      "type": "integer"
-    },
-    "resources": {
-      "additionalProperties": false,
-      "required": [],
-      "title": "resources",
-      "type": "object"
+      "type": "object",
+      "properties": {}
     },
     "securityContext": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "allowPrivilegeEscalation": {
-          "default": false,
-          "title": "allowPrivilegeEscalation",
           "type": "boolean"
         },
         "capabilities": {
-          "additionalProperties": false,
+          "type": "object",
           "properties": {
             "drop": {
+              "type": "array",
               "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  }
-                ],
-                "required": []
+                "type": "string"
               },
-              "title": "drop",
-              "type": "array"
+              "minItems": 0
             }
           },
           "required": [
             "drop"
-          ],
-          "title": "capabilities",
-          "type": "object"
+          ]
         },
         "readOnlyRootFilesystem": {
-          "default": true,
-          "title": "readOnlyRootFilesystem",
           "type": "boolean"
         },
         "runAsNonRoot": {
-          "default": true,
-          "title": "runAsNonRoot",
           "type": "boolean"
         },
         "runAsUser": {
-          "default": 65533,
-          "title": "runAsUser",
           "type": "integer"
         }
       },
@@ -342,324 +128,295 @@
         "readOnlyRootFilesystem",
         "runAsNonRoot",
         "runAsUser"
-      ],
-      "title": "securityContext",
-      "type": "object"
+      ]
     },
-    "server": {
-      "additionalProperties": false,
-      "description": "Server arguments",
+    "service": {
+      "type": "object",
       "properties": {
-        "antispam": {
-          "additionalProperties": false,
-          "required": [],
-          "title": "antispam",
-          "type": "object"
+        "type": {
+          "type": "string"
         },
-        "extraArgs": {
-          "description": "configMapName: witness-config\nwitnessPolicy: \"\"",
+        "ports": {
+          "type": "array",
           "items": {
-            "required": []
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer"
+              },
+              "protocol": {
+                "type": "string"
+              },
+              "targetPort": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "name",
+              "port",
+              "protocol",
+              "targetPort"
+            ]
           },
-          "title": "extraArgs",
-          "type": "array"
-        },
-        "gcp": {
-          "additionalProperties": false,
-          "required": [],
-          "title": "gcp",
-          "type": "object"
+          "minItems": 0
+        }
+      },
+      "required": [
+        "ports",
+        "type"
+      ]
+    },
+    "resources": {
+      "type": "object",
+      "properties": {}
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "path",
+            "port"
+          ]
+        }
+      },
+      "required": [
+        "httpGet"
+      ]
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "path",
+            "port"
+          ]
+        }
+      },
+      "required": [
+        "httpGet"
+      ]
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer"
+    },
+    "lifecycle": {
+      "type": "object",
+      "properties": {
+        "preStop": {
+          "type": "object",
+          "properties": {
+            "exec": {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 0
+                }
+              },
+              "required": [
+                "command"
+              ]
+            }
+          },
+          "required": [
+            "exec"
+          ]
+        }
+      },
+      "required": [
+        "preStop"
+      ]
+    },
+    "nodeSelector": {
+      "type": "object",
+      "properties": {
+        "iam.gke.io/gke-metadata-server-enabled": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "iam.gke.io/gke-metadata-server-enabled"
+      ]
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {}
+    },
+    "affinity": {
+      "type": "object",
+      "properties": {}
+    },
+    "neg": {
+      "type": "object",
+      "properties": {
+        "http": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name",
+            "port"
+          ]
         },
         "grpc": {
-          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "name",
+            "port"
+          ]
+        }
+      },
+      "required": [
+        "grpc",
+        "http"
+      ]
+    },
+    "server": {
+      "type": "object",
+      "properties": {
+        "antispam": {
+          "type": "object",
+          "properties": {}
+        },
+        "tesseraLivecycle": {
+          "type": "object",
+          "properties": {}
+        },
+        "gcp": {
+          "type": "object",
+          "properties": {}
+        },
+        "grpc": {
+          "type": "object",
           "properties": {
             "port": {
-              "default": "3001",
-              "title": "port",
               "type": "string"
             }
           },
           "required": [
             "port"
-          ],
-          "title": "grpc",
-          "type": "object"
-        },
-        "grpcSvcTLS": {
-          "additionalProperties": false,
-          "required": [],
-          "title": "grpcSvcTLS",
-          "type": "object"
+          ]
         },
         "hostname": {
-          "default": "localhost",
-          "title": "hostname",
           "type": "string"
         },
         "http": {
-          "additionalProperties": false,
+          "type": "object",
           "properties": {
-            "metricsPort": {
-              "default": "2112",
-              "title": "metricsPort",
+            "port": {
               "type": "string"
             },
-            "port": {
-              "default": "3000",
-              "title": "port",
+            "metricsPort": {
               "type": "string"
             }
           },
           "required": [
-            "port",
-            "metricsPort"
-          ],
-          "title": "http",
-          "type": "object"
-        },
-        "readOnly": {
-          "default": false,
-          "title": "readOnly",
-          "type": "boolean"
+            "metricsPort",
+            "port"
+          ]
         },
         "serverConfig": {
-          "additionalProperties": false,
-          "required": [],
-          "title": "serverConfig",
-          "type": "object"
+          "type": "object",
+          "properties": {}
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "grpcSvcTLS": {
+          "type": "object",
+          "properties": {}
         },
         "signer": {
-          "additionalProperties": false,
-          "required": [],
-          "title": "signer",
-          "type": "object"
-        },
-        "tesseraLivecycle": {
-          "additionalProperties": false,
-          "required": [],
-          "title": "tesseraLivecycle",
-          "type": "object"
+          "type": "object",
+          "properties": {}
         },
         "witnessing": {
-          "additionalProperties": false,
-          "description": "file:\n  path: /pki/signer.pem\n  withPassword: false\n  secret:\n    name: \"signing-key\"\n    key: signing-key\n    mountPath: /pki\n    mountSubPath: signer.pem\nkms:\n  hash: sha256\n  key: gcpkms://keyname\ntink:\n  kekURI: gcp-kms://keyname\n  configMapName: tink-config\n  keyset: \"\"",
-          "required": [],
-          "title": "witnessing",
-          "type": "object"
+          "type": "object",
+          "properties": {}
+        },
+        "extraArgs": {
+          "type": "array",
+          "items": {}
         }
       },
       "required": [
         "antispam",
-        "tesseraLivecycle",
+        "extraArgs",
         "gcp",
         "grpc",
+        "grpcSvcTLS",
         "hostname",
         "http",
-        "serverConfig",
         "readOnly",
-        "grpcSvcTLS",
+        "serverConfig",
         "signer",
-        "witnessing",
-        "extraArgs"
-      ],
-      "title": "server",
-      "type": "object"
-    },
-    "service": {
-      "additionalProperties": false,
-      "properties": {
-        "ports": {
-          "items": {
-            "anyOf": [
-              {
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "default": "3000-tcp",
-                    "title": "name",
-                    "type": "string"
-                  },
-                  "port": {
-                    "default": 80,
-                    "title": "port",
-                    "type": "integer"
-                  },
-                  "protocol": {
-                    "default": "TCP",
-                    "title": "protocol",
-                    "type": "string"
-                  },
-                  "targetPort": {
-                    "default": 3000,
-                    "title": "targetPort",
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "name",
-                  "port",
-                  "protocol",
-                  "targetPort"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "default": "3001-tcp",
-                    "title": "name",
-                    "type": "string"
-                  },
-                  "port": {
-                    "default": 3001,
-                    "title": "port",
-                    "type": "integer"
-                  },
-                  "protocol": {
-                    "default": "TCP",
-                    "title": "protocol",
-                    "type": "string"
-                  },
-                  "targetPort": {
-                    "default": 3001,
-                    "title": "targetPort",
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "name",
-                  "port",
-                  "protocol",
-                  "targetPort"
-                ],
-                "type": "object"
-              },
-              {
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "default": "metrics",
-                    "title": "name",
-                    "type": "string"
-                  },
-                  "port": {
-                    "default": 2112,
-                    "title": "port",
-                    "type": "integer"
-                  },
-                  "protocol": {
-                    "default": "TCP",
-                    "title": "protocol",
-                    "type": "string"
-                  },
-                  "targetPort": {
-                    "default": 2112,
-                    "title": "targetPort",
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "name",
-                  "port",
-                  "protocol",
-                  "targetPort"
-                ],
-                "type": "object"
-              }
-            ],
-            "required": []
-          },
-          "title": "ports",
-          "type": "array"
-        },
-        "type": {
-          "default": "ClusterIP",
-          "title": "type",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type",
-        "ports"
-      ],
-      "title": "service",
-      "type": "object"
-    },
-    "serviceAccount": {
-      "additionalProperties": false,
-      "properties": {
-        "annotations": {
-          "additionalProperties": false,
-          "description": "Annotations to add to the service account",
-          "required": [],
-          "title": "annotations",
-          "type": "object"
-        },
-        "automount": {
-          "default": true,
-          "description": "Automatically mount a ServiceAccount's API credentials?",
-          "title": "automount",
-          "type": "boolean"
-        },
-        "create": {
-          "default": true,
-          "description": "Specifies whether a service account should be created",
-          "title": "create",
-          "type": "boolean"
-        },
-        "name": {
-          "default": "",
-          "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template",
-          "title": "name",
-          "type": "string"
-        }
-      },
-      "required": [
-        "create",
-        "automount",
-        "annotations",
-        "name"
-      ],
-      "title": "serviceAccount",
-      "type": "object"
-    },
-    "terminationGracePeriodSeconds": {
-      "default": 65,
-      "title": "terminationGracePeriodSeconds",
-      "type": "integer"
-    },
-    "tolerations": {
-      "items": {
-        "required": []
-      },
-      "title": "tolerations",
-      "type": "array"
+        "tesseraLivecycle",
+        "witnessing"
+      ]
     }
   },
   "required": [
-    "replicaCount",
-    "image",
-    "namespace",
-    "imagePullSecrets",
-    "nameOverride",
+    "affinity",
     "fullnameOverride",
-    "serviceAccount",
+    "image",
+    "imagePullSecrets",
+    "lifecycle",
+    "livenessProbe",
+    "nameOverride",
+    "namespace",
+    "neg",
+    "nodeSelector",
     "podAnnotations",
     "podLabels",
     "podSecurityContext",
-    "securityContext",
-    "service",
-    "resources",
-    "livenessProbe",
     "readinessProbe",
+    "replicaCount",
+    "resources",
+    "securityContext",
+    "server",
+    "service",
+    "serviceAccount",
     "terminationGracePeriodSeconds",
-    "lifecycle",
-    "nodeSelector",
-    "tolerations",
-    "affinity",
-    "neg",
-    "server"
-  ],
-  "type": "object"
+    "tolerations"
+  ]
 }


### PR DESCRIPTION
The schema was validating objects where the fields were not explicitly defined. This reverts back to a simpler JSON schema. Verified this works locally by generating the configuration with values from staging.

Also cleaned up the markdown template to fix lint errors.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
