### PR TITLE
fix(rekor): migrate redis persistence from accessMode to accessModes …

### DIFF
--- a/charts/rekor/Chart.yaml
+++ b/charts/rekor/Chart.yaml
@@ -4,7 +4,7 @@ description: Part of the sigstore project, Rekor is a timestamping server and tr
 
 type: application
 
-version: 1.8.0
+version: 1.8.1
 appVersion: 1.5.2
 
 keywords:

--- a/charts/rekor/README.md
+++ b/charts/rekor/README.md
@@ -1,6 +1,6 @@
 # rekor
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
+![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
 
 Part of the sigstore project, Rekor is a timestamping server and transparency log for storing signatures, as well as an API based server for validation
 
@@ -117,7 +117,7 @@ Part of the sigstore project, Rekor is a timestamping server and transparency lo
 | redis.livenessProbe.timeoutSeconds | int | `1` |  |
 | redis.name | string | `"redis"` |  |
 | redis.nodeSelector | object | `{}` |  |
-| redis.persistence.accessMode | string | `"ReadWriteOnce"` |  |
+| redis.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | redis.persistence.annotations | object | `{}` |  |
 | redis.persistence.enabled | bool | `false` |  |
 | redis.persistence.existingClaim | string | `""` |  |

--- a/charts/rekor/templates/redis/deployment.yaml
+++ b/charts/rekor/templates/redis/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     matchLabels:
       {{- include "rekor.redis.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.redis.replicaCount }}
-  {{- if and .Values.redis.persistence.enabled (eq .Values.redis.persistence.accessMode "ReadWriteOnce") }}
+  {{- if and .Values.redis.persistence.enabled (has "ReadWriteOnce" .Values.redis.persistence.accessModes) }}
   strategy:
     type: Recreate
   {{- end }}

--- a/charts/rekor/templates/redis/pvc.yaml
+++ b/charts/rekor/templates/redis/pvc.yaml
@@ -4,15 +4,14 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ template "rekor.redis.fullname" . }}
 {{ include "rekor.namespace" . | indent 2 }}
-  labels:
-    {{- include "rekor.redis.labels" . | nindent 4 }}
   {{- with .Values.redis.persistence.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  labels:
+    {{- include "rekor.redis.labels" . | nindent 4 }}
 spec:
-  accessModes:
-    - {{ .Values.redis.persistence.accessMode }}
+  accessModes: {{- toYaml .Values.redis.persistence.accessModes | nindent 4 }}
   {{- if .Values.redis.persistence.storageClass }}
   {{- if eq .Values.redis.persistence.storageClass "-" }}
   storageClassName: ""

--- a/charts/rekor/values.schema.json
+++ b/charts/rekor/values.schema.json
@@ -387,8 +387,11 @@
                 "persistence": {
                     "type": "object",
                     "properties": {
-                        "accessMode": {
-                            "type": "string"
+                        "accessModes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "annotations": {
                             "type": "object"

--- a/charts/rekor/values.yaml
+++ b/charts/rekor/values.yaml
@@ -35,7 +35,8 @@ redis:
     annotations: {}
     existingClaim: ""
     storageClass: ""
-    accessMode: ReadWriteOnce
+    accessModes:
+      - ReadWriteOnce
     size: 5Gi
   readinessProbe:
     initialDelaySeconds: 5


### PR DESCRIPTION
fix(rekor): migrate redis persistence from accessMode to accessModes list

Changed the Redis PersistentVolumeClaim template to use `accessModes` (plural) instead of the singular `accessMode`.

Updated the Deployment template to use `has` for checking the `accessModes` list when determining the Recreate strategy.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
