### PR TITLE
set otel values, allow extraEnv override

### DIFF
--- a/charts/ctlog-tiles/Chart.yaml
+++ b/charts/ctlog-tiles/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctlog-tiles
 description: Tiles-based certificate log (TesseraCT)
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: v0.1.1
 keywords:
   - security

--- a/charts/ctlog-tiles/README.md
+++ b/charts/ctlog-tiles/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1](https://img.shields.io/badge/AppVersion-v0.1.1-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1](https://img.shields.io/badge/AppVersion-v0.1.1-informational?style=flat-square)
 
 Tiles-based certificate log (TesseraCT)
 
@@ -167,6 +167,7 @@ server:
 | securityContext.runAsUser | int | `65533` |  |
 | server.antispam | object | `{}` |  |
 | server.extraArgs | list | `[]` |  |
+| server.extraEnv | list | `[]` |  |
 | server.fulcio.configMap.key | string | `"fulcio"` |  |
 | server.fulcio.configMap.mountPath | string | `"/etc/fulcio"` |  |
 | server.fulcio.configMap.mountSubPath | string | `"roots.pem"` |  |

--- a/charts/ctlog-tiles/templates/deployment.yaml
+++ b/charts/ctlog-tiles/templates/deployment.yaml
@@ -51,6 +51,20 @@ spec:
             {{- toYaml .Values.lifecycle | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(POD_NAMESPACE),k8s.container.name={{ .Chart.Name }}"
+            {{- with .Values.server.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
 {{- if or ((.Values.server.posix).privateKey).secret (.Values.server.fulcio).configMap (.Values.server.posix).storageDir .Values.server.witnessing }}
           volumeMounts:
 {{- end }}

--- a/charts/ctlog-tiles/values.schema.json
+++ b/charts/ctlog-tiles/values.schema.json
@@ -180,6 +180,9 @@
                 "extraArgs": {
                     "type": "array"
                 },
+                "extraEnv": {
+                    "type": "array"
+                },
                 "fulcio": {
                     "type": "object",
                     "properties": {

--- a/charts/ctlog-tiles/values.yaml
+++ b/charts/ctlog-tiles/values.yaml
@@ -147,3 +147,10 @@ server:
     # timeout: "5s"
   logLevel: "1"
   extraArgs: []
+  # Additional env vars appended to the container. The chart always sets
+  # POD_NAME, POD_NAMESPACE, and OTEL_RESOURCE_ATTRIBUTES (needed so the
+  # GCP OTel metric exporter maps to k8s_container rather than k8s_cluster
+  # and each pod gets its own time series). Anything added here is appended.
+  extraEnv: []
+    # - name: MY_VAR
+    #   value: "my-value"


### PR DESCRIPTION
seeing lots of timeseries collisions for ctlog-tiles deployments in GCP, this should set the correct values to squelch this