### PR TITLE
fix: Update disableGrpc flag name in prober helpers template

### DIFF
--- a/charts/sigstore-prober/Chart.yaml
+++ b/charts/sigstore-prober/Chart.yaml
@@ -4,7 +4,7 @@ description: Sigstore API Endpoint Prober
 
 type: application
 
-version: 0.1.5
+version: 0.1.6
 appVersion: 0.7.29
 
 

--- a/charts/sigstore-prober/README.md
+++ b/charts/sigstore-prober/README.md
@@ -1,6 +1,6 @@
 # sigstore-prober
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.29](https://img.shields.io/badge/AppVersion-0.7.29-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.29](https://img.shields.io/badge/AppVersion-0.7.29-informational?style=flat-square)
 
 Sigstore API Endpoint Prober
 

--- a/charts/sigstore-prober/templates/_helpers.tpl
+++ b/charts/sigstore-prober/templates/_helpers.tpl
@@ -44,7 +44,7 @@ Create args for sigstore prober components
 - "-grpc-port={{ .Values.spec.args.grpcPort }}"
 {{- end }}
 {{- if .Values.spec.args.disableGrpc }}
-- "-disableGrpc"
+- "-disable-grpc"
 {{- end }}
 {{- if .Values.prometheus.port }}
 - "-addr=:{{ .Values.prometheus.port }}"


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

This change fixes the flag name for the `disableGrpc` value in the prober helpers template.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
