### PR TITLE
stop gpg signing charts (we still sign oci distributed ones)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,29 +38,11 @@ jobs:
         run: |
           helm repo add sigstore https://sigstore.github.io/helm-charts
 
-      - name: Install sigstore Helm plugin
-        run: |
-          helm plugin install https://github.com/sigstore/helm-sigstore
-
-      - name: Install GPG Keys
-        run: |
-          cat <(echo -e "${{ secrets.GPG_PRIVATE_KEY }}") | gpg --import --batch
-          gpg --export > /home/runner/.gnupg/pubring.gpg
-          gpg --export-secret-keys > /home/runner/.gnupg/secring.gpg
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_SIGN: "true"
-          CR_KEY: "${{ secrets.GPG_KEY_NAME }}"
-          CR_KEYRING: "/home/runner/.gnupg/secring.gpg"
-
-      - name: Upload Helm Charts to Rekor
-        run: |
-          for chart in `find .cr-release-packages -name '*.tgz' -print`; do
-            helm sigstore upload --keyring=/home/runner/.gnupg/secring.gpg ${chart}
-          done
+          CR_SIGN: "false"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_SIGN: "false"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0


### PR DESCRIPTION
The GPG key associated with this repository has been expired for several years. With Helm version 4, the charts no longer correctly verify with the "helm verify" command.

However, we are still using Cosign to actually sign the contents of the chart as they are distributed over OCI. We want to continue to do this. Since the signatures with GPG weren't really valid and we would prefer OCI distribution anyway, this just stops signing the charts with GPG.