### PR TITLE
Add podLabels and podAnnotations support for fulcio chart

### DIFF
--- a/charts/fulcio/Chart.yaml
+++ b/charts/fulcio/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.9.2
+version: 2.9.3
 appVersion: 1.8.7
 
 keywords:

--- a/charts/fulcio/README.md
+++ b/charts/fulcio/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.9.2](https://img.shields.io/badge/Version-2.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
+![Version: 2.9.3](https://img.shields.io/badge/Version-2.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 Fulcio is a free code signing Certificate Authority, built to make short-lived certificates available to anyone.
 
@@ -88,6 +88,8 @@ helm uninstall [RELEASE_NAME]
 | createcerts.image.version | string | `"sha256:7f59f7c08d1a82ac5fbd6d0f1f9082152dadc8d59022c52780eb3648f4b88112"` |  |
 | createcerts.name | string | `"createcerts"` |  |
 | createcerts.nodeSelector | object | `{}` |  |
+| createcerts.podAnnotations | object | `{}` |  |
+| createcerts.podLabels | object | `{}` |  |
 | createcerts.replicaCount | int | `1` |  |
 | createcerts.securityContext.runAsNonRoot | bool | `true` |  |
 | createcerts.securityContext.runAsUser | int | `65533` |  |

--- a/charts/fulcio/templates/createcerts-job.yaml
+++ b/charts/fulcio/templates/createcerts-job.yaml
@@ -15,6 +15,16 @@ spec:
   ttlSecondsAfterFinished: {{ .Values.createcerts.ttlSecondsAfterFinished }}
 {{- end }}
   template:
+    metadata:
+    {{- if .Values.createcerts.podAnnotations }}
+      annotations:
+        {{ toYaml .Values.createcerts.podAnnotations | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "fulcio.labels" . | nindent 8 }}
+        {{- if .Values.createcerts.podLabels }}
+        {{ toYaml .Values.createcerts.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "fulcio.serviceAccountName.createcerts" . }}
       restartPolicy: Never

--- a/charts/fulcio/templates/fulcio-deployment.yaml
+++ b/charts/fulcio/templates/fulcio-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- toYaml .Values.server.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "fulcio.selectorLabels" . | nindent 8 }}
+        {{- include "fulcio.labels" . | nindent 8 }}
         {{- if .Values.server.podLabels }}
         {{- toYaml .Values.server.podLabels | nindent 8 }}
         {{- end }}

--- a/charts/fulcio/values.schema.json
+++ b/charts/fulcio/values.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
         "config": {
@@ -46,6 +46,12 @@
                     "type": "string"
                 },
                 "nodeSelector": {
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
                     "type": "object"
                 },
                 "replicaCount": {
@@ -195,7 +201,7 @@
                 }
             }
         },
-                "neg": {
+        "neg": {
             "type": "object",
             "properties": {
                 "grpc": {

--- a/charts/fulcio/values.yaml
+++ b/charts/fulcio/values.yaml
@@ -160,6 +160,8 @@ createcerts:
     runAsNonRoot: true
     runAsUser: 65533
   annotations: {}
+  podAnnotations: {}
+  podLabels: {}
   tolerations: []
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
Add podLabels and podAnnotations configuration to fulcio templates to allow setting custom labels and annotations on pod templates.

Additionally, use fulcio.labels instead of fulcio.selectorLabels in deployment pod template for consistency with other charts.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
