### PR TITLE
Add opt-in flag for fulcio init

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.7.3
+version: 2.7.4
 appVersion: 1.8.5
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.7.3](https://img.shields.io/badge/Version-2.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.5](https://img.shields.io/badge/AppVersion-1.8.5-informational?style=flat-square)
+![Version: 2.7.4](https://img.shields.io/badge/Version-2.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.5](https://img.shields.io/badge/AppVersion-1.8.5-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 
@@ -111,6 +111,7 @@ helm uninstall [RELEASE_NAME]
 | forceNamespace | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | init.containerResources | object | `{}` |  |
+| init.enabled | bool | `false` |  |
 | init.image.curl.imagePullPolicy | string | `"IfNotPresent"` |  |
 | init.image.curl.registry | string | `"docker.io"` |  |
 | init.image.curl.repository | string | `"curlimages/curl"` |  |

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
-{{- if not .Values.server.args.disable_ct_log }}
+{{- if and (not .Values.server.args.disable_ct_log) .Values.init.enabled }}
       initContainers:
         - name: "check-ctlog-health"
           image: "{{ template "fulcio.image" .Values.init.image.curl }}"

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -157,6 +157,9 @@
                 "containerResources": {
                     "type": "object"
                 },
+                "enabled": {
+                    "type": "boolean"
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -5,6 +5,7 @@ namespace:
 imagePullSecrets: []
 
 init:
+  enabled: false
   image:
     curl:
       registry: docker.io


### PR DESCRIPTION
When the legacy ctlog chart is deployed with
`createctconfig.enabled=true`, ctlog depends on fulcio being up and running so it can download the root cert from the /api/v1/rootCert endpoint and use it for the ctlog-secret secret. The init container added a circular dependency because fulcio needed to wait for the ctlog service to be fully up and running. There is not a good way for the fulcio chart to tell how `createctconfig.enabled` is set in the ctlog chart, or even if the ctlog-tiles chart is being used instead, so this changes adds an opt-in flag, defaulting to false, for the deployer to flip if they want the URL check and know that either the ctlog chart is not being used or the createctconfig job is disabled.

Fixes https://github.com/sigstore/helm-charts/issues/1131

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
