### PR TITLE
Add ctlog-tiles chart

### DIFF
--- a/charts/ctlog-tiles/.helmignore
+++ b/charts/ctlog-tiles/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ctlog-tiles/Chart.yaml
+++ b/charts/ctlog-tiles/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: ctlog-tiles
+description: Tiles-based certificate log (TesseraCT)
+type: application
+version: 0.1.0
+appVersion: v0.1.1
+keywords:
+  - security
+  - certificate transparency
+home: https://sigstore.dev
+sources:
+  - https://github.com/transparency-dev/tesseract
+maintainers:
+  - name: The Sigstore Authors
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/images: |
+    - name: tesseract-posix
+      image: ghcr.io/sigstore/scaffolding/tesseract/posix:v0.1.1@sha256:767c2dbe4a83be9243246564244aa381322f08f2a864371f62b880c465033815
+    - name: tesseract-gcp
+      image: ghcr.io/sigstore/scaffolding/tesseract/gcp:v0.1.1@sha256:17d3788b736de01ab0586359626c01789910a6e2981e7b90014fbda8689f5017

--- a/charts/ctlog-tiles/README.md
+++ b/charts/ctlog-tiles/README.md
@@ -1,0 +1,194 @@
+# ctlog-tiles
+
+<!-- This README.md is generated. Please edit README.md.gotmpl -->
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1](https://img.shields.io/badge/AppVersion-v0.1.1-informational?style=flat-square)
+
+Tiles-based certificate log (TesseraCT)
+
+**Homepage:** <https://sigstore.dev>
+
+## Quick Installation
+
+To install the helm chart with default values run following command.
+The [Values](#values) section describes the configuration options for this chart.
+
+```shell
+helm dependency update .
+helm install [RELEASE_NAME] .
+```
+
+## Uninstallation
+
+To uninstall the Helm chart run following command.
+
+```shell
+helm uninstall [RELEASE_NAME]
+```
+
+## Specifying Fulcio roots
+
+Unlike the ctlog chart, there is no createctconfig job that runs and fetches Fulcio's roots from the rootCert endpoint. The roots need to be known ahead of time and specified directly in values.yaml:
+
+```
+server:
+  ...
+  fulcio:
+    rootPEM: |-
+      -----BEGIN CERTIFICATE-----
+      ...
+```
+
+## Using the POSIX backend
+
+In values.yaml, set `image.flavor` to `"posix"` (default).
+
+Create a secret for the private key:
+
+```
+openssl ecparam -name prime256v1 -genkey -noout -out /path/to/privkey.pem
+kubectl -n ctlog-tiles-system create secret generic ctlog-signing-key --from-file=signing-key=/path/to/privkey.pem
+```
+
+Encrypted secret keys are not supported.
+
+Configure the private key and storage directory in values.yaml:
+
+```
+server:
+  ...
+  posix:
+    privateKey:
+      path: /etc/ctfe/signer.pem
+      secret:
+        name: signing-key
+        key: signing-key
+        mountPath: /etc/ctfe
+        mountSubPath: signer.pem
+    storageDir:
+      path: /storage
+      name: ctlog
+      volume:
+        hostPath:
+          path: /data/ctlog-storage
+          type: Directory
+```
+
+## Using the GCP backend
+
+The deployment needs to be running in a GKE cluster with workload identity
+enabled and with permission to access secrets, storage objects, and Spanner
+databases.
+
+In values.yaml, set `image.flavor` to `"gcp"`.
+
+Create a Spanner instance and database in GCP:
+
+```
+gcloud spanner instances create tesseract \
+    --config=regional-us-west1 \
+    --description="test" --nodes=1
+gcloud spanner databases create sequencer --instance tesseract
+# If using antispam, create the antispam database too:
+# gcloud spanner databases create antispam --instance tesseract
+```
+
+Create a GCS bucket:
+
+```
+gcloud storage buckets create gs://unique-tesseract-bucket-name
+```
+
+Create secrets in Secret Manager for both the private and public keys:
+
+```
+gcloud secrets create tesseract-private --data-file=/path/to/privkey.pem
+gcloud secrets create tesseract-public --data-file=/path/to/pubkey.pem
+```
+
+Configure the Spanner path, bucket, and signer keys in values.yaml:
+
+```
+server:
+  ...
+  gcp:
+    spanner: projects/my-project/instances/tesseract/databases/sequencer
+    bucket: unique-tesseract-bucket-name
+    signer:
+      privateKey: projects/1234/secrets/tesseract-private/versions/1
+      publicKey: projects/1234/secrets/tesseract-public/versions/1
+```
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| The Sigstore Authors |  |  |
+
+## Source Code
+
+* <https://github.com/transparency-dev/tesseract>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
+| image.flavor | string | `"posix"` |  |
+| image.gcpSHA | string | `"sha256:17d3788b736de01ab0586359626c01789910a6e2981e7b90014fbda8689f5017"` |  |
+| image.posixSHA | string | `"sha256:767c2dbe4a83be9243246564244aa381322f08f2a864371f62b880c465033815"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.registry | string | `"ghcr.io"` |  |
+| image.repository | string | `"sigstore/scaffolding/tesseract"` |  |
+| image.version | string | `"v0.1.1"` |  |
+| imagePullSecrets | list | `[]` |  |
+| lifecycle.preStop.exec.command[0] | string | `"sleep"` |  |
+| lifecycle.preStop.exec.command[1] | string | `"15"` |  |
+| livenessProbe.httpGet.path | string | `"/healthz"` |  |
+| livenessProbe.httpGet.port | int | `6962` |  |
+| nameOverride | string | `""` |  |
+| namespace.create | bool | `false` |  |
+| namespace.name | string | `"ctlog-tiles-system"` |  |
+| neg.http.name | string | `""` |  |
+| neg.http.port | int | `80` |  |
+| nodeSelector."iam.gke.io/gke-metadata-server-enabled" | string | `"true"` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| readinessProbe.httpGet.path | string | `"/healthz"` |  |
+| readinessProbe.httpGet.port | int | `6962` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `65533` |  |
+| server.antispam | object | `{}` |  |
+| server.extraArgs | list | `[]` |  |
+| server.fulcio.configMap.key | string | `"fulcio"` |  |
+| server.fulcio.configMap.mountPath | string | `"/etc/fulcio"` |  |
+| server.fulcio.configMap.mountSubPath | string | `"roots.pem"` |  |
+| server.fulcio.configMap.name | string | `"fulcio-roots"` |  |
+| server.fulcio.path | string | `"/etc/fulcio/roots.pem"` |  |
+| server.fulcio.rootPEM | string | `""` |  |
+| server.gcp | object | `{}` |  |
+| server.hostname | string | `"localhost"` |  |
+| server.http.port | string | `"6962"` |  |
+| server.logLevel | string | `"1"` |  |
+| server.posix | object | `{}` |  |
+| server.serverConfig | object | `{}` |  |
+| server.tesseraLivecycle | object | `{}` |  |
+| server.witnessing | object | `{}` |  |
+| service.ports[0].name | string | `"6962-tcp"` |  |
+| service.ports[0].port | int | `80` |  |
+| service.ports[0].protocol | string | `"TCP"` |  |
+| service.ports[0].targetPort | int | `6962` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automount | bool | `true` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| terminationGracePeriodSeconds | int | `65` |  |
+| tolerations | list | `[]` |  |

--- a/charts/ctlog-tiles/README.md.gotmpl
+++ b/charts/ctlog-tiles/README.md.gotmpl
@@ -1,0 +1,130 @@
+{{ template "chart.header" . }}
+
+<!-- This README.md is generated. Please edit README.md.gotmpl -->
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Quick Installation
+
+To install the helm chart with default values run following command.
+The [Values](#values) section describes the configuration options for this chart.
+
+```shell
+helm dependency update .
+helm install [RELEASE_NAME] .
+```
+
+## Uninstallation
+
+To uninstall the Helm chart run following command.
+
+```shell
+helm uninstall [RELEASE_NAME]
+```
+
+## Specifying Fulcio roots
+
+Unlike the ctlog chart, there is no createctconfig job that runs and fetches Fulcio's roots from the rootCert endpoint. The roots need to be known ahead of time and specified directly in values.yaml:
+
+```
+server:
+  ...
+  fulcio:
+    rootPEM: |-
+      -----BEGIN CERTIFICATE-----
+      ...
+```
+
+## Using the POSIX backend
+
+In values.yaml, set `image.flavor` to `"posix"` (default).
+
+Create a secret for the private key:
+
+```
+openssl ecparam -name prime256v1 -genkey -noout -out /path/to/privkey.pem
+kubectl -n ctlog-tiles-system create secret generic ctlog-signing-key --from-file=signing-key=/path/to/privkey.pem
+```
+
+Encrypted secret keys are not supported.
+
+Configure the private key and storage directory in values.yaml:
+
+```
+server:
+  ...
+  posix:
+    privateKey:
+      path: /etc/ctfe/signer.pem
+      secret:
+        name: signing-key
+        key: signing-key
+        mountPath: /etc/ctfe
+        mountSubPath: signer.pem
+    storageDir:
+      path: /storage
+      name: ctlog
+      volume:
+        hostPath:
+          path: /data/ctlog-storage
+          type: Directory
+```
+
+## Using the GCP backend
+
+The deployment needs to be running in a GKE cluster with workload identity
+enabled and with permission to access secrets, storage objects, and Spanner
+databases.
+
+In values.yaml, set `image.flavor` to `"gcp"`.
+
+Create a Spanner instance and database in GCP:
+
+```
+gcloud spanner instances create tesseract \
+    --config=regional-us-west1 \
+    --description="test" --nodes=1
+gcloud spanner databases create sequencer --instance tesseract
+# If using antispam, create the antispam database too:
+# gcloud spanner databases create antispam --instance tesseract
+```
+
+Create a GCS bucket:
+
+```
+gcloud storage buckets create gs://unique-tesseract-bucket-name
+```
+
+Create secrets in Secret Manager for both the private and public keys:
+
+```
+gcloud secrets create tesseract-private --data-file=/path/to/privkey.pem
+gcloud secrets create tesseract-public --data-file=/path/to/pubkey.pem
+```
+
+Configure the Spanner path, bucket, and signer keys in values.yaml:
+
+```
+server:
+  ...
+  gcp:
+    spanner: projects/my-project/instances/tesseract/databases/sequencer
+    bucket: unique-tesseract-bucket-name
+    signer:
+      privateKey: projects/1234/secrets/tesseract-private/versions/1
+      publicKey: projects/1234/secrets/tesseract-public/versions/1
+```
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/charts/ctlog-tiles/templates/_helpers.tpl
+++ b/charts/ctlog-tiles/templates/_helpers.tpl
@@ -1,0 +1,166 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ctlog-tiles.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ctlog-tiles.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ctlog-tiles.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ctlog-tiles.labels" -}}
+helm.sh/chart: {{ include "ctlog-tiles.chart" . }}
+{{ include "ctlog-tiles.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ctlog-tiles.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ctlog-tiles.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ctlog-tiles.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ctlog-tiles.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Server Arguments
+*/}}
+{{- define "ctlog-tiles.args" -}}
+{{- if .Values.server.antispam }}
+{{- if .Values.server.antispam.inmemoryAntispamCacheSize }}
+- {{ printf "--inmemory_antispam_cache_size=%s" .Values.server.antispam.inmemoryAntispamCacheSize | quote }}
+{{- end }}
+{{- if .Values.server.antispam.pushbackMaxAntispamLag }}
+- {{ printf "--pushback_max_antispam_lag=%d" (.Values.server.antispam.pushbackMaxAntispamLag | int) | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.server.tesseraLifecycle }}
+{{- if .Values.server.tesseraLifecycle.batchMaxAge }}
+- {{ printf "--batch_max_age=%s" .Values.server.tesseraLifecycle.batchMaxAge | quote }}
+{{- end }}
+{{- if .Values.server.tesseraLifecycle.batchMaxSize }}
+- {{ printf "--batch_max-_ize=%d" (.Values.server.tesseraLifecycle.batchMaxSize | int) | quote }}
+{{- end }}
+{{- if .Values.server.tesseraLifecycle.checkpointInterval }}
+- {{ printf "--checkpoint_interval=%s" .Values.server.tesseraLifecycle.checkpointInterval | quote }}
+{{- end }}
+{{- if .Values.server.tesseraLifecycle.pushbackMaxOutstanding }}
+- {{ printf "--pushback_max_outstanding=%d" (.Values.server.tesseraLifecycle.pushbackMaxOutstanding | int) | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.server.gcp }}
+- {{ printf "--bucket=%s" .Values.server.gcp.bucket | quote }}
+- {{ printf "--spanner_db_path=%s" .Values.server.gcp.spanner | quote }}
+{{- if .Values.server.gcp.signer }}
+- {{ printf "--signer_public_key_secret_name=%s" .Values.server.gcp.signer.publicKey | quote }}
+- {{ printf "--signer_private_key_secret_name=%s" .Values.server.gcp.signer.privateKey | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.server.posix }}
+- {{ printf "--storage_dir=%s" (.Values.server.posix.storageDir).path | quote }}
+{{- if .Values.server.posix.privateKey }}
+- {{ printf "--private_key=%s" .Values.server.posix.privateKey.path | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.server.hostname }}
+- {{ printf "--origin=%s" .Values.server.hostname | quote }}
+{{- end }}
+- {{ printf "--http_endpoint=0.0.0.0:%d" (default 6962 (.Values.server.http.port | int)) | quote }}
+{{- if .Values.server.serverConfig }}
+{{- if .Values.server.serverConfig.timeout }}
+- {{ printf "--client_http_timeout=%s" .Values.server.timeout | quote }}
+{{- end }}
+{{- end }}
+- "--ext_key_usages=CodeSigning"
+- {{ printf "-v=%s" .Values.server.logLevel | quote }}
+- {{ printf "--roots_pem_file=%s" .Values.server.fulcio.path | quote }}
+{{- if .Values.server.witnessing }}
+- "--witness_policy_file=/etc/witness-config/witness.policy
+{{- if .Values.server.witnessing.witnessTimeout }}
+- {{ printf "--witness_timeout=%s" .Values.server.witnessing.witnessTimeout }}
+{{- end }}
+{{- end }}
+{{-  range .Values.server.extraArgs }}
+- {{ . | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "ctlog-tiles.containerPorts" -}}
+{{- range . }}
+- name: {{ .name }}
+  containerPort: {{ (ternary .port .targetPort (empty .targetPort)) | int }}
+  protocol: {{ default "TCP" .protocol }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the image path for the passed in image field
+*/}}
+{{- define "ctlog-tiles.image" -}}
+{{- $version := printf "@%s" .version -}}
+{{- if ne (substr 0 7 .version) "sha256:" -}}
+{{- $version = printf ":%s" .version -}}
+{{- if and (eq .flavor "posix") .posixSHA -}}
+{{- $version = printf "%s@%s" $version .posixSHA }}
+{{- else if and (eq .flavor "gcp") .gcpSHA -}}
+{{- $version = printf "%s@%s" $version .gcpSHA }}
+{{- end -}}
+{{- end -}}
+{{- printf "%s/%s/%s%s" .registry .repository .flavor $version -}}
+{{- end -}}
+
+{{/*
+Return the port for the external service listener
+*/}}
+{{- define "ctlog-tiles.port" -}}
+{{ (index .Values.service.ports 0).port | int }}
+{{- end -}}
+
+{{/*
+Create the ingress service backend
+*/}}
+{{- define "ctlog-tiles.ingress.backend" -}}
+service:
+  name: {{ include "ctlog-tiles.fullname" . }}
+  port:
+    number: {{ include "ctlog-tiles.port" . }}
+{{- end -}}

--- a/charts/ctlog-tiles/templates/configmap.yaml
+++ b/charts/ctlog-tiles/templates/configmap.yaml
@@ -1,0 +1,25 @@
+{{- if (.Values.server.fulcio).configMap }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.server.fulcio.configMap.name }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "ctlog-tiles.labels" . | nindent 4 }}
+data:
+  {{ .Values.server.fulcio.configMap.key }}: {{ .Values.server.fulcio.rootPEM | quote }}
+{{- end }}
+{{- if .Values.server.witnessing }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.server.witnessing.configMapName }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "ctlog-tiles.labels" . | nindent 4 }}
+data:
+  witness.policy: {{ required "Witness policy is required" .Values.server.witnessing.witnessPolicy | quote }}
+{{- end }}
+

--- a/charts/ctlog-tiles/templates/deployment.yaml
+++ b/charts/ctlog-tiles/templates/deployment.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ctlog-tiles.fullname" . }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "ctlog-tiles.labels" . | nindent 4 }}
+{{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ctlog-tiles.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ctlog-tiles.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ctlog-tiles.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ template "ctlog-tiles.image" .Values.image }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+{{ include "ctlog-tiles.args" . | indent 12 }}
+          ports:
+{{- include "ctlog-tiles.containerPorts" .Values.service.ports | indent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+{{- if or ((.Values.server.posix).privateKey).secret (.Values.server.fulcio).configMap .Values.server.witnessing }}
+          volumeMounts:
+{{- end }}
+{{- if ((.Values.server.posix).privateKey).secret }}
+            - name: {{ .Values.server.posix.privateKey.secret.name }}
+              mountPath: {{ (.Values.server.posix.privateKey.secret).mountPath }}
+              readOnly: true
+{{- end }}
+{{- if ((.Values.server.fulcio).configMap) }}
+            - name: {{ .Values.server.fulcio.configMap.name }}
+              mountPath: {{ .Values.server.fulcio.configMap.mountPath }}
+              readOnly: true
+{{- end }}
+{{- if (.Values.server.posix).storageDir }}
+            - name: {{ .Values.server.posix.storageDir.name }}
+              mountPath: {{ .Values.server.posix.storageDir.path }}
+{{- end }}
+{{- if .Values.server.witnessing }}
+            - name: witness-config
+              mountPath: /etc/witness-config
+{{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+{{- if or ((.Values.server.posix).privateKey).secret (.Values.server.fulcio).configMap (.Values.server.posix).storageDir .Values.server.witnessing }}
+      volumes:
+{{- end }}
+{{- if ((.Values.server.posix).privateKey).secret }}
+        - name: {{ .Values.server.posix.privateKey.secret.name }}
+          secret:
+            secretName: {{ .Values.server.posix.privateKey.secret.name }}
+            items:
+              - key: {{ .Values.server.posix.privateKey.secret.key }}
+                path: {{ .Values.server.posix.privateKey.secret.mountSubPath }}
+{{- end }}
+{{- if (.Values.server.fulcio).configMap }}
+        - name: {{ .Values.server.fulcio.configMap.name }}
+          configMap:
+            name: {{ .Values.server.fulcio.configMap.name }}
+            items:
+              - key: {{ .Values.server.fulcio.configMap.key }}
+                path: {{ .Values.server.fulcio.configMap.mountSubPath }}
+{{- end }}
+{{- if ((.Values.server.posix).storageDir).volume }}
+        - name: {{ .Values.server.posix.storageDir.name -}}
+          {{- toYaml .Values.server.posix.storageDir.volume | nindent 10 }}
+{{- end }}
+{{- if .Values.server.witnessing }}
+        - name: witness-config
+          configMap:
+            name: {{ .Values.server.witnessing.configMapName }}
+{{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ctlog-tiles/templates/namespace.yaml
+++ b/charts/ctlog-tiles/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name }}
+{{- end }}

--- a/charts/ctlog-tiles/templates/service.yaml
+++ b/charts/ctlog-tiles/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ctlog-tiles.fullname" . }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "ctlog-tiles.labels" . | nindent 4 }}
+  annotations:
+    cloud.google.com/neg: '{"exposed_ports": {"{{ .Values.neg.http.port }}":{"name": "{{ .Values.neg.http.name }}"}}}'
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- tpl (toYaml .Values.service.ports) . | nindent 4 }}
+  selector:
+    {{- include "ctlog-tiles.selectorLabels" . | nindent 4 }}

--- a/charts/ctlog-tiles/templates/serviceaccount.yaml
+++ b/charts/ctlog-tiles/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ctlog-tiles.serviceAccountName" . }}
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "ctlog-tiles.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/ctlog-tiles/values.schema.json
+++ b/charts/ctlog-tiles/values.schema.json
@@ -1,0 +1,294 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "flavor": {
+                    "type": "string"
+                },
+                "gcpSHA": {
+                    "type": "string"
+                },
+                "posixSHA": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "lifecycle": {
+            "type": "object",
+            "properties": {
+                "preStop": {
+                    "type": "object",
+                    "properties": {
+                        "exec": {
+                            "type": "object",
+                            "properties": {
+                                "command": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "namespace": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "neg": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "nodeSelector": {
+            "type": "object",
+            "properties": {
+                "iam.gke.io/gke-metadata-server-enabled": {
+                    "type": "string"
+                }
+            }
+        },
+        "podAnnotations": {
+            "type": "object"
+        },
+        "podLabels": {
+            "type": "object"
+        },
+        "podSecurityContext": {
+            "type": "object"
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object"
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                }
+            }
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "antispam": {
+                    "type": "object"
+                },
+                "extraArgs": {
+                    "type": "array"
+                },
+                "fulcio": {
+                    "type": "object",
+                    "properties": {
+                        "configMap": {
+                            "type": "object",
+                            "properties": {
+                                "key": {
+                                    "type": "string"
+                                },
+                                "mountPath": {
+                                    "type": "string"
+                                },
+                                "mountSubPath": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "rootPEM": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "gcp": {
+                    "type": "object"
+                },
+                "hostname": {
+                    "type": "string"
+                },
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "port": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "logLevel": {
+                    "type": "string"
+                },
+                "posix": {
+                    "type": "object"
+                },
+                "serverConfig": {
+                    "type": "object"
+                },
+                "tesseraLivecycle": {
+                    "type": "object"
+                },
+                "witnessing": {
+                    "type": "object"
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "ports": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "integer"
+                            },
+                            "protocol": {
+                                "type": "string"
+                            },
+                            "targetPort": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "automount": {
+                    "type": "boolean"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "integer"
+        },
+        "tolerations": {
+            "type": "array"
+        }
+    }
+}

--- a/charts/ctlog-tiles/values.yaml
+++ b/charts/ctlog-tiles/values.yaml
@@ -1,0 +1,149 @@
+# Default values for ctlog-tiles.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  flavor: posix  # Must be posix or gcp
+  registry: ghcr.io
+  repository: sigstore/scaffolding/tesseract
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  # crane digest ghcr.io/sigstore/ctlog-tiles:v2.0.1
+  version: v0.1.1
+  posixSHA: sha256:767c2dbe4a83be9243246564244aa381322f08f2a864371f62b880c465033815
+  gcpSHA: sha256:17d3788b736de01ab0586359626c01789910a6e2981e7b90014fbda8689f5017
+
+namespace:
+  create: false
+  name: ctlog-tiles-system
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65533
+
+service:
+  type: ClusterIP
+  ports:
+    - name: 6962-tcp
+      port: 80
+      protocol: TCP
+      targetPort: 6962
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 6962
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 6962
+
+terminationGracePeriodSeconds: 65
+lifecycle:
+  preStop:
+    exec:
+      command: ["sleep", "15"]
+
+nodeSelector:
+  iam.gke.io/gke-metadata-server-enabled: "true"   # support workload identity
+
+tolerations: []
+
+affinity: {}
+
+neg:
+  http:
+    name: ""
+    port: 80
+
+# Server arguments
+server:
+  antispam: {}
+    # inmemoryAntispamCacheSize: "256k"
+    # pushbackMaxAntispamLag: 2048
+  tesseraLivecycle: {}
+    # batchMaxAge: "250ms"
+    # batchMaxSize: 256
+    # checkpointInterval: "1.5s"
+    # pushbackMaxOutstanding: 4096
+  gcp: {}
+    # spanner: projects/{projectId}/instances/{instanceId}/databases/{databaseId}
+    # antispamSpanner: projects/{projectId}/instances/{instanceId}/databases/{databaseId}
+    # bucket: tesseract-bucket
+    # signer:
+    #   privateKey: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}
+    #   publicKey: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}
+  posix: {}
+    # privateKey:
+    #   path: /etc/ctfe/signer.pem
+    #   secret:
+    #     name: signing-key
+    #     key: signing-key
+    #     mountPath: /etc/ctfe
+    #     mountSubPath: signer.pem
+    # storageDir:
+    #   path: /storage
+    #   name: ctlog
+    #   volume:
+    #     hostPath:
+    #       path: /data/ctlog-storage
+    #       type: Directory
+  fulcio:
+    rootPEM: ""
+    path: /etc/fulcio/roots.pem
+    configMap:
+      name: fulcio-roots
+      key: fulcio
+      mountPath: /etc/fulcio
+      mountSubPath: roots.pem
+  witnessing: {}
+    # witnessTimeout: "5s"
+    # witnessPolicy: ""
+    # configMapName: witness-config
+  hostname: "localhost"
+  http:
+    port: "6962"
+  serverConfig: {}
+    # timeout: "5s"
+  logLevel: "1"
+  extraArgs: []

--- a/ct-install.yaml
+++ b/ct-install.yaml
@@ -6,6 +6,7 @@ excluded-charts:
   - fulcio
   - scaffold
   - rekor-tiles
+  - ctlog-tiles
 validate-maintainers: false
 remote: origin
 target-branch: main


### PR DESCRIPTION
Add a chart named ctlog-tiles to support TesseraCT as an alternative CT log for Fulcio. The POSIX and GCP backends are supported.

This chart has a unique way of crafting the image string based on which personality (posix or gcp) is chosen. This lets values.yaml/Chart.yaml still be the source of truth for the image version, which is consistent with how Sigstore charts are used in the public good instance (as opposed to overriding the image version in the infrastructure values.yaml).

This is closely based on the rekor-tiles chart. It creates NEGs but no explicit Ingress gateway, since a multi-purpose load balancer needs to be created externally to link the service to the backend bucket.

Relates to https://github.com/sigstore/rekor-tiles/issues/73

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
