### PR TITLE
Add podLabels and podAnnotations support for trillian chart

### DIFF
--- a/charts/trillian/Chart.yaml
+++ b/charts/trillian/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 0.3.14
+version: 0.3.15
 appVersion: 1.7.2
 
 keywords:

--- a/charts/trillian/README.md
+++ b/charts/trillian/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.3.14](https://img.shields.io/badge/Version-0.3.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 0.3.15](https://img.shields.io/badge/Version-0.3.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
 
 Trillian is a log that stores an accurate, immutable and verifiable history of activity.
 
@@ -41,6 +41,7 @@ helm uninstall [RELEASE_NAME]
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | createdb.affinity | object | `{}` |  |
+| createdb.annotations | object | `{}` |  |
 | createdb.dbname | string | `"trillian"` |  |
 | createdb.enabled | bool | `true` |  |
 | createdb.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -49,6 +50,8 @@ helm uninstall [RELEASE_NAME]
 | createdb.image.version | string | `"sha256:3cee6c78973b82af6c3c3632bf8d44dafbab1632b3999a7292b170237c5dd5cc"` | v0.7.31 |
 | createdb.name | string | `"createdb"` |  |
 | createdb.nodeSelector | object | `{}` |  |
+| createdb.podAnnotations | object | `{}` |  |
+| createdb.podLabels | object | `{}` |  |
 | createdb.serviceAccount.annotations | object | `{}` |  |
 | createdb.serviceAccount.create | bool | `false` |  |
 | createdb.serviceAccount.name | string | `""` |  |
@@ -74,6 +77,8 @@ helm uninstall [RELEASE_NAME]
 | logServer.livenessProbe | object | `{}` |  |
 | logServer.name | string | `"log-server"` |  |
 | logServer.nodeSelector | object | `{}` |  |
+| logServer.podAnnotations | object | `{}` |  |
+| logServer.podLabels | object | `{}` |  |
 | logServer.portHTTP | int | `8090` |  |
 | logServer.portRPC | int | `8091` |  |
 | logServer.readinessProbe | object | `{}` |  |
@@ -105,6 +110,8 @@ helm uninstall [RELEASE_NAME]
 | logSigner.livenessProbe | object | `{}` |  |
 | logSigner.name | string | `"log-signer"` |  |
 | logSigner.nodeSelector | object | `{}` |  |
+| logSigner.podAnnotations | object | `{}` |  |
+| logSigner.podLabels | object | `{}` |  |
 | logSigner.portHTTP | int | `8090` |  |
 | logSigner.portRPC | int | `8091` |  |
 | logSigner.readinessProbe | object | `{}` |  |
@@ -169,6 +176,8 @@ helm uninstall [RELEASE_NAME]
 | mysql.persistence.size | string | `"5Gi"` |  |
 | mysql.persistence.storageClass | string | `nil` |  |
 | mysql.persistence.subPath | string | `""` |  |
+| mysql.podAnnotations | object | `{}` |  |
+| mysql.podLabels | object | `{}` |  |
 | mysql.port | int | `3306` |  |
 | mysql.readinessProbe.exec.command[0] | string | `"/etc/init.d/mysql"` |  |
 | mysql.readinessProbe.exec.command[1] | string | `"status"` |  |

--- a/charts/trillian/templates/createdb/createdb-job.yaml
+++ b/charts/trillian/templates/createdb/createdb-job.yaml
@@ -15,6 +15,16 @@ spec:
   ttlSecondsAfterFinished: {{ .Values.createdb.ttlSecondsAfterFinished }}
 {{- end }}
   template:
+    metadata:
+    {{- if .Values.createdb.podAnnotations }}
+      annotations:
+        {{ toYaml .Values.createdb.podAnnotations | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "trillian.mysql.labels" . | nindent 8 }}
+        {{- if .Values.createdb.podLabels }}
+        {{ toYaml .Values.createdb.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "trillian.serviceAccountName.logServer" . }}
       restartPolicy: Never

--- a/charts/trillian/values.schema.json
+++ b/charts/trillian/values.schema.json
@@ -1,10 +1,14 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
     "properties": {
         "createdb": {
+            "type": "object",
             "properties": {
                 "affinity": {
-                    "properties": {},
+                    "type": "object"
+                },
+                "annotations": {
                     "type": "object"
                 },
                 "dbname": {
@@ -14,6 +18,7 @@
                     "type": "boolean"
                 },
                 "image": {
+                    "type": "object",
                     "properties": {
                         "pullPolicy": {
                             "type": "string"
@@ -27,20 +32,24 @@
                         "version": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "name": {
                     "type": "string"
                 },
                 "nodeSelector": {
-                    "properties": {},
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
                     "type": "object"
                 },
                 "serviceAccount": {
+                    "type": "object",
                     "properties": {
                         "annotations": {
-                            "properties": {},
                             "type": "object"
                         },
                         "create": {
@@ -49,8 +58,7 @@
                         "name": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "tolerations": {
                     "type": "array"
@@ -58,8 +66,7 @@
                 "ttlSecondsAfterFinished": {
                     "type": "integer"
                 }
-            },
-            "type": "object"
+            }
         },
         "forceNamespace": {
             "type": "string"
@@ -68,8 +75,10 @@
             "type": "array"
         },
         "initContainerImage": {
+            "type": "object",
             "properties": {
                 "curl": {
+                    "type": "object",
                     "properties": {
                         "imagePullPolicy": {
                             "type": "string"
@@ -83,10 +92,10 @@
                         "version": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "netcat": {
+                    "type": "object",
                     "properties": {
                         "imagePullPolicy": {
                             "type": "string"
@@ -100,16 +109,14 @@
                         "version": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 }
-            },
-            "type": "object"
+            }
         },
         "logServer": {
+            "type": "object",
             "properties": {
                 "affinity": {
-                    "properties": {},
                     "type": "object"
                 },
                 "enabled": {
@@ -119,6 +126,7 @@
                     "type": "array"
                 },
                 "image": {
+                    "type": "object",
                     "properties": {
                         "pullPolicy": {
                             "type": "string"
@@ -132,18 +140,21 @@
                         "version": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "livenessProbe": {
-                    "properties": {},
                     "type": "object"
                 },
                 "name": {
                     "type": "string"
                 },
                 "nodeSelector": {
-                    "properties": {},
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
                     "type": "object"
                 },
                 "portHTTP": {
@@ -153,20 +164,24 @@
                     "type": "integer"
                 },
                 "readinessProbe": {
-                    "properties": {},
                     "type": "object"
                 },
                 "replicaCount": {
                     "type": "integer"
                 },
                 "resources": {
-                    "properties": {},
                     "type": "object"
                 },
                 "service": {
+                    "type": "object",
                     "properties": {
+                        "headless": {
+                            "type": "boolean"
+                        },
                         "ports": {
+                            "type": "array",
                             "items": {
+                                "type": "object",
                                 "properties": {
                                     "name": {
                                         "type": "string"
@@ -180,24 +195,18 @@
                                     "targetPort": {
                                         "type": "integer"
                                     }
-                                },
-                                "type": "object"
-                            },
-                            "type": "array"
+                                }
+                            }
                         },
                         "type": {
                             "type": "string"
-                        },
-                        "headless": {
-                            "type": "boolean"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "serviceAccount": {
+                    "type": "object",
                     "properties": {
                         "annotations": {
-                            "properties": {},
                             "type": "object"
                         },
                         "create": {
@@ -206,19 +215,17 @@
                         "name": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "tolerations": {
                     "type": "array"
                 }
-            },
-            "type": "object"
+            }
         },
         "logSigner": {
+            "type": "object",
             "properties": {
                 "affinity": {
-                    "properties": {},
                     "type": "object"
                 },
                 "enabled": {
@@ -234,6 +241,7 @@
                     "type": "boolean"
                 },
                 "image": {
+                    "type": "object",
                     "properties": {
                         "pullPolicy": {
                             "type": "string"
@@ -247,18 +255,21 @@
                         "version": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "livenessProbe": {
-                    "properties": {},
                     "type": "object"
                 },
                 "name": {
                     "type": "string"
                 },
                 "nodeSelector": {
-                    "properties": {},
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
                     "type": "object"
                 },
                 "portHTTP": {
@@ -268,20 +279,24 @@
                     "type": "integer"
                 },
                 "readinessProbe": {
-                    "properties": {},
                     "type": "object"
                 },
                 "replicaCount": {
                     "type": "integer"
                 },
                 "resources": {
-                    "properties": {},
                     "type": "object"
                 },
                 "service": {
+                    "type": "object",
                     "properties": {
+                        "headless": {
+                            "type": "boolean"
+                        },
                         "ports": {
+                            "type": "array",
                             "items": {
+                                "type": "object",
                                 "properties": {
                                     "name": {
                                         "type": "string"
@@ -295,27 +310,18 @@
                                     "targetPort": {
                                         "type": "integer"
                                     }
-                                },
-                                "type": "object"
-                            },
-                            "type": "array"
+                                }
+                            }
                         },
                         "type": {
                             "type": "string"
-                        },
-                        "headless": {
-                            "type": "boolean"
                         }
-                    },
-                    "type": "object"
-                },
-                "electionSystem": {
-                    "type": "string"
+                    }
                 },
                 "serviceAccount": {
+                    "type": "object",
                     "properties": {
                         "annotations": {
-                            "properties": {},
                             "type": "object"
                         },
                         "create": {
@@ -324,24 +330,24 @@
                         "name": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "tolerations": {
                     "type": "array"
                 }
-            },
-            "type": "object"
+            }
         },
         "mysql": {
+            "type": "object",
             "properties": {
                 "args": {
+                    "type": "array",
                     "items": {
                         "type": "string"
-                    },
-                    "type": "array"
+                    }
                 },
                 "auth": {
+                    "type": "object",
                     "properties": {
                         "existingSecret": {
                             "type": "string"
@@ -355,15 +361,16 @@
                         "username": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "enabled": {
                     "type": "boolean"
                 },
                 "gcp": {
+                    "type": "object",
                     "properties": {
                         "cloudsql": {
+                            "type": "object",
                             "properties": {
                                 "registry": {
                                     "type": "string"
@@ -372,8 +379,10 @@
                                     "type": "string"
                                 },
                                 "resources": {
+                                    "type": "object",
                                     "properties": {
                                         "requests": {
+                                            "type": "object",
                                             "properties": {
                                                 "cpu": {
                                                     "type": "string"
@@ -381,27 +390,26 @@
                                                 "memory": {
                                                     "type": "string"
                                                 }
-                                            },
-                                            "type": "object"
+                                            }
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 },
                                 "securityContext": {
+                                    "type": "object",
                                     "properties": {
                                         "allowPrivilegeEscalation": {
                                             "type": "boolean"
                                         },
                                         "capabilities": {
+                                            "type": "object",
                                             "properties": {
                                                 "drop": {
+                                                    "type": "array",
                                                     "items": {
                                                         "type": "string"
-                                                    },
-                                                    "type": "array"
+                                                    }
                                                 }
-                                            },
-                                            "type": "object"
+                                            }
                                         },
                                         "readOnlyRootFilesystem": {
                                             "type": "boolean"
@@ -409,10 +417,10 @@
                                         "runAsNonRoot": {
                                             "type": "boolean"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 },
                                 "unixDomainSocket": {
+                                    "type": "object",
                                     "properties": {
                                         "enabled": {
                                             "type": "boolean"
@@ -420,14 +428,12 @@
                                         "path": {
                                             "type": "string"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 },
                                 "version": {
                                     "type": "string"
                                 }
-                            },
-                            "type": "object"
+                            }
                         },
                         "enabled": {
                             "type": "boolean"
@@ -436,6 +442,7 @@
                             "type": "string"
                         },
                         "scaffoldSQLProxy": {
+                            "type": "object",
                             "properties": {
                                 "registry": {
                                     "type": "string"
@@ -444,8 +451,10 @@
                                     "type": "string"
                                 },
                                 "resources": {
+                                    "type": "object",
                                     "properties": {
                                         "requests": {
+                                            "type": "object",
                                             "properties": {
                                                 "cpu": {
                                                     "type": "string"
@@ -453,27 +462,26 @@
                                                 "memory": {
                                                     "type": "string"
                                                 }
-                                            },
-                                            "type": "object"
+                                            }
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 },
                                 "securityContext": {
+                                    "type": "object",
                                     "properties": {
                                         "allowPrivilegeEscalation": {
                                             "type": "boolean"
                                         },
                                         "capabilities": {
+                                            "type": "object",
                                             "properties": {
                                                 "drop": {
+                                                    "type": "array",
                                                     "items": {
                                                         "type": "string"
-                                                    },
-                                                    "type": "array"
+                                                    }
                                                 }
-                                            },
-                                            "type": "object"
+                                            }
                                         },
                                         "readOnlyRootFilesystem": {
                                             "type": "boolean"
@@ -481,22 +489,20 @@
                                         "runAsNonRoot": {
                                             "type": "boolean"
                                         }
-                                    },
-                                    "type": "object"
+                                    }
                                 },
                                 "version": {
                                     "type": "string"
                                 }
-                            },
-                            "type": "object"
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "hostname": {
                     "type": "string"
                 },
                 "image": {
+                    "type": "object",
                     "properties": {
                         "pullPolicy": {
                             "type": "string"
@@ -510,21 +516,21 @@
                         "version": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "livenessProbe": {
+                    "type": "object",
                     "properties": {
                         "exec": {
+                            "type": "object",
                             "properties": {
                                 "command": {
+                                    "type": "array",
                                     "items": {
                                         "type": "string"
-                                    },
-                                    "type": "array"
+                                    }
                                 }
-                            },
-                            "type": "object"
+                            }
                         },
                         "failureThreshold": {
                             "type": "integer"
@@ -541,22 +547,21 @@
                         "timeoutSeconds": {
                             "type": "integer"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "name": {
                     "type": "string"
                 },
                 "persistence": {
+                    "type": "object",
                     "properties": {
                         "accessModes": {
+                            "type": "array",
                             "items": {
                                 "type": "string"
-                            },
-                            "type": "array"
+                            }
                         },
                         "annotations": {
-                            "properties": {},
                             "type": "object"
                         },
                         "enabled": {
@@ -572,29 +577,35 @@
                             "type": "string"
                         },
                         "storageClass": {
-                            "type": ["string", "null"]
+                            "type": "null"
                         },
                         "subPath": {
                             "type": "string"
                         }
-                    },
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
                     "type": "object"
                 },
                 "port": {
                     "type": "integer"
                 },
                 "readinessProbe": {
+                    "type": "object",
                     "properties": {
                         "exec": {
+                            "type": "object",
                             "properties": {
                                 "command": {
+                                    "type": "array",
                                     "items": {
                                         "type": "string"
-                                    },
-                                    "type": "array"
+                                    }
                                 }
-                            },
-                            "type": "object"
+                            }
                         },
                         "failureThreshold": {
                             "type": "integer"
@@ -611,29 +622,29 @@
                         "timeoutSeconds": {
                             "type": "integer"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "replicaCount": {
                     "type": "integer"
                 },
                 "resources": {
-                    "properties": {},
                     "type": "object"
                 },
                 "secret": {
+                    "type": "object",
                     "properties": {
                         "annotations": {
-                            "properties": {},
                             "type": "object"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "service": {
+                    "type": "object",
                     "properties": {
                         "ports": {
+                            "type": "array",
                             "items": {
+                                "type": "object",
                                 "properties": {
                                     "name": {
                                         "type": "string"
@@ -647,21 +658,18 @@
                                     "targetPort": {
                                         "type": "integer"
                                     }
-                                },
-                                "type": "object"
-                            },
-                            "type": "array"
+                                }
+                            }
                         },
                         "type": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "serviceAccount": {
+                    "type": "object",
                     "properties": {
                         "annotations": {
-                            "properties": {},
                             "type": "object"
                         },
                         "create": {
@@ -670,21 +678,20 @@
                         "name": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "strategy": {
+                    "type": "object",
                     "properties": {
                         "type": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 }
-            },
-            "type": "object"
+            }
         },
         "namespace": {
+            "type": "object",
             "properties": {
                 "create": {
                     "type": "boolean"
@@ -692,28 +699,26 @@
                 "name": {
                     "type": "string"
                 }
-            },
-            "type": "object"
+            }
         },
         "quotaSystem": {
+            "type": "object",
             "properties": {
                 "driver": {
                     "type": "string"
                 }
-            },
-            "type": "object"
+            }
         },
         "storageSystem": {
+            "type": "object",
             "properties": {
                 "driver": {
                     "type": "string"
                 },
                 "envCredentials": {
-                    "type": ["array", "string", "null"]
+                    "type": "array"
                 }
-            },
-            "type": "object"
+            }
         }
-    },
-    "type": "object"
+    }
 }

--- a/charts/trillian/values.yaml
+++ b/charts/trillian/values.yaml
@@ -123,6 +123,8 @@ mysql:
     existingClaim: ""
     accessModes:
       - ReadWriteOnce
+  podAnnotations: {}
+  podLabels: {}
   serviceAccount:
     create: true
     name: ""
@@ -140,6 +142,8 @@ logServer:
     pullPolicy: IfNotPresent
     # -- trillian v1.7.2 (scaffolding v0.7.31)
     version: sha256:d953a8eb3f9311e55ebee754de234f1f63e4db2d5e76c15326c288fb0887bb11
+  podAnnotations: {}
+  podLabels: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -178,6 +182,8 @@ logSigner:
     pullPolicy: IfNotPresent
     # -- trillian v1.7.2 (scaffolding v0.7.31)
     version: sha256:51631983a7e6f0b3faeb188c590e65b9793a6a6617e0631f8b4fd68e98d0460e
+  podAnnotations: {}
+  podLabels: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -213,6 +219,9 @@ createdb:
     create: false
     name: ""
     annotations: {}
+  annotations: {}
+  podAnnotations: {}
+  podLabels: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Add podLabels and podAnnotations configuration to trillian templates to allow setting custom labels and annotations on pod templates.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
