### PR TITLE
Fix Redis livenessProbe rendering in deployment template

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.7.10
+version: 1.7.11
 appVersion: 1.5.2
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.7.10](https://img.shields.io/badge/Version-1.7.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
+![Version: 1.7.11](https://img.shields.io/badge/Version-1.7.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 
@@ -101,6 +101,15 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | redis.image.registry | string | `"docker.io"` |  |
 | redis.image.repository | string | `"redis"` |  |
 | redis.image.version | string | `"sha256:148bb5411c184abd288d9aaed139c98123eeb8824c5d3fce03cf721db58066d8"` | 6.2.17-alpine3.21 |
+| redis.livenessProbe.exec.command[0] | string | `"/bin/sh"` |  |
+| redis.livenessProbe.exec.command[1] | string | `"-i"` |  |
+| redis.livenessProbe.exec.command[2] | string | `"-c"` |  |
+| redis.livenessProbe.exec.command[3] | string | `"test \"$(redis-cli -h 127.0.0.1 ping)\" = \"PONG\""` |  |
+| redis.livenessProbe.failureThreshold | int | `3` |  |
+| redis.livenessProbe.initialDelaySeconds | int | `5` |  |
+| redis.livenessProbe.periodSeconds | int | `10` |  |
+| redis.livenessProbe.successThreshold | int | `1` |  |
+| redis.livenessProbe.timeoutSeconds | int | `1` |  |
 | redis.name | string | `"redis"` |  |
 | redis.nodeSelector | object | `{}` |  |
 | redis.port | int | `6379` |  |

--- a/charts/rekor/templates/redis/deployment.yaml
+++ b/charts/rekor/templates/redis/deployment.yaml
@@ -58,7 +58,7 @@ spec:
 {{ toYaml .Values.redis.readinessProbe | indent 12 }}
 {{- end }}
 {{- if .Values.redis.livenessProbe }}
-          readinessProbe:
+          livenessProbe:
 {{ toYaml .Values.redis.livenessProbe | indent 12 }}
 {{- end }}
           resources:

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -396,6 +396,37 @@
                     },
                     "type": "object"
                 },
+                "livenessProbe": {
+                    "properties": {
+                        "exec": {
+                            "properties": {
+                                "command": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    },
+                    "type": "object"
+                },
                 "replicaCount": {
                     "type": "integer"
                 },

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -42,6 +42,18 @@ redis:
         - -i
         - -c
         - test "$(redis-cli -h 127.0.0.1 ping)" = "PONG"
+  livenessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+    exec:
+      command:
+        - /bin/sh
+        - -i
+        - -c
+        - test "$(redis-cli -h 127.0.0.1 ping)" = "PONG"
   service:
     type: ClusterIP
     ports:


### PR DESCRIPTION
The original template incorrectly rendered livenessProbe as a second readinessProbe. Fix the template key name and add default livenessProbe configuration to values.yaml.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
