### PR TITLE
feat(policy-controller): configure webhook strategy

### DIFF
--- a/charts/policy-controller/Chart.yaml
+++ b/charts/policy-controller/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 type: application
 
 name: policy-controller
-version: 0.10.7
+version: 0.10.8
 appVersion: 0.13.1
 
 maintainers:

--- a/charts/policy-controller/README.md
+++ b/charts/policy-controller/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 0.10.7](https://img.shields.io/badge/Version-0.10.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
+![Version: 0.10.8](https://img.shields.io/badge/Version-0.10.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
 
 The Helm chart for Policy  Controller
 
@@ -207,6 +207,9 @@ helm uninstall [RELEASE_NAME]
 | webhook.serviceAccount.annotations | object | `{}` |  |
 | webhook.serviceAccount.create | bool | `true` |  |
 | webhook.serviceAccount.name | string | `""` |  |
+| webhook.strategy.rollingUpdate.maxSurge | string | `"25%"` |  |
+| webhook.strategy.rollingUpdate.maxUnavailable | string | `"25%"` |  |
+| webhook.strategy.type | string | `"RollingUpdate"` |  |
 | webhook.volumeMounts | list | `[]` |  |
 | webhook.volumes | list | `[]` |  |
 | webhook.webhookNames.defaulting | string | `"defaulting.clusterimagepolicy.sigstore.dev"` |  |

--- a/charts/policy-controller/templates/webhook/deployment_webhook.yaml
+++ b/charts/policy-controller/templates/webhook/deployment_webhook.yaml
@@ -8,6 +8,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.webhook.replicaCount }}
+  strategy:
+{{- toYaml .Values.webhook.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "policy-controller.selectorLabels" . | nindent 6 }}

--- a/charts/policy-controller/values.schema.json
+++ b/charts/policy-controller/values.schema.json
@@ -474,6 +474,43 @@
           "title": "serviceAccount",
           "type": "object"
         },
+        "strategy": {
+          "properties": {
+            "rollingUpdate": {
+              "properties": {
+                "maxSurge": {
+                  "default": "25%",
+                  "required": [],
+                  "title": "maxSurge",
+                  "type": [
+                    "string",
+                    "integer"
+                  ]
+                },
+                "maxUnavailable": {
+                  "default": "25%",
+                  "required": [],
+                  "title": "maxUnavailable",
+                  "type": [
+                    "string",
+                    "integer"
+                  ]
+                }
+              },
+              "required": [],
+              "title": "rollingUpdate",
+              "type": "object"
+            },
+            "type": {
+              "default": "RollingUpdate",
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "strategy",
+          "type": "object"
+        },
         "volumeMounts": {
           "items": {
             "required": []

--- a/charts/policy-controller/values.yaml
+++ b/charts/policy-controller/values.yaml
@@ -16,6 +16,17 @@ webhook:
   customLabels: {}
   configData: {}
   replicaCount: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # @schema
+      # type: [string, integer]
+      # @schema
+      maxUnavailable: 25%
+      # @schema
+      # type: [string, integer]
+      # @schema
+      maxSurge: 25%
   name: webhook
   image:
     repository: ghcr.io/sigstore/policy-controller/policy-controller


### PR DESCRIPTION
## Description of the change

Expose the policy-controller webhook Deployment strategy as
`webhook.strategy`.

The default preserves the existing rolling-update behavior:

```yaml
webhook:
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 25%
      maxSurge: 25%
```

This allows small, multi-replica installations to set
`webhook.strategy.rollingUpdate.maxUnavailable: 1`, avoiding rollout
deadlocks while retaining one available webhook replica.

## Existing or Associated Issue(s)

Fixes #748.

Related: #749 previously proposed this capability but was closed without merge.

## Additional Information

- Bumped chart version to `0.10.8`.
- Added generated values schema and README entries.
- `maxUnavailable` and `maxSurge` accept Kubernetes `IntOrString` values.
- Validated with `helm lint` and `ct lint`.

## Checklist

- [x] Chart version bumped in `Chart.yaml`
- [x] Variables documented in `values.yaml` and README
- [x] JSON Schema generated
- [x] Chart Testing `ct lint` passes
- [x] Commit includes DCO sign-off
