### PR TITLE
Use less confusing name for security contexts

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.10.6
+version: 1.0.0
 appVersion: 0.13.1
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -57,6 +57,13 @@ spec:
       secretRef:
         name: mysecret
 ```
+
+**IMPORTANT:** Earlier versions of the chart were using
+`webhook.podSecurityContext` for defining the container level security context
+and `webhook.securityContext` for the one at pod level. Recent versions use the
+more intuitive `webhook.podSecurityContext` and
+`webhook.containerSecurityContext`.
+
 #### Configuring Custom Certificate Authorities (CA)
 
 The `policy-controller` can be configured to use custom CAs to communicate to container registries, for example, when you have a private registry with a self-signed TLS certificate.
@@ -172,6 +179,11 @@ helm uninstall [RELEASE_NAME]
 | webhook.affinity | object | `{}` |  |
 | webhook.automountServiceAccountToken | bool | `true` |  |
 | webhook.configData | object | `{}` |  |
+| webhook.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| webhook.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| webhook.containerSecurityContext.enabled | bool | `true` |  |
+| webhook.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
+| webhook.containerSecurityContext.runAsUser | int | `1000` |  |
 | webhook.customLabels | object | `{}` |  |
 | webhook.env | object | `{}` |  |
 | webhook.envFrom | object | `{}` |  |
@@ -187,11 +199,8 @@ helm uninstall [RELEASE_NAME]
 | webhook.podAnnotations | object | `{}` |  |
 | webhook.podDisruptionBudget.enabled | bool | `true` |  |
 | webhook.podDisruptionBudget.minAvailable | int | `1` |  |
-| webhook.podSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
-| webhook.podSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| webhook.podSecurityContext.enabled | bool | `true` |  |
-| webhook.podSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
-| webhook.podSecurityContext.runAsUser | int | `1000` |  |
+| webhook.podSecurityContext.enabled | bool | `false` |  |
+| webhook.podSecurityContext.runAsUser | int | `65532` |  |
 | webhook.priorityClass | string | `""` |  |
 | webhook.registryCaBundle | object | `{}` |  |
 | webhook.replicaCount | int | `1` |  |
@@ -199,8 +208,6 @@ helm uninstall [RELEASE_NAME]
 | webhook.resources.limits.memory | string | `"512Mi"` |  |
 | webhook.resources.requests.cpu | string | `"100m"` |  |
 | webhook.resources.requests.memory | string | `"128Mi"` |  |
-| webhook.securityContext.enabled | bool | `false` |  |
-| webhook.securityContext.runAsUser | int | `65532` |  |
 | webhook.service.annotations | object | `{}` |  |
 | webhook.service.port | int | `443` |  |
 | webhook.service.type | string | `"ClusterIP"` |  |

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -137,9 +137,9 @@ spec:
             httpHeaders:
             - name: k-kubelet-probe
               value: "webhook"
-{{- if .Values.webhook.podSecurityContext.enabled }}
+{{- if .Values.webhook.containerSecurityContext.enabled }}
         securityContext:
-        {{- with .Values.webhook.podSecurityContext }}
+        {{- with .Values.webhook.containerSecurityContext }}
         {{- omit . "enabled" | toYaml | nindent 10}}
         {{- end }}
 {{- end }}
@@ -160,9 +160,9 @@ spec:
       # high value that we respect whatever value it has configured for the lame duck grace period.
       terminationGracePeriodSeconds: 300
 
-      {{- if .Values.webhook.securityContext.enabled }}
+      {{- if .Values.webhook.podSecurityContext.enabled }}
       securityContext:
-        {{- with .Values.webhook.securityContext }}
+        {{- with .Values.webhook.podSecurityContext }}
         {{- omit . "enabled" | toYaml | nindent 8}}
         {{- end }}
       {{- end }}

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -91,7 +91,7 @@
           "title": "image",
           "type": "object"
         },
-        "podSecurityContext": {
+        "containerSecurityContext": {
           "properties": {
             "enabled": {
               "default": false,
@@ -100,7 +100,7 @@
             }
           },
           "required": [],
-          "title": "podSecurityContext",
+          "title": "containerSecurityContext",
           "type": "object"
         },
         "priorityClass": {
@@ -310,7 +310,7 @@
           "title": "podDisruptionBudget",
           "type": "object"
         },
-        "podSecurityContext": {
+        "containerSecurityContext": {
           "properties": {
             "allowPrivilegeEscalation": {
               "default": false,
@@ -353,7 +353,7 @@
             }
           },
           "required": [],
-          "title": "podSecurityContext",
+          "title": "containerSecurityContext",
           "type": "object"
         },
         "priorityClass": {
@@ -413,7 +413,7 @@
           "title": "resources",
           "type": "object"
         },
-        "securityContext": {
+        "podSecurityContext": {
           "properties": {
             "enabled": {
               "default": false,
@@ -427,7 +427,7 @@
             }
           },
           "required": [],
-          "title": "securityContext",
+          "title": "podSecurityContext",
           "type": "object"
         },
         "service": {

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -38,12 +38,12 @@ webhook:
     requests:
       cpu: 100m
       memory: 128Mi
-  securityContext:
+  podSecurityContext:
     enabled: false
     runAsUser: 65532
   failurePolicy: Fail
   podAnnotations: {}
-  podSecurityContext:
+  containerSecurityContext:
     enabled: true
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true


### PR DESCRIPTION
## Description of the change

The pod-level security context of policy controller's webhook was configured using `webhook.securityContext`, while the container-level security context was using `webhook.podSecurityContext`. The former is debatable, the latter is just plain confusing.

This change uses explicit names for both contexts, removing all confusion.

## Existing or Associated Issue(s)

n/a, if needed I will create one

## Additional Information

This is probably a breaking change, as users overriding security context need to change their values.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
