### PR TITLE
Bump Rekor v2 to v2.1.0

### DIFF
--- a/charts/rekor-tiles/Chart.yaml
+++ b/charts/rekor-tiles/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rekor-tiles
 description: Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 type: application
-version: 1.0.5
-appVersion: "2.0.1"
+version: 1.1.0
+appVersion: "2.1.0"
 keywords:
   - security
   - transparency logs
@@ -15,5 +15,7 @@ maintainers:
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/images: |
-    - name: rekor-tiles
-      image: ghcr.io/sigstore/rekor-tiles:v2.0.1@sha256:640300626b3f3aa6c068df92a3f2336320c1327ba42ce84f44b893379adbadef
+    - name: rekor-tiles-gcp
+      image: ghcr.io/sigstore/rekor-tiles/gcp:v2.1.0@sha256:fc3f2e814c9c7a00064047cfaaa3a1b11f61aee1fd081308ddd8608c1f8bee38
+    - name: rekor-tiles-posix
+      image: ghcr.io/sigstore/rekor-tiles/posix:v2.1.0@sha256:23dca2f666638fa61a9e4bc7dab1b524a616bdfe19fb9723e95b5c5000f724dc

--- a/charts/rekor-tiles/README.md
+++ b/charts/rekor-tiles/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 
@@ -58,10 +58,13 @@ If using Tink or another KMS, provide the KMS configuration through values.yaml.
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
+| image.flavor | string | `"gcp"` |  |
+| image.gcpSHA | string | `"sha256:fc3f2e814c9c7a00064047cfaaa3a1b11f61aee1fd081308ddd8608c1f8bee38"` |  |
+| image.posixSHA | string | `"sha256:23dca2f666638fa61a9e4bc7dab1b524a616bdfe19fb9723e95b5c5000f724dc"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |
 | image.repository | string | `"sigstore/rekor-tiles"` |  |
-| image.version | string | `"v2.0.1@sha256:640300626b3f3aa6c068df92a3f2336320c1327ba42ce84f44b893379adbadef"` |  |
+| image.version | string | `"v2.1.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | lifecycle.preStop.exec.command[0] | string | `"sleep"` |  |
 | lifecycle.preStop.exec.command[1] | string | `"15"` |  |
@@ -95,6 +98,7 @@ If using Tink or another KMS, provide the KMS configuration through values.yaml.
 | server.hostname | string | `"localhost"` |  |
 | server.http.metricsPort | string | `"2112"` |  |
 | server.http.port | string | `"3000"` |  |
+| server.posix | object | `{}` |  |
 | server.readOnly | bool | `false` |  |
 | server.serverConfig | object | `{}` |  |
 | server.signer | object | `{}` |  |

--- a/charts/rekor-tiles/templates/deployment.yaml
+++ b/charts/rekor-tiles/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             {{- toYaml .Values.lifecycle | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-{{- if or .Values.server.signer.file .Values.server.grpcSvcTLS .Values.server.signer.tink .Values.server.witnessing }}
+{{- if or .Values.server.signer.file .Values.server.grpcSvcTLS .Values.server.signer.tink .Values.server.witnessing (.Values.server.posix).storageDir }}
           volumeMounts:
 {{- end }}
 {{- if .Values.server.signer.file }}
@@ -92,8 +92,12 @@ spec:
             - name: witness-config
               mountPath: /etc/witness-config
 {{- end }}
+{{- if (.Values.server.posix).storageDir }}
+            - name: {{ .Values.server.posix.storageDir.name }}
+              mountPath: {{ .Values.server.posix.storageDir.path }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-{{- if or .Values.server.signer.file .Values.server.grpcSvcTLS .Values.server.signer.tink .Values.server.witnessing }}
+{{- if or .Values.server.signer.file .Values.server.grpcSvcTLS .Values.server.signer.tink .Values.server.witnessing (.Values.server.posix).storageDir }}
       volumes:
 {{- end }}
 {{- if ((.Values.server.signer.file).secret).name }}
@@ -123,6 +127,10 @@ spec:
         - name: witness-config
           configMap:
             name: {{ .Values.server.witnessing.configMapName }}
+{{- end }}
+{{- if ((.Values.server.posix).storageDir).volume }}
+        - name: {{ .Values.server.posix.storageDir.name -}}
+          {{- toYaml .Values.server.posix.storageDir.volume | nindent 10 }}
 {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/rekor-tiles/values.schema.json
+++ b/charts/rekor-tiles/values.schema.json
@@ -10,6 +10,15 @@
     "image": {
       "type": "object",
       "properties": {
+        "flavor": {
+            "type": "string"
+        },
+        "gcpSHA": {
+            "type": "string"
+        },
+        "posixSHA": {
+            "type": "string"
+        },
         "registry": {
           "type": "string"
         },
@@ -24,6 +33,9 @@
         }
       },
       "required": [
+        "flavor",
+        "gcpSHA",
+        "posixSHA",
         "pullPolicy",
         "registry",
         "repository",
@@ -326,6 +338,10 @@
           "type": "object",
           "properties": {}
         },
+        "posix": {
+          "type": "object",
+          "properties": {}
+        },
         "grpc": {
           "type": "object",
           "properties": {
@@ -387,6 +403,7 @@
         "grpcSvcTLS",
         "hostname",
         "http",
+        "posix",
         "readOnly",
         "serverConfig",
         "signer",

--- a/charts/rekor-tiles/values.yaml
+++ b/charts/rekor-tiles/values.yaml
@@ -5,12 +5,15 @@
 replicaCount: 1
 
 image:
+  flavor: gcp  # Must be gcp or posix
   registry: ghcr.io
   repository: sigstore/rekor-tiles
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  # crane digest ghcr.io/sigstore/rekor-tiles:v2.0.1
-  version: v2.0.1@sha256:640300626b3f3aa6c068df92a3f2336320c1327ba42ce84f44b893379adbadef
+  # crane digest ghcr.io/sigstore/rekor-tiles/gcp:v2.1.0
+  version: v2.1.0
+  gcpSHA: sha256:fc3f2e814c9c7a00064047cfaaa3a1b11f61aee1fd081308ddd8608c1f8bee38
+  posixSHA: sha256:23dca2f666638fa61a9e4bc7dab1b524a616bdfe19fb9723e95b5c5000f724dc
 
 namespace:
   create: false
@@ -109,6 +112,16 @@ server:
   antispam: {}
   tesseraLivecycle: {}
   gcp: {}
+    # spanner: projects/{projectId}/instances/{instanceId}/databases/{databaseId}
+    # bucket: rekor-tiles-bucket
+  posix: {}
+    # storageDir:
+    #   path: /storage
+    #   name: ctlog
+    #   volume:
+    #     hostPath:
+    #       path: /data/rekor-tiles-storage
+    #       type: Directory
   grpc:
     port: "3001"
   hostname: "localhost"
@@ -118,7 +131,7 @@ server:
   serverConfig: {}
   readOnly: false
   grpcSvcTLS: {}
-  signer: {}
+  signer: {}  # posix supports file, gcp supports file, kms, and tink
     # file:
     #   path: /pki/signer.pem
     #   withPassword: false


### PR DESCRIPTION
We now produce multiple containers for each storage backend, so I've also mirrored the ctlog-tiles chart's usage of 'flavor' to support multiple different backends.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
