### PR TITLE
Use transparency-dev tesseract image

### DIFF
--- a/charts/ctlog-tiles/Chart.yaml
+++ b/charts/ctlog-tiles/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctlog-tiles
 description: Tiles-based certificate log (TesseraCT)
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.1.1
 keywords:
   - security
@@ -16,6 +16,6 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
     - name: tesseract-posix
-      image: ghcr.io/sigstore/scaffolding/tesseract/posix:v0.1.1@sha256:767c2dbe4a83be9243246564244aa381322f08f2a864371f62b880c465033815
+      image: ghcr.io/transparency-dev/tesseract/posix:v0.1.1@sha256:8269c32a1b1deb159ba75016421314cb5e68304c2813d444aca3efdf0e9d5027
     - name: tesseract-gcp
-      image: ghcr.io/sigstore/scaffolding/tesseract/gcp:v0.1.1@sha256:17d3788b736de01ab0586359626c01789910a6e2981e7b90014fbda8689f5017
+      image: ghcr.io/transparency-dev/tesseract/gcp:v0.1.1@sha256:aca34cce9b40279c3b9041d98241e188bd30dd932a7cd73e3b3e9fdda13532f7

--- a/charts/ctlog-tiles/README.md
+++ b/charts/ctlog-tiles/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1](https://img.shields.io/badge/AppVersion-v0.1.1-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1](https://img.shields.io/badge/AppVersion-v0.1.1-informational?style=flat-square)
 
 Tiles-based certificate log (TesseraCT)
 
@@ -136,11 +136,11 @@ server:
 | affinity | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.flavor | string | `"posix"` |  |
-| image.gcpSHA | string | `"sha256:17d3788b736de01ab0586359626c01789910a6e2981e7b90014fbda8689f5017"` |  |
-| image.posixSHA | string | `"sha256:767c2dbe4a83be9243246564244aa381322f08f2a864371f62b880c465033815"` |  |
+| image.gcpSHA | string | `"sha256:aca34cce9b40279c3b9041d98241e188bd30dd932a7cd73e3b3e9fdda13532f7"` |  |
+| image.posixSHA | string | `"sha256:8269c32a1b1deb159ba75016421314cb5e68304c2813d444aca3efdf0e9d5027"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |
-| image.repository | string | `"sigstore/scaffolding/tesseract"` |  |
+| image.repository | string | `"ghcr.io/transparency-dev/tesseract"` |  |
 | image.version | string | `"v0.1.1"` |  |
 | imagePullSecrets | list | `[]` |  |
 | lifecycle.preStop.exec.command[0] | string | `"sleep"` |  |

--- a/charts/ctlog-tiles/values.yaml
+++ b/charts/ctlog-tiles/values.yaml
@@ -7,13 +7,13 @@ replicaCount: 1
 image:
   flavor: posix  # Must be posix or gcp
   registry: ghcr.io
-  repository: sigstore/scaffolding/tesseract
+  repository: ghcr.io/transparency-dev/tesseract
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   # crane digest ghcr.io/sigstore/ctlog-tiles:v2.0.1
   version: v0.1.1
-  posixSHA: sha256:767c2dbe4a83be9243246564244aa381322f08f2a864371f62b880c465033815
-  gcpSHA: sha256:17d3788b736de01ab0586359626c01789910a6e2981e7b90014fbda8689f5017
+  posixSHA: sha256:8269c32a1b1deb159ba75016421314cb5e68304c2813d444aca3efdf0e9d5027
+  gcpSHA: sha256:aca34cce9b40279c3b9041d98241e188bd30dd932a7cd73e3b3e9fdda13532f7
 
 namespace:
   create: false


### PR DESCRIPTION
TesseraCT is producing its own images so we don't need to maintain our own in scaffolding.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
