### PR TITLE
rekor-tiles: Add support for aws and gcpcloudsql server flavors

### DIFF
--- a/charts/rekor-tiles/Chart.yaml
+++ b/charts/rekor-tiles/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rekor-tiles
 description: Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 type: application
-version: 1.1.2
+version: 1.1.3
 appVersion: "2.2.1"
 keywords:
   - security
@@ -19,3 +19,7 @@ annotations:
       image: ghcr.io/sigstore/rekor-tiles/gcp:v2.2.1@sha256:17f6584cc8f531083a56d3ff2dd4e03b00c604a6b6f6bc62a5e29c7baea46895
     - name: rekor-tiles-posix
       image: ghcr.io/sigstore/rekor-tiles/posix:v2.2.1@sha256:627422bf9da146d1d9ff4e1c1e8301a1780ab6ad9b32bccff51ecd9f8c820e41
+    - name: rekor-tiles-aws
+      image: ghcr.io/sigstore/rekor-tiles/aws:v2.2.1@sha256:cd82665772e1aaf50e270806a0179fd21cf87c88eb5245a047efc7c6ef02d216
+    - name: rekor-tiles-gcpcloudsql
+      image: ghcr.io/sigstore/rekor-tiles/gcpcloudsql:v2.2.1@sha256:cf2cec2cd58c17c2a19c9fea81ef33660d92063935122da0491a30beca6c89b0

--- a/charts/rekor-tiles/README.md
+++ b/charts/rekor-tiles/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
 
 Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 
@@ -58,8 +58,10 @@ If using Tink or another KMS, provide the KMS configuration through values.yaml.
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
+| image.awsSHA | string | `"sha256:cd82665772e1aaf50e270806a0179fd21cf87c88eb5245a047efc7c6ef02d216"` |  |
 | image.flavor | string | `"gcp"` |  |
 | image.gcpSHA | string | `"sha256:17f6584cc8f531083a56d3ff2dd4e03b00c604a6b6f6bc62a5e29c7baea46895"` |  |
+| image.gcpcloudsqlSHA | string | `"sha256:cf2cec2cd58c17c2a19c9fea81ef33660d92063935122da0491a30beca6c89b0"` |  |
 | image.posixSHA | string | `"sha256:627422bf9da146d1d9ff4e1c1e8301a1780ab6ad9b32bccff51ecd9f8c820e41"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |
@@ -91,8 +93,10 @@ If using Tink or another KMS, provide the KMS configuration through values.yaml.
 | securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.runAsUser | int | `65533` |  |
 | server.antispam | object | `{}` |  |
+| server.aws | object | `{}` |  |
 | server.extraArgs | list | `[]` |  |
 | server.gcp | object | `{}` |  |
+| server.gcpcloudsql | object | `{}` |  |
 | server.grpc.port | string | `"3001"` |  |
 | server.grpcSvcTLS | object | `{}` |  |
 | server.hostname | string | `"localhost"` |  |

--- a/charts/rekor-tiles/templates/_helpers.tpl
+++ b/charts/rekor-tiles/templates/_helpers.tpl
@@ -99,6 +99,20 @@ Server Arguments
 - {{ printf "--gcp-bucket=%s" .Values.server.gcp.bucket | quote }}
 - {{ printf "--gcp-spanner=%s" .Values.server.gcp.spanner | quote }}
 {{- end }}
+{{- if .Values.server.gcpcloudsql }}
+- {{ printf "--gcp-cloudsql-dsn=%s" .Values.server.gcpcloudsql.cloudsqlDsn | quote }}
+- {{ printf "--gcp-bucket=%s" .Values.server.gcpcloudsql.bucket | quote }}
+{{- end }}
+{{- if .Values.server.aws }}
+- {{ printf "--aws-bucket=%s" .Values.server.aws.bucket | quote }}
+- {{ printf "--aws-mysql-dsn=%s" .Values.server.aws.mysqlDsn | quote }}
+{{- if .Values.server.aws.maxOpenConns }}
+- {{ printf "--aws-max-open-conns=%d" (.Values.server.aws.maxOpenConns | int) | quote }}
+{{- end }}
+{{- if .Values.server.aws.maxIdleConns }}
+- {{ printf "--aws-max-idle-conns=%d" (.Values.server.aws.maxIdleConns | int) | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.server.posix }}
 - {{ printf "--storage-dir=%s" (.Values.server.posix.storageDir).path | quote }}
 {{- end }}
@@ -180,6 +194,10 @@ Create the image path for the passed in image field
 {{- $version = printf "%s@%s" $version .posixSHA }}
 {{- else if and (eq .flavor "gcp") .gcpSHA -}}
 {{- $version = printf "%s@%s" $version .gcpSHA }}
+{{- else if and (eq .flavor "aws") .awsSHA -}}
+{{- $version = printf "%s@%s" $version .awsSHA }}
+{{- else if and (eq .flavor "gcpcloudsql") .gcpcloudsqlSHA -}}
+{{- $version = printf "%s@%s" $version .gcpcloudsqlSHA }}
 {{- end -}}
 {{- end -}}
 {{- printf "%s/%s/%s%s" .registry .repository .flavor $version -}}

--- a/charts/rekor-tiles/values.schema.json
+++ b/charts/rekor-tiles/values.schema.json
@@ -19,6 +19,12 @@
         "posixSHA": {
             "type": "string"
         },
+        "awsSHA": {
+            "type": "string"
+        },
+        "gcpcloudsqlSHA": {
+            "type": "string"
+        },
         "registry": {
           "type": "string"
         },
@@ -36,6 +42,8 @@
         "flavor",
         "gcpSHA",
         "posixSHA",
+        "awsSHA",
+        "gcpcloudsqlSHA",
         "pullPolicy",
         "registry",
         "repository",
@@ -342,6 +350,14 @@
           "type": "object",
           "properties": {}
         },
+        "aws": {
+          "type": "object",
+          "properties": {}
+        },
+        "gcpcloudsql": {
+          "type": "object",
+          "properties": {}
+        },
         "grpc": {
           "type": "object",
           "properties": {
@@ -404,6 +420,8 @@
         "hostname",
         "http",
         "posix",
+        "aws",
+        "gcpcloudsql",
         "readOnly",
         "serverConfig",
         "signer",

--- a/charts/rekor-tiles/values.yaml
+++ b/charts/rekor-tiles/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  flavor: gcp  # Must be gcp or posix
+  flavor: gcp  # Must be gcp, posix, aws, or gcpcloudsql
   registry: ghcr.io
   repository: sigstore/rekor-tiles
   pullPolicy: IfNotPresent
@@ -15,6 +15,10 @@ image:
   gcpSHA: sha256:17f6584cc8f531083a56d3ff2dd4e03b00c604a6b6f6bc62a5e29c7baea46895
   # crane digest ghcr.io/sigstore/rekor-tiles/posix:v2.2.1
   posixSHA: sha256:627422bf9da146d1d9ff4e1c1e8301a1780ab6ad9b32bccff51ecd9f8c820e41
+  # crane digest ghcr.io/sigstore/rekor-tiles/aws:v2.2.1
+  awsSHA: sha256:cd82665772e1aaf50e270806a0179fd21cf87c88eb5245a047efc7c6ef02d216
+  # crane digest ghcr.io/sigstore/rekor-tiles/gcpcloudsql:v2.2.1
+  gcpcloudsqlSHA: sha256:cf2cec2cd58c17c2a19c9fea81ef33660d92063935122da0491a30beca6c89b0
 
 namespace:
   create: false
@@ -115,6 +119,14 @@ server:
   gcp: {}
     # spanner: projects/{projectId}/instances/{instanceId}/databases/{databaseId}
     # bucket: rekor-tiles-bucket
+  gcpcloudsql: {}
+    # cloudsqlDsn: user:password@tcp(127.0.0.1:3306)/rekor
+    # bucket: rekor-tiles-bucket
+  aws: {}
+    # bucket: rekor-tiles-bucket
+    # mysqlDsn: user:password@tcp(127.0.0.1:3306)/rekor
+    # maxOpenConns: 100
+    # maxIdleConns: 10
   posix: {}
     # storageDir:
     #   path: /storage


### PR DESCRIPTION
Extends the `rekor-tiles` helm chart to fully support deploying with the `aws` and `gcpcloudsql` container images. This adds the server arguments as well for these additional storage backends.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
