### PR TITLE
feat(tsa): support additional server args and config files

### DIFF
--- a/charts/tsa/Chart.yaml
+++ b/charts/tsa/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 
 type: application
 
-version: 2.1.2
+version: 2.1.3
 appVersion: 2.1.0
 
 keywords:

--- a/charts/tsa/README.md
+++ b/charts/tsa/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. Please edit README.md.gotmpl -->
 
-![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Timestamp Authority issuing RFC3161 signed timestamps.
 
@@ -94,6 +94,7 @@ helm uninstall [RELEASE_NAME]
 | namespace.name | string | `"tsa-system"` |  |
 | neg.http.name | string | `""` |  |
 | neg.http.port | int | `80` |  |
+| server.additionalArgs | list | `[]` |  |
 | server.affinity | object | `{}` |  |
 | server.args.cert_chain | string | `"chain"` |  |
 | server.args.kms_key_resource | string | `"resource"` |  |
@@ -102,6 +103,7 @@ helm uninstall [RELEASE_NAME]
 | server.args.tink_enc_keyset | string | `"keyset"` |  |
 | server.args.tink_hcvault_token | string | `"token"` |  |
 | server.args.tink_key_resource | string | `"resource"` |  |
+| server.configMap.additionalKeys | object | `{}` |  |
 | server.env.GOOGLE_APPLICATION_CREDENTIALS | string | `""` |  |
 | server.image.pullPolicy | string | `"IfNotPresent"` |  |
 | server.image.registry | string | `"ghcr.io"` |  |

--- a/charts/tsa/templates/tsa-configmap.yaml
+++ b/charts/tsa/templates/tsa-configmap.yaml
@@ -19,3 +19,6 @@ data:
   {{- if .Values.server.args.creds }}
   cloud_credentials: {{.Values.server.args.creds | quote }}
   {{- end }}
+  {{- range $name, $content := .Values.server.configMap.additionalKeys }}
+  {{ $name | quote }}: {{ $content | quote }}
+  {{- end }}

--- a/charts/tsa/templates/tsa-deployment.yaml
+++ b/charts/tsa/templates/tsa-deployment.yaml
@@ -52,6 +52,9 @@ spec:
             {{- if .Values.server.logging.production }}
             - "--log-type=prod"
             {{- end -}}
+            {{- range $arg := .Values.server.additionalArgs }}
+            - {{ $arg | quote }}
+            {{- end }}
 {{- if .Values.server.env }}
           env:
 {{- range $key, $value := .Values.server.env }}

--- a/charts/tsa/values.schema.json
+++ b/charts/tsa/values.schema.json
@@ -33,6 +33,10 @@
         },
         "server": {
             "properties": {
+                "additionalArgs": {
+                    "type": "array",
+                    "description": "Additional args to append to the server's args array"
+                },
                 "affinity": {
                     "properties": {},
                     "type": "object"
@@ -62,6 +66,14 @@
                         }
                     },
                     "type": "object"
+                },
+                "configMap": {
+                    "properties": {
+                        "additionalKeys": {
+                            "type": "object",
+                            "description": "Additional keys to add to the configmap as key: content pairs"
+                        }
+                    }
                 },
                 "env": {
                     "properties": {

--- a/charts/tsa/values.yaml
+++ b/charts/tsa/values.yaml
@@ -7,6 +7,9 @@ server:
   name: server
   svcPort: 80
   secret: tsa-server-secret
+  additionalArgs: []
+  configMap:
+    additionalKeys: {}
   logging:
     production: false
   env:


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

 -->

## Description of the change

This PR configures the tsa chart to allow arbitrary additional `args` to be passed to the TSA `Deployment`, as well as arbitrary key-value pairs to the TSA `ConfigMap`, allowing additional last-mile configuration the user may need for their environment.

## Existing or Associated Issue(s)

No existing issue

## Additional Information

N/A

## Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). Where applicable, update and bump the versions in any associated umbrella chart
- [X] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [X] JSON Schema generated.
- [X] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
