### PR TITLE
add extraEnv support to rekor-tiles

### DIFF
--- a/charts/rekor-tiles/Chart.yaml
+++ b/charts/rekor-tiles/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rekor-tiles
 description: Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: "2.3.0"
 keywords:
   - security

--- a/charts/rekor-tiles/README.md
+++ b/charts/rekor-tiles/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 Part of the sigstore project, Rekor v2 (Rekor on tiles) is a signature transparency log
 
@@ -95,6 +95,7 @@ If using Tink or another KMS, provide the KMS configuration through values.yaml.
 | server.antispam | object | `{}` |  |
 | server.aws | object | `{}` |  |
 | server.extraArgs | list | `[]` |  |
+| server.extraEnv | list | `[]` |  |
 | server.gcp | object | `{}` |  |
 | server.gcpcloudsql | object | `{}` |  |
 | server.grpc.port | string | `"3001"` |  |

--- a/charts/rekor-tiles/templates/deployment.yaml
+++ b/charts/rekor-tiles/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
                 name: {{ (.Values.server.signer.file.secret).name }}
                 key: password
 {{- end }}
+          {{- with .Values.server.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           args:
 {{ include "rekor-tiles.args" . | indent 12 }}
           ports:

--- a/charts/rekor-tiles/values.schema.json
+++ b/charts/rekor-tiles/values.schema.json
@@ -409,11 +409,16 @@
         "extraArgs": {
           "type": "array",
           "items": {}
+        },
+        "extraEnv": {
+          "type": "array",
+          "items": {}
         }
       },
       "required": [
         "antispam",
         "extraArgs",
+        "extraEnv",
         "gcp",
         "grpc",
         "grpcSvcTLS",

--- a/charts/rekor-tiles/values.yaml
+++ b/charts/rekor-tiles/values.yaml
@@ -164,3 +164,10 @@ server:
     # configMapName: witness-config
     # witnessPolicy: ""
   extraArgs: []
+  # Additional env vars appended to the container. The chart always sets
+  # POD_NAME, K8S_NAMESPACE, and OTEL_RESOURCE_ATTRIBUTES (needed so the
+  # GCP OTel metric exporter maps to k8s_container rather than k8s_cluster
+  # and each pod gets its own time series). Anything added here is appended.
+  extraEnv: []
+    # - name: MY_VAR
+    #   value: "my-value"


### PR DESCRIPTION
allow environment variables to be set for rekor-tiles deployment (eg for spanner directpath)