### PR TITLE
Deprecate createcerts

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.6.16
+version: 2.7.0
 appVersion: 1.8.3
 
 keywords:

--- a/charts/fulcio/README.md.gotmpl
+++ b/charts/fulcio/README.md.gotmpl
@@ -106,3 +106,20 @@ To enabled access from external resources, an Ingress resource is created. The c
 >     grpc:
 >       enabled: false
 > ```
+
+## Key Management for Certificate Authority
+
+Fulcio supports the following options for certificate authority backends: googleca, pkcs11ca, aws-hsm-root-ca-path, fileca, kmsca. For all except fileca, set the appropriate values in values.yaml to configure the CA roots for the given backend.
+
+For fileca, the signing keys and certificates need to be generated manually and uploaded as a Secret that the Fulcio deployment can mount. For example:
+
+```
+pass=mysecurepassword
+openssl ecparam -name prime256v1 -genkey | openssl pkcs8 -passout "pass:${pass}" -topk8 -out "/pki/key.pem" # generate the signing key
+openssl req -x509 -new -key /pki/key.pem -out /pki/cert.pem -sha256 -days 100 -subj "/O=test/CN=self.signed.ca" -passin "pass:${pass}" # generate the self-signed certificate
+kubectl -n fulcio-system create secret generic --from-file=private=/pki/key.pem --from-file=cert=/pki/cert.pem --from-literal=password=$pass fulcio-server-secret # upload to Kubernetes
+```
+
+Alternatively, use a secure system like [ExternalSecret](https://external-secrets.io/v0.4.4/api-externalsecret/) to safely store and populate key material.
+
+By default, createcerts.enabled is set to true and will automatically generate key material. This setting is deprecated and it is recommended to change this setting to false and generate your own key material. This way, the root certificate can be shared out of band with the CTlog chart and it does not need to implicitly trust the Fulcio HTTP server to provide the correct root.

--- a/charts/fulcio/templates/NOTES.txt
+++ b/charts/fulcio/templates/NOTES.txt
@@ -1,0 +1,4 @@
+{{- if (.Values.createcerts).enabled -}}
+**DEPRECATED**: createcerts is deprecated. If using the fileca certificate authority, create the fulcio-server-secrets secret containing the private signing key, encryption password, and certiticate authority manually or using a secure system like External Secret (see README.md for more information).
+To dismiss this message, set createcerts.enabled=false in your values.yaml.
+{{- end -}}


### PR DESCRIPTION
Using createcerts to have the Fulcio chart automatically generate its roots for the fileca certificate authority mode is deprecated. Instead, users should generate their key material out of band. This way, the CTLog chart can share the Fulcio root in its configuration instead of implicitly trusting Fulcio's rootCerts endpoint.

Relates to https://github.com/sigstore/scaffolding/issues/1833

This is how the installation/upgrade message now appears if createcerts.enabled is not set to false:

```
Release "fulcio" has been upgraded. Happy Helming!
NAME: fulcio
LAST DEPLOYED: Thu Dec 11 10:41:09 2025
NAMESPACE: fulcio-system
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
**DEPRECATED**: createcerts is deprecated. If using the fileca certificate authority, create the fulcio-secrets secret containing the private signing key, encryption password, and certiticate authority manually.
To dismiss this message, set createcerts.enabled=false in your values.yaml.
```

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
