### PR TITLE
CODEOWNERS: Fix syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @sigstore/sigstore-oncall
-* @sigstore/infrastructure-team
+* @sigstore/sigstore-oncall @sigstore/infrastructure-team


### PR DESCRIPTION
A match (like "*") can only be specified once: all owners for that match must be on the same line.

Fixes #1090 