### PR TITLE
feat(fulcio): make server livenessProbe and readinessProbe configurable

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.9.3
+version: 2.10.0
 appVersion: 1.8.7
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.9.3](https://img.shields.io/badge/Version-2.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 
@@ -171,10 +171,12 @@ helm uninstall [RELEASE_NAME]
 | server.ingresses[0].staticGlobalIP | string | `"lb-ext-ip"` |  |
 | server.ingresses[0].tls | list | `[]` |  |
 | server.kmsType | string | `"none"` | KMS type for signing key (possible values: "" / "none", "aws") |
+| server.livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/healthz","port":5555,"scheme":"HTTP"},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probe for the fulcio server container. `httpGet.port` should match `server.args.port`. |
 | server.logging.production | bool | `false` |  |
 | server.name | string | `"server"` |  |
 | server.nodeSelector | object | `{}` |  |
 | server.podLabels | object | `{}` | Additional labels to add to the server pod |
+| server.readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/healthz","port":5555,"scheme":"HTTP"},"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe for the fulcio server container. `httpGet.port` should match `server.args.port`. |
 | server.replicaCount | int | `1` |  |
 | server.secret | string | `"fulcio-server-secret"` |  |
 | server.securityContext.runAsNonRoot | bool | `true` |  |

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -117,24 +117,14 @@ spec:
                   name: {{ .Values.server.awsKmsCredentialsSecretName }}
                   key: secretAccessKey
             {{- end }}
+{{- if .Values.server.livenessProbe }}
           livenessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /healthz
-              port: {{ .Values.server.args.port }}
-              scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
+{{ toYaml .Values.server.livenessProbe | indent 12 }}
+{{- end }}
+{{- if .Values.server.readinessProbe }}
           readinessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /healthz
-              port: {{ .Values.server.args.port }}
-              scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
+{{ toYaml .Values.server.readinessProbe | indent 12 }}
+{{- end }}
           volumeMounts:
             - name: fulcio-config
               mountPath: /etc/fulcio-config

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -559,6 +559,74 @@
                 },
                 "tolerations": {
                     "type": "array"
+                },
+                "livenessProbe": {
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "scheme": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                },
+                "readinessProbe": {
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "httpGet": {
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "scheme": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
                 }
             }
         }

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -62,6 +62,28 @@ server:
     name: ""
     annotations: {}
     mountToken: true
+  # -- Liveness probe for the fulcio server container. `httpGet.port` should
+  # match `server.args.port`.
+  livenessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /healthz
+      port: 5555
+      scheme: HTTP
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  # -- Readiness probe for the fulcio server container. `httpGet.port` should
+  # match `server.args.port`.
+  readinessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /healthz
+      port: 5555
+      scheme: HTTP
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
   service:
     type: ClusterIP
     ports:


### PR DESCRIPTION
## Description of the change

Make the fulcio-server `livenessProbe` and `readinessProbe` configurable via Helm values. They were previously hardcoded in `templates/fulcio-deployment.yaml`, so any operator who needed to tune probe timing had to fork the chart.

The default render is byte-identical to the previous hardcoded output, so this is backward compatible for existing deployments.

## Existing or Associated Issue(s)

N/A

## Additional Information

The hardcoded `timeoutSeconds: 1, failureThreshold: 3` is aggressive for environments where the istio sidecar, node networking, or DNS occasionally takes more than 1s, leading to healthy pods being killed by kubelet. Exposing the probes via values lets operators tune for their environment without forking.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.