### PR TITLE
Disable log export

### DIFF
--- a/charts/ctlog-tiles/Chart.yaml
+++ b/charts/ctlog-tiles/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ctlog-tiles
 description: Tiles-based certificate log (TesseraCT)
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: v0.1.2
 keywords:
   - security

--- a/charts/ctlog-tiles/README.md
+++ b/charts/ctlog-tiles/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.2](https://img.shields.io/badge/AppVersion-v0.1.2-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.2](https://img.shields.io/badge/AppVersion-v0.1.2-informational?style=flat-square)
 
 Tiles-based certificate log (TesseraCT)
 

--- a/charts/ctlog-tiles/templates/_helpers.tpl
+++ b/charts/ctlog-tiles/templates/_helpers.tpl
@@ -114,6 +114,7 @@ Server Arguments
 {{- if .Values.server.logLevel }}
 - {{ printf "-slog_level=%s" .Values.server.logLevel | quote }}
 {{- end }}
+- "--slog_to_cloud_api=false"
 - {{ printf "--roots_pem_file=%s" .Values.server.fulcio.path | quote }}
 {{- if .Values.server.witnessing }}
 - "--witness_policy_file=/etc/witness-config/witness.policy


### PR DESCRIPTION
The tesseract pod is currently experiencing an error "ERROR --otel_project_id is required when --slog_to_cloud_api is true". slog_to_cloud_api defaults to true and otel_project_id defaults to empty. Since logs from Kubernetes pods are collected in the GCP log explorer, let's turn the new slog export flag off for now to resolve this error.

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

<!-- Describe the change being requested. -->

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
