### PR TITLE
Add persistent storage support for Redis

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.7.12
+version: 1.8.0
 appVersion: 1.5.2
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.7.12](https://img.shields.io/badge/Version-1.7.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 
@@ -117,6 +117,12 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | redis.livenessProbe.timeoutSeconds | int | `1` |  |
 | redis.name | string | `"redis"` |  |
 | redis.nodeSelector | object | `{}` |  |
+| redis.persistence.accessMode | string | `"ReadWriteOnce"` |  |
+| redis.persistence.annotations | object | `{}` |  |
+| redis.persistence.enabled | bool | `true` |  |
+| redis.persistence.existingClaim | string | `""` |  |
+| redis.persistence.size | string | `"5Gi"` |  |
+| redis.persistence.storageClass | string | `""` |  |
 | redis.port | int | `6379` |  |
 | redis.readinessProbe.exec.command[0] | string | `"/bin/sh"` |  |
 | redis.readinessProbe.exec.command[1] | string | `"-i"` |  |

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -119,7 +119,7 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | redis.nodeSelector | object | `{}` |  |
 | redis.persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | redis.persistence.annotations | object | `{}` |  |
-| redis.persistence.enabled | bool | `true` |  |
+| redis.persistence.enabled | bool | `false` |  |
 | redis.persistence.existingClaim | string | `""` |  |
 | redis.persistence.size | string | `"5Gi"` |  |
 | redis.persistence.storageClass | string | `""` |  |

--- a/charts/rekor/templates/redis/deployment.yaml
+++ b/charts/rekor/templates/redis/deployment.yaml
@@ -18,11 +18,10 @@ spec:
     matchLabels:
       {{- include "rekor.redis.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.redis.replicaCount }}
-  {{- if .Values.redis.strategy }}
+  {{- if and .Values.redis.persistence.enabled (eq .Values.redis.persistence.accessMode "ReadWriteOnce") }}
   strategy:
-{{ toYaml .Values.redis.strategy | trim | indent 4 }}
-    {{ if eq .Values.redis.strategy.type "Recreate" }}rollingUpdate: null{{ end }}
-{{- end }}
+    type: Recreate
+  {{- end }}
   template:
     metadata:
     {{- if .Values.redis.podAnnotations }}
@@ -96,5 +95,14 @@ spec:
     {{- end }}
       volumes:
         - name: storage
+        {{- if .Values.redis.persistence.enabled }}
+          persistentVolumeClaim:
+            {{- if .Values.redis.persistence.existingClaim }}
+            claimName: {{ .Values.redis.persistence.existingClaim }}
+            {{- else }}
+            claimName: {{ template "rekor.redis.fullname" . }}
+            {{- end }}
+        {{- else }}
           emptyDir: {}
+        {{- end }}
 {{- end }}

--- a/charts/rekor/templates/redis/pvc.yaml
+++ b/charts/rekor/templates/redis/pvc.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.redis.persistence.accessMode | default "ReadWriteOnce" }}
+    - {{ .Values.redis.persistence.accessMode }}
   {{- if .Values.redis.persistence.storageClass }}
   {{- if eq .Values.redis.persistence.storageClass "-" }}
   storageClassName: ""
@@ -22,5 +22,5 @@ spec:
   {{- end }}
   resources:
     requests:
-      storage: {{ .Values.redis.persistence.size | default "5Gi" }}
+      storage: {{ .Values.redis.persistence.size }}
 {{- end }}

--- a/charts/rekor/templates/redis/pvc.yaml
+++ b/charts/rekor/templates/redis/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.redis.enabled .Values.redis.persistence.enabled (not .Values.redis.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "rekor.redis.fullname" . }}
+{{ include "rekor.namespace" . | indent 2 }}
+  labels:
+    {{- include "rekor.redis.labels" . | nindent 4 }}
+  {{- with .Values.redis.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.redis.persistence.accessMode | default "ReadWriteOnce" }}
+  {{- if .Values.redis.persistence.storageClass }}
+  {{- if eq .Values.redis.persistence.storageClass "-" }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.redis.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size | default "5Gi" }}
+{{- end }}

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -347,45 +347,8 @@
                         }
                     }
                 },
-                "name": {
-                    "type": "string"
-                },
-                "nodeSelector": {
-                    "properties": {},
-                    "type": "object"
-                },
-                "persistence": {
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "accessMode": {
-                            "type": "string",
-                            "enum": [
-                                "ReadWriteOnce",
-                                "ReadWriteMany"
-                            ]
-                        },
-                        "existingClaim": {
-                            "type": "string"
-                        },
-                        "storageClass": {
-                            "type": "string"
-                        },
-                        "size": {
-                            "type": "string"
-                        },
-                        "annotations": {
-                            "properties": {},
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                },
-                "port": {
-                    "type": "integer"
-                },
-                "readinessProbe": {
+                "livenessProbe": {
+                    "type": "object",
                     "properties": {
                         "exec": {
                             "type": "object",
@@ -420,6 +383,29 @@
                 },
                 "nodeSelector": {
                     "type": "object"
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "accessMode": {
+                            "type": "string"
+                        },
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "existingClaim": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "string"
+                        },
+                        "storageClass": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "port": {
                     "type": "integer"

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -347,8 +347,45 @@
                         }
                     }
                 },
-                "livenessProbe": {
-                    "type": "object",
+                "name": {
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "properties": {},
+                    "type": "object"
+                },
+                "persistence": {
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "accessMode": {
+                            "type": "string",
+                            "enum": [
+                                "ReadWriteOnce",
+                                "ReadWriteMany"
+                            ]
+                        },
+                        "existingClaim": {
+                            "type": "string"
+                        },
+                        "storageClass": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "string"
+                        },
+                        "annotations": {
+                            "properties": {},
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "readinessProbe": {
                     "properties": {
                         "exec": {
                             "type": "object",

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -31,7 +31,7 @@ redis:
     version: "sha256:148bb5411c184abd288d9aaed139c98123eeb8824c5d3fce03cf721db58066d8"
   resources: {}
   persistence:
-    enabled: true
+    enabled: false
     annotations: {}
     existingClaim: ""
     storageClass: ""

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -30,6 +30,13 @@ redis:
     # -- 6.2.17-alpine3.21
     version: "sha256:148bb5411c184abd288d9aaed139c98123eeb8824c5d3fce03cf721db58066d8"
   resources: {}
+  persistence:
+    enabled: true
+    annotations: {}
+    existingClaim: ""
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 5Gi
   readinessProbe:
     initialDelaySeconds: 5
     periodSeconds: 10


### PR DESCRIPTION
Add PVC configuration for Redis with support for:
- ReadWriteOnce and ReadWriteMany access modes
- Custom StorageClass selection
- Using an existing PVC
- Automatic deployment strategy selection based on access mode (Recreate for RWO, default RollingUpdate for RWX)

When persistence is disabled, emptyDir is used as before.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
