### PR TITLE
Add podLabels and podAnnotations support for tuf chart

### DIFF
--- a/charts/tuf/Chart.yaml
+++ b/charts/tuf/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tuf
 description: A framework for securing software update systems - the scaffolding implementation
 type: application
-version: 0.1.29
+version: 0.1.30
 appVersion: 0.7.31
 
 home: https://sigstore.dev/

--- a/charts/tuf/README.md
+++ b/charts/tuf/README.md
@@ -1,6 +1,6 @@
 # tuf
 
-![Version: 0.1.29](https://img.shields.io/badge/Version-0.1.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.31](https://img.shields.io/badge/AppVersion-0.7.31-informational?style=flat-square)
+![Version: 0.1.30](https://img.shields.io/badge/Version-0.1.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.31](https://img.shields.io/badge/AppVersion-0.7.31-informational?style=flat-square)
 
 A framework for securing software update systems - the scaffolding implementation
 
@@ -25,6 +25,8 @@ A framework for securing software update systems - the scaffolding implementatio
 | deployment.imagePullPolicy | string | `"IfNotPresent"` |  |
 | deployment.name | string | `"tuf"` |  |
 | deployment.nodeSelector | object | `{}` |  |
+| deployment.podAnnotations | object | `{}` |  |
+| deployment.podLabels | object | `{}` |  |
 | deployment.port | int | `8080` |  |
 | deployment.registry | string | `"ghcr.io"` |  |
 | deployment.replicas | int | `1` |  |

--- a/charts/tuf/templates/_helpers.tpl
+++ b/charts/tuf/templates/_helpers.tpl
@@ -73,7 +73,7 @@ Define the tuf.namespace template if set with forceNamespace or .Release.Namespa
 {{- end -}}
 
 {{/*
-Create labels for tuf components
+Selector labels
 */}}
 {{- define "tuf.matchLabels" -}}
 app.kubernetes.io/component: {{ .Values.deployment.name | quote }}
@@ -81,8 +81,15 @@ app.kubernetes.io/name: {{ include "tuf.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
-{{- define "tuf.metaLabels" -}}
+{{/*
+Common labels
+*/}}
+{{- define "tuf.labels" -}}
 helm.sh/chart: {{ include "tuf.chart" . }}
+{{ include "tuf.matchLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 

--- a/charts/tuf/templates/deployment.yaml
+++ b/charts/tuf/templates/deployment.yaml
@@ -10,13 +10,11 @@ metadata:
   labels:
     {{- include "tuf.metaLabels" . | nindent 4 }}
     {{- include "tuf.matchLabels" . | nindent 4 }}
-
 spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
       {{- include "tuf.matchLabels" . | nindent 6 }}
-
 {{- if .Values.deployment.strategy }}
   strategy:
 {{ toYaml .Values.deployment.strategy | trim | indent 4 }}
@@ -24,9 +22,15 @@ spec:
 {{- end }}
   template:
     metadata:
+    {{- if .Values.deployment.podAnnotations }}
+      annotations:
+        {{ toYaml .Values.deployment.podAnnotations | nindent 8 }}
+    {{- end }}
       labels:
-        {{- include "tuf.metaLabels" . | nindent 8 }}
-        {{- include "tuf.matchLabels" . | nindent 8 }}
+        {{- include "tuf.labels" . | nindent 8 }}
+        {{- if .Values.deployment.podLabels }}
+        {{ toYaml .Values.deployment.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
       containers:

--- a/charts/tuf/templates/deployment.yaml
+++ b/charts/tuf/templates/deployment.yaml
@@ -8,8 +8,7 @@ metadata:
     {{- toYaml .Values.deployment.annotations | nindent 4 }}
 {{- end }}
   labels:
-    {{- include "tuf.metaLabels" . | nindent 4 }}
-    {{- include "tuf.matchLabels" . | nindent 4 }}
+    {{- include "tuf.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:

--- a/charts/tuf/values.schema.json
+++ b/charts/tuf/values.schema.json
@@ -1,14 +1,14 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
     "properties": {
         "deployment": {
+            "type": "object",
             "properties": {
                 "affinity": {
-                    "properties": {},
                     "type": "object"
                 },
                 "containerSecurityContext": {
-                    "properties": {},
                     "type": "object"
                 },
                 "imagePullPolicy": {
@@ -18,7 +18,12 @@
                     "type": "string"
                 },
                 "nodeSelector": {
-                    "properties": {},
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
                     "type": "object"
                 },
                 "port": {
@@ -37,7 +42,6 @@
                     "type": "object"
                 },
                 "securityContext": {
-                    "properties": {},
                     "type": "object"
                 },
                 "tolerations": {
@@ -47,21 +51,12 @@
                     "type": "string"
                 },
                 "volumeMounts": {
-                    "type": "array",
-                    "items": {
-                        "properties": {},
-                        "type": "object"
-                    }
+                    "type": "array"
                 },
                 "volumes": {
-                    "type": "array",
-                    "items": {
-                        "properties": {},
-                        "type": "object"
-                    }
+                    "type": "array"
                 }
-            },
-            "type": "object"
+            }
         },
         "enabled": {
             "type": "boolean"
@@ -76,9 +71,9 @@
             "type": "array"
         },
         "ingress": {
+            "type": "object",
             "properties": {
                 "annotations": {
-                    "properties": {},
                     "type": "object"
                 },
                 "className": {
@@ -88,9 +83,12 @@
                     "type": "boolean"
                 },
                 "http": {
+                    "type": "object",
                     "properties": {
                         "hosts": {
+                            "type": "array",
                             "items": {
+                                "type": "object",
                                 "properties": {
                                     "host": {
                                         "type": "string"
@@ -98,21 +96,18 @@
                                     "path": {
                                         "type": "string"
                                     }
-                                },
-                                "type": "object"
-                            },
-                            "type": "array"
+                                }
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "name": {
                     "type": "string"
                 }
-            },
-            "type": "object"
+            }
         },
         "namespace": {
+            "type": "object",
             "properties": {
                 "create": {
                     "type": "boolean"
@@ -120,8 +115,7 @@
                 "name": {
                     "type": "string"
                 }
-            },
-            "type": "object"
+            }
         },
         "roleBindingName": {
             "type": "string"
@@ -130,26 +124,16 @@
             "type": "string"
         },
         "secrets": {
+            "type": "object",
             "properties": {
                 "ctlog": {
+                    "type": "object",
                     "properties": {
                         "create": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
+                            "type": "boolean"
                         },
                         "enabled": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "name": {
-                            "type": "string",
-                            "examples": [
-                                "rekor-public-key"
-                            ]
+                            "type": "boolean"
                         },
                         "key": {
                             "type": "string"
@@ -160,28 +144,16 @@
                         "path": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "fulcio": {
+                    "type": "object",
                     "properties": {
                         "create": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
+                            "type": "boolean"
                         },
                         "enabled": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "name": {
-                            "type": "string",
-                            "examples": [
-                                "fulcio-server-secret"
-                            ]
+                            "type": "boolean"
                         },
                         "key": {
                             "type": "string"
@@ -192,28 +164,16 @@
                         "path": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "rekor": {
+                    "type": "object",
                     "properties": {
                         "create": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
+                            "type": "boolean"
                         },
                         "enabled": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "name": {
-                            "type": "string",
-                            "examples": [
-                                "ctlog-public-key"
-                            ]
+                            "type": "boolean"
                         },
                         "key": {
                             "type": "string"
@@ -224,28 +184,16 @@
                         "path": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "tsa": {
+                    "type": "object",
                     "properties": {
                         "create": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
+                            "type": "boolean"
                         },
                         "enabled": {
-                            "type": "boolean",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "name": {
-                            "type": "string",
-                            "examples": [
-                                "tsa-cert-chain"
-                            ]
+                            "type": "boolean"
                         },
                         "key": {
                             "type": "string"
@@ -256,13 +204,12 @@
                         "path": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 }
-            },
-            "type": "object"
+            }
         },
         "service": {
+            "type": "object",
             "properties": {
                 "name": {
                     "type": "string"
@@ -270,12 +217,10 @@
                 "port": {
                     "type": "integer"
                 }
-            },
-            "type": "object"
+            }
         },
         "serviceAccountName": {
             "type": "string"
         }
-    },
-    "type": "object"
+    }
 }

--- a/charts/tuf/values.yaml
+++ b/charts/tuf/values.yaml
@@ -18,6 +18,8 @@ deployment:
   resources: {}
   containerSecurityContext: {}
   securityContext: {}
+  podAnnotations: {}
+  podLabels: {}
   tolerations: []
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
Add podLabels and podAnnotations configuration to tuf deployment template to allow setting custom labels and annotations on pod templates.

Additionally, consolidate tuf.metaLabels and tuf.matchLabels into a single tuf.labels helper for consistency with other sigstore charts.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
