### PR TITLE
Add support for external LBs for fulcio and tsa

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.7.5
+version: 2.8.0
 appVersion: 1.8.5
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.7.5](https://img.shields.io/badge/Version-2.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.5](https://img.shields.io/badge/AppVersion-1.8.5-informational?style=flat-square)
+![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.5](https://img.shields.io/badge/AppVersion-1.8.5-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 
@@ -118,6 +118,10 @@ helm uninstall [RELEASE_NAME]
 | init.image.curl.version | string | `"sha256:935d9100e9ba842cdb060de42472c7ca90cfe9a7c96e4dacb55e79e560b3ff40"` | 8.17.0 |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"fulcio-system"` |  |
+| neg.grpc.name | string | `""` |  |
+| neg.grpc.port | int | `5554` |  |
+| neg.http.name | string | `""` |  |
+| neg.http.port | int | `80` |  |
 | server.affinity | object | `{}` |  |
 | server.args.aws_hsm_root_ca_path | string | `nil` |  |
 | server.args.certificateAuthority | string | `"fileca"` |  |

--- a/charts/fulcio/templates/fulcio-service.yaml
+++ b/charts/fulcio/templates/fulcio-service.yaml
@@ -17,6 +17,9 @@ metadata:
   {{- $printed = true -}}
 {{- end }}
 {{- end }}
+{{- if not .Values.server.ingresses }}
+    cloud.google.com/neg: '{"exposed_ports": {"{{ .Values.neg.http.port }}":{"name": "{{ .Values.neg.http.name }}"}, "{{ .Values.neg.grpc.port }}":{"name": "{{ .Values.neg.grpc.name}}"}}}'
+{{- end }}
   labels:
     {{- include "fulcio.labels" . | nindent 4 }}
 {{- if .Values.server.service.labels }}

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -195,6 +195,33 @@
                 }
             }
         },
+                "neg": {
+            "type": "object",
+            "properties": {
+                "grpc": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
         "server": {
             "type": "object",
             "properties": {

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -127,6 +127,14 @@ server:
   nodeSelector: {}
   affinity: {}
 
+neg:
+  http:
+    name: ""
+    port: 80
+  grpc:
+    name: ""
+    port: 5554
+
 createcerts:
   enabled: true
   replicaCount: 1

--- a/charts/tsa/Chart.yaml
+++ b/charts/tsa/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.0.4
+version: 2.1.0
 appVersion: 2.0.5
 
 keywords:

--- a/charts/tsa/README.md
+++ b/charts/tsa/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.0.4](https://img.shields.io/badge/Version-2.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.5](https://img.shields.io/badge/AppVersion-2.0.5-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.5](https://img.shields.io/badge/AppVersion-2.0.5-informational?style=flat-square)
 
 Timestamp Authority issuing RFC3161 signed timestamps.
 
@@ -92,6 +92,8 @@ helm uninstall [RELEASE_NAME]
 | forceNamespace | string | `""` |  |
 | namespace.create | bool | `false` |  |
 | namespace.name | string | `"tsa-system"` |  |
+| neg.http.name | string | `""` |  |
+| neg.http.port | int | `80` |  |
 | server.affinity | object | `{}` |  |
 | server.args.cert_chain | string | `"chain"` |  |
 | server.args.kms_key_resource | string | `"resource"` |  |

--- a/charts/tsa/templates/tsa-service.yaml
+++ b/charts/tsa/templates/tsa-service.yaml
@@ -11,6 +11,8 @@ metadata:
     cloud.google.com/backend-config: '{"ports": {"{{- $.Values.server.svcPort -}}":"{{- printf "%v" $backendConfigName -}}"}}'
   {{- end }}
     cloud.google.com/neg: '{"ingress": true}'
+{{- else }}
+    cloud.google.com/neg: '{"exposed_ports": {"{{ .Values.neg.http.port }}":{"name": "{{ .Values.neg.http.name }}"}}}'
 {{- end }}
   labels:
     {{- include "tsa.labels" . | nindent 4 }}

--- a/charts/tsa/values.schema.json
+++ b/charts/tsa/values.schema.json
@@ -15,6 +15,22 @@
             },
             "type": "object"
         },
+        "neg": {
+            "type": "object",
+            "properties": {
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
         "server": {
             "properties": {
                 "affinity": {

--- a/charts/tsa/values.yaml
+++ b/charts/tsa/values.yaml
@@ -60,5 +60,10 @@ server:
   nodeSelector: {}
   affinity: {}
 
+neg:
+  http:
+    name: ""
+    port: 80
+
 # Force namespace of namespaced resources
 forceNamespace: ""


### PR DESCRIPTION
If Ingresses are not defined, have the Service resources for the fulcio and tsa charts create NEG resources in the GCP infrastructure, which will allow terraform-managed load balancers to forward traffic to the exposed pod ports.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
